### PR TITLE
Fix: http2session.shutdown() is not a function

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -161,7 +161,7 @@ module.exports = function (dependencies) {
       clearInterval(this.healthCheckInterval);
     }
     if (this.session && !this.session.destroyed) {
-      this.session.shutdown({graceful: true}, () => {
+      this.session.close(() => {
         this.session.destroy();
         if (callback) {
           callback();


### PR DESCRIPTION
Use [`http2session.close([callback])`](https://nodejs.org/api/http2.html#http2_http2session_close_callback) instead.

```
(node:58669) UnhandledPromiseRejectionWarning: TypeError: this.session.shutdown is not a function
    at Client.shutdown (/Code/pushy-api/node_modules/@parse/node-apn/lib/client.js:144:20)
    at Provider.shutdown (/Code/pushy-api/node_modules/@parse/node-apn/lib/provider.js:46:17)
    at exports.publish.apnsProvider.send.then (/Code/pushy-api/logic/push/platforms/ios.js:122:30)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```