### PR TITLE
Fixes header assignment

### DIFF
--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -46,7 +46,7 @@ Notification.prototype.headers = function headers() {
     headers["apns-id"] = this.payload.id;
   }
 
-  if (this.payload.expiry > 0) {
+  if (this.payload.expiry) {
     headers["apns-expiration"] = this.payload.expiry;
   }
 

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -38,28 +38,28 @@ Notification.prototype = require("./apsProperties");
 Notification.prototype.headers = function headers() {
   let headers = {};
 
-  if (this.priority !== 10) {
-    headers["apns-priority"] = this.priority;
+  if (this.payload.priority) {
+    headers["apns-priority"] = this.payload.priority;
   }
 
-  if (this.id) {
-    headers["apns-id"] = this.id;
+  if (this.payload.id) {
+    headers["apns-id"] = this.payload.id;
   }
 
-  if (this.expiry > 0) {
-    headers["apns-expiration"] = this.expiry;
+  if (this.payload.expiry > 0) {
+    headers["apns-expiration"] = this.payload.expiry;
   }
 
-  if (this.topic) {
-    headers["apns-topic"] = this.topic;
+  if (this.payload.topic) {
+    headers["apns-topic"] = this.payload.topic;
   }
 
-  if (this.collapseId) {
-    headers["apns-collapse-id"] = this.collapseId;
+  if (this.payload.collapseId) {
+    headers["apns-collapse-id"] = this.payload.collapseId;
   }
 
-  if (this.pushType) {
-    headers["apns-push-type"] = this.pushType;
+  if (this.payload.pushType) {
+    headers["apns-push-type"] = this.payload.pushType;
   }
 
   return headers;

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -118,14 +118,14 @@ describe("Notification", function() {
 
 		context("priority is non-default", function() {
 			it("contains the apns-priority header", function() {
-				note.priority = 5;
+				note.payload.priority = 5;
 				expect(note.headers()).to.have.property("apns-priority", 5);
 			});
 		});
 
 		context("id is set", function() {
 			it("contains the apns-id header", function() {
-				note.id = "123e4567-e89b-12d3-a456-42665544000";
+				note.payload.id = "123e4567-e89b-12d3-a456-42665544000";
 
 				expect(note.headers()).to.have.property("apns-id", "123e4567-e89b-12d3-a456-42665544000");
 			});
@@ -133,7 +133,7 @@ describe("Notification", function() {
 
 		context("expiry is non-zero", function() {
 			it("contains the apns-expiration header", function() {
-				note.expiry = 1000;
+				note.payload.expiry = 1000;
 
 				expect(note.headers()).to.have.property("apns-expiration", 1000);
 			});
@@ -141,7 +141,7 @@ describe("Notification", function() {
 
 		context("topic is set", function() {
 			it("contains the apns-topic header", function() {
-				note.topic = "io.apn.node";
+				note.payload.topic = "io.apn.node";
 
 				expect(note.headers()).to.have.property("apns-topic", "io.apn.node");
 			});
@@ -149,7 +149,7 @@ describe("Notification", function() {
 
 		context("collapseId is set", function () {
 			it("contains the apns-collapse-id header", function () {
-				note.collapseId = "io.apn.collapse";
+				note.payload.collapseId = "io.apn.collapse";
 
 				expect(note.headers()).to.have.property("apns-collapse-id", "io.apn.collapse");
 			});
@@ -157,9 +157,9 @@ describe("Notification", function() {
 
 		context("pushType is set", function () {
 			it("contains the apns-push-type header", function () {
-				note.pushType = "alert";
+				note.payload.pushType = "background";
 
-				expect(note.headers()).to.have.property("apns-push-type", "alert");
+				expect(note.headers()).to.have.property("apns-push-type", "background");
 			});
 		});
 	});


### PR DESCRIPTION
It looks like iOS notification headers aren't actually being set. This became most obvious recently with the required headers for iOS 13, as described in https://github.com/parse-community/parse-server/issues/6106

This PR alters header generation so that the supported apns headers are set.