### PR TITLE
Add support for handling http2 GOAWAY messages and set http2 ping interval

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -53,6 +53,16 @@ module.exports = function (dependencies) {
         }
       });
 
+      this.session.on("goaway", (errorCode, lastStreamId, opaqueData) => {
+         logger(`GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`);
+         // gracefully stop accepting new streams
+         if (this.session && !this.session.destroyed) {
+           this.session.close(() => {
+             this.session.destroy();
+           });
+         }
+       });
+
       if (logger.enabled) {
         this.session.on("connect", () => {
           logger("Session connected");
@@ -62,9 +72,6 @@ module.exports = function (dependencies) {
         });
         this.session.on("frameError", (frameType, errorCode, streamId) => {
           logger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
-        });
-        this.session.on("goaway", (errorCode, lastStreamId, opaqueData) => {
-          logger(`GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`);
         });
       }
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -19,6 +19,16 @@ module.exports = function (dependencies) {
 
   function Client (options) {
     this.config = config(options);
+    this.healthCheckInterval = setInterval(() => {
+         if (this.session && !this.session.destroyed) {
+             this.session.ping((error, duration) => {
+                 if (error) {
+                     logger("No Ping response after " + duration + " ms");
+                 }
+                 logger("Ping response after " + duration + " ms");
+             })
+         }
+     }, this.config.heartBeat).unref();
   }
 
   Client.prototype.write = function write (notification, device, count) {
@@ -140,6 +150,9 @@ module.exports = function (dependencies) {
   };
 
   Client.prototype.shutdown = function shutdown(callback) {
+    if (this.healthCheckInterval) {
+      clearInterval(this.healthCheckInterval);
+    }
     if (this.session && !this.session.destroyed) {
       this.session.shutdown({graceful: true}, () => {
         this.session.destroy();


### PR DESCRIPTION
This is a fix to this issue: https://github.com/parse-community/parse-server/issues/6057

The changes are collected from the PR to the original `node-apn` repository:
* https://github.com/node-apn/node-apn/pull/642
* https://github.com/node-apn/node-apn/pull/643

They are known to fix the issue according to this thread: https://github.com/node-apn/node-apn/issues/640