### PR TITLE
Typed Notification.pushType

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -110,6 +110,8 @@ export class Provider extends EventEmitter {
   shutdown(): void;
 }
 
+export type NotificationPushType = 'background' | 'alert';
+
 export interface NotificationAlertOptions {
   title?: string;
   subtitle?: string;
@@ -150,7 +152,7 @@ export class Notification {
   public priority: number;
 
   public collapseId: string;
-  public pushType: string;
+  public pushType: NotificationPushType;
   public threadId: string;
 
   /**


### PR DESCRIPTION
Added a specific type for Notification.pushType, rather than typing it as a generic `string`.