### PR TITLE
fix: add support to zero valued expiry

### DIFF
--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -9,7 +9,7 @@ function Notification (payload) {
   this.compiled = false;
 
   this.aps = {};
-  this.expiry = 0;
+  this.expiry = -1;
   this.priority = 10;
 
   if (payload) {
@@ -46,7 +46,7 @@ Notification.prototype.headers = function headers() {
     headers["apns-id"] = this.id;
   }
 
-  if (this.expiry > 0) {
+  if (this.expiry >= 0) {
     headers["apns-expiration"] = this.expiry;
   }
 

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -131,11 +131,27 @@ describe("Notification", function() {
 			});
 		});
 
-		context("expiry is non-zero", function() {
+		context("expiry is greater than zero", function() {
 			it("contains the apns-expiration header", function() {
 				note.expiry = 1000;
 
 				expect(note.headers()).to.have.property("apns-expiration", 1000);
+			});
+		});
+
+        context("expiry is zero", function() {
+			it("contains the apns-expiration header", function() {
+				note.expiry = 0;
+
+				expect(note.headers()).to.have.property("apns-expiration", 0);
+			});
+		});
+
+        context("expiry is negative", function() {
+			it("not contains the apns-expiration header", function() {
+				note.expiry = -1;
+
+				expect(note.headers()).to.not.have.property("apns-expiration");
 			});
 		});
 


### PR DESCRIPTION
This was proposed by @n8ham, on node-apn/node-apn repository, the text
below was written by him.

The value of the `expiry` field is passed to the `apns-expiration`
header. This is Apple's documentation for that header:

> The date at which the notification is no longer valid. This value is a
> Unix epoch expressed in seconds (UTC). If the value is nonzero, APNs
> stores the notification and tries to deliver it at least once,
> repeating the attempt as needed until the specified date. If the value
> is 0, APNs attempts to deliver the notification only once and does not
> store the notification.

node-apn should therefore support `0` as a value for `expiry`, enabling
users to request notifications that are attemted only once. Instead of
`0` we can use `-1` as a flag for "unset", since negative numbers are
not valid for `apns-expiration`.

I've tested this change with the notification service and setting
`expiry` to `0` gave the expected results."