### PR TITLE
Change ResponseFailure.status typing to be number

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -84,7 +84,7 @@ export interface ResponseSent {
 export interface ResponseFailure {
   device: string;
   error?: Error;
-  status?: string;
+  status?: number;
   response?: {
     reason: string;
     timestamp?: string;


### PR DESCRIPTION
In the original project, we left status as a string: https://github.com/node-apn/node-apn/blob/master/lib/client.js#L80

In this fork, with the new http2 code, it's a number: https://github.com/parse-community/node-apn/blob/master/lib/client.js#L124