### PR TITLE
Update endpoint address

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,7 @@ const extend = require("./util/extend");
 
 let EndpointAddress = {
   production: "api.push.apple.com",
-  development: "api.development.push.apple.com"
+  development: "api.sandbox.push.apple.com"
 };
 
 module.exports = function(dependencies) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,7 @@ const extend = require("./util/extend");
 
 let EndpointAddress = {
   production: "api.push.apple.com",
-  development:    "api.development.push.apple.com"
+  development: "api.development.push.apple.com"
 };
 
 module.exports = function(dependencies) {

--- a/test/config.js
+++ b/test/config.js
@@ -25,7 +25,7 @@ describe("config", function () {
       pfx: null,
       passphrase: null,
       production: false,
-      address: "api.development.push.apple.com",
+      address: "api.sandbox.push.apple.com",
       port: 443,
       proxy: null,
       rejectUnauthorized: true,
@@ -51,7 +51,7 @@ describe("config", function () {
     });
 
     it("should use api.sandbox.push.apple.com as the default connection address", function () {
-      expect(config()).to.have.property("address", "api.development.push.apple.com");
+      expect(config()).to.have.property("address", "api.sandbox.push.apple.com");
     });
 
     it("should use api.push.apple.com when NODE_ENV=production", function () {
@@ -61,7 +61,7 @@ describe("config", function () {
 
     it("should give precedence to production flag over NODE_ENV=production", function () {
       process.env.NODE_ENV = "production";
-      expect(config({ production: false })).to.have.property("address", "api.development.push.apple.com");
+      expect(config({ production: false })).to.have.property("address", "api.sandbox.push.apple.com");
     });
 
     it("should use api.push.apple.com when production:true", function () {


### PR DESCRIPTION
This is the most recent Apple's documentation:
https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns
> Establish a Connection to APNs
> Use HTTP/2 and TLS 1.2 or later to establish a connection between your
> provider server and one of the following servers:
> - Development server: api.sandbox.push.apple.com:443
> - Production server: api.push.apple.com:443

To keep in sync with Apple's documentation, EndpointAddress.development
should be updated.