### PR TITLE
Install coveralls as a dev dependency on publish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 - 10
 after_success:
 - npm install -g istanbul
-- npm install coveralls
+- npm install -D coveralls
 - istanbul cover node_modules/.bin/_mocha --report lcovonly -- -R spec
 - "./node_modules/.bin/coveralls < ./coverage/lcov.info"
 - rm -rf ./coverage


### PR DESCRIPTION
Currently, `coveralls` is added as a normal dependency so all users are forced to install it too.