### PR TITLE
Update some of the urls in README for parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,25 +7,20 @@ node-apn
 
 [![Maintenance help wanted](https://img.shields.io/badge/maintenance-help%20wanted-red.svg)](https://github.com/node-apn/node-apn/issues/436)
 [![Build status][ci-image] ][ci-url]
-[![Code coverage][coverage-image]][coverage-url]
 [![Codacy][codacy-image]][codacy-url]
-[![dependencies][dependencies-image]][dependencies-url]
-[![devdependencies][devdependencies-image]][devdependencies-url]
+![dependencies][dependencies-image]
+![devdependencies][devdependencies-image]
 
 [logo]:doc/logo.png
 [npm-image]:https://nodei.co/npm/@parse/node-apn.png?downloads=true
 [npm-url]:https://npmjs.com/package/@parse/node-apn
 [ci-image]:https://api.travis-ci.org/parse-community/node-apn.svg
 [ci-url]:https://travis-ci.org/parse-community/node-apn
-[coverage-image]:https://coveralls.io/repos/argon/node-apn/badge.svg?branch=develop
-[coverage-url]:https://coveralls.io/r/argon/node-apn
 [codacy-image]:https://www.codacy.com/project/badge/e7735fbe0db244f3b310657d0dabaa11
 [codacy-url]:https://www.codacy.com/public/argon/node-apn
 
-[dependencies-image]:https://david-dm.org/parse-community/node-apn/status.svg
-[dependencies-url]:https://david-dm.org/parse-community/node-apn
-[devdependencies-image]:https://david-dm.org/parse-community/node-apn/dev-status.svg
-[devdependencies-url]:https://david-dm.org/parse-community/node-apn?type=dev
+[dependencies-image]:https://img.shields.io/david/parse-community/node-apn
+[devdependencies-image]:https://img.shields.io/david/dev/parse-community/node-apn
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ node-apn
 [![devdependencies][devdependencies-image]][devdependencies-url]
 
 [logo]:doc/logo.png
-[npm-image]:https://nodei.co/npm/apn.png?downloads=true
-[npm-url]:https://npmjs.com/package/apn
-[ci-image]:https://api.travis-ci.org/node-apn/node-apn.svg
-[ci-url]:https://travis-ci.org/node-apn/node-apn
+[npm-image]:https://nodei.co/npm/@parse/node-apn.png?downloads=true
+[npm-url]:https://npmjs.com/package/@parse/node-apn
+[ci-image]:https://api.travis-ci.org/parse-community/node-apn.svg
+[ci-url]:https://travis-ci.org/parse-community/node-apn
 [coverage-image]:https://coveralls.io/repos/argon/node-apn/badge.svg?branch=develop
 [coverage-url]:https://coveralls.io/r/argon/node-apn
 [codacy-image]:https://www.codacy.com/project/badge/e7735fbe0db244f3b310657d0dabaa11
 [codacy-url]:https://www.codacy.com/public/argon/node-apn
 
-[dependencies-image]:https://david-dm.org/node-apn/node-apn/status.svg
-[dependencies-url]:https://david-dm.org/node-apn/node-apn
-[devdependencies-image]:https://david-dm.org/node-apn/node-apn/dev-status.svg
-[devdependencies-url]:https://david-dm.org/node-apn/node-apn?type=dev
+[dependencies-image]:https://david-dm.org/parse-community/node-apn/status.svg
+[dependencies-url]:https://david-dm.org/parse-community/node-apn
+[devdependencies-image]:https://david-dm.org/parse-community/node-apn/dev-status.svg
+[devdependencies-url]:https://david-dm.org/parse-community/node-apn?type=dev
 
 ## Features
 
@@ -132,7 +132,7 @@ This will result in the the following notification payload being sent to the dev
 {"messageFrom":"John Appelseed","aps":{"badge":3,"sound":"ping.aiff","alert":"\uD83D\uDCE7 \u2709 You have a new message"}}
 ```
 
-You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`. 
+You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`.
 
 If you are constantly creating `Provider` instances in your app, make sure to call `Provider.shutdown()` when you are done with each provider to release its resources and memory.
 
@@ -177,7 +177,7 @@ Released under the MIT License
 > THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 [npm]: https://npmjs.org
-[node-apn]: https://github.com/node-apn/node-apn
+[node-apn]: https://github.com/parse-community/node-apn
 [certificateWiki]:https://github.com/node-apn/node-apn/wiki/Preparing-Certificates "Preparing Certificates"
 [pl]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html "Local and Push Notification Programming Guide: APNs Overview"
 [tn2265]: http://developer.apple.com/library/ios/#technotes/tn2265/_index.html "Troubleshooting Push Notifications"

--- a/README.md
+++ b/README.md
@@ -5,22 +5,14 @@ node-apn
 
 > A Node.js module for interfacing with the Apple Push Notification service.
 
-[![Maintenance help wanted](https://img.shields.io/badge/maintenance-help%20wanted-red.svg)](https://github.com/node-apn/node-apn/issues/436)
+![Maintenance help wanted](https://img.shields.io/badge/maintenance-help%20wanted-red.svg)
 [![Build status][ci-image] ][ci-url]
-[![Codacy][codacy-image]][codacy-url]
-![dependencies][dependencies-image]
-![devdependencies][devdependencies-image]
 
 [logo]:doc/logo.png
 [npm-image]:https://nodei.co/npm/@parse/node-apn.png?downloads=true
 [npm-url]:https://npmjs.com/package/@parse/node-apn
 [ci-image]:https://api.travis-ci.org/parse-community/node-apn.svg
 [ci-url]:https://travis-ci.org/parse-community/node-apn
-[codacy-image]:https://www.codacy.com/project/badge/e7735fbe0db244f3b310657d0dabaa11
-[codacy-url]:https://www.codacy.com/public/argon/node-apn
-
-[dependencies-image]:https://img.shields.io/david/parse-community/node-apn
-[devdependencies-image]:https://img.shields.io/david/dev/parse-community/node-apn
 
 ## Features
 


### PR DESCRIPTION
I'm not sure which make sense to change here
and what the remaining equivalent are.
For example, it would make sense to properly indicate whether
@parse/node-apn has up to date dependencies.

https://nodei.co/ seems to have issues with `@a/b` package names and doesn't show download statistics.