### PR TITLE
Proxy support

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const VError = require("verror");
+const tls = require("tls");
 const extend = require("./util/extend");
+const createProxySocket = require("./util/proxy");
 
 module.exports = function (dependencies) {
   // Used for routine logs such as HTTP status codes, etc.
@@ -87,6 +89,36 @@ module.exports = function (dependencies) {
 
     // Connect session
     if (!this.session || this.session.closed || this.session.destroyed) {
+      return this.connect().then(() => this.request(notification, device, count));
+    }
+    return this.request(notification, device, count);
+  }
+
+  Client.prototype.connect = function connect () {
+    if (this.sessionPromise) return this.sessionPromise;
+
+    const proxySocketPromise = this.config.proxy
+      ? createProxySocket(this.config.proxy, {
+          host: this.config.address,
+          port: this.config.port,
+        })
+      : Promise.resolve();
+
+    this.sessionPromise = proxySocketPromise.then(socket => {
+      this.sessionPromise = null;
+      if (socket) {
+        this.config.createConnection = (authority) =>
+          authority.protocol === "http:"
+          ? socket
+          : authority.protocol === "https:"
+          ? tls.connect(+authority.port || 443, authority.hostname, {
+              socket,
+              servername: authority.hostname,
+              ALPNProtocols: ["h2"],
+            })
+          : null
+      }
+
       const session = this.session = http2.connect(this._mockOverrideUrl || `https://${this.config.address}`, this.config);
 
       this.session.on("close", () => {
@@ -129,8 +161,12 @@ module.exports = function (dependencies) {
         }
         this.closeAndDestroySession(session);
       });
-    }
+    });
 
+    return this.sessionPromise;
+  }
+
+  Client.prototype.request = function request (notification, device, count) {
     let tokenGeneration = null;
     let status = null;
     let responseData = "";

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -1,0 +1,20 @@
+"use strict";
+
+const http = require("http");
+
+module.exports = function createProxySocket(proxy, target) {
+  return new Promise((resolve, reject) => {
+    const req = http.request({
+      host: proxy.host,
+      port: proxy.port,
+      method: "connect",
+      path: target.host + ":" + target.port,
+      headers: { Connection: "Keep-Alive" },
+    });
+    req.on("error", reject);
+    req.on("connect", (res, socket, head) => {
+      resolve(socket);
+    });
+    req.end();
+  });
+}


### PR DESCRIPTION
Hello!

This PR adds proxy support for native https2.

Proxy support [is already documented](https://github.com/parse-community/node-apn#connecting-through-an-http-proxy), but in fact it is only present in [the `node-apn/node-http2` based versions](https://github.com/node-apn/node-apn/blob/3.0.0/lib/protocol/endpoint.js#L84).