### PR TITLE
Proposal: Add a configurable info/error logger

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -108,6 +108,16 @@ export class Provider extends EventEmitter {
    * A "recipient" is a String containing the hex-encoded device token.
    */
   send(notification: Notification, recipients: string|string[]): Promise<Responses>;
+
+  /**
+   * Set an info logger, and optionally an errorLogger to separately log errors.
+   *
+   * In order to log, these functions must have a property '.enabled' that is true.
+   * (The default logger uses the npm 'debug' module which sets '.enabled' 
+   * based on the DEBUG environment variable)
+   */
+  setLogger(logger: (string) => void, errorLogger?: (string) => void): Promise<Responses>;
+
   /**
    * Indicate to node-apn that it should close all open connections when the queue of pending notifications is fully drained. This will allow your application to terminate.
    */

--- a/lib/client.js
+++ b/lib/client.js
@@ -121,7 +121,8 @@ module.exports = function (dependencies) {
         this.session.on("connect", () => {
           this.logger("Session connected");
         });
-
+      }
+      if (this.errorLogger.enabled) {
         this.session.on("frameError", (frameType, errorCode, streamId) => {
           this.errorLogger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
         });

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,11 @@ const VError = require("verror");
 const extend = require("./util/extend");
 
 module.exports = function (dependencies) {
-  const logger = dependencies.logger;
+  // Used for routine logs such as HTTP status codes, etc.
+  const defaultLogger = dependencies.logger;
+  // Used for unexpected events that should be rare under normal circumstances,
+  // e.g. connection errors.
+  const defaultErrorLogger = dependencies.errorLogger || defaultLogger;
   const config = dependencies.config;
   const http2 = dependencies.http2;
 
@@ -24,14 +28,16 @@ module.exports = function (dependencies) {
 
   function Client (options) {
     this.config = config(options);
+    this.logger = defaultLogger;
+    this.errorLogger = defaultErrorLogger;
     this.healthCheckInterval = setInterval(() => {
       if (this.session && !this.session.closed && !this.session.destroyed && !this.isDestroyed) {
         this.session.ping((error, duration) => {
           if (error) {
-            logger("No Ping response after " + duration + " ms with error:" + error.message);
+            this.errorLogger("No Ping response after " + duration + " ms with error:" + error.message);
             return;
           }
-          logger("Ping response after " + duration + " ms");
+          this.logger("Ping response after " + duration + " ms");
         });
       }
     }, this.config.heartBeat).unref();
@@ -84,40 +90,40 @@ module.exports = function (dependencies) {
       const session = this.session = http2.connect(this._mockOverrideUrl || `https://${this.config.address}`, this.config);
 
       this.session.on("close", () => {
-        if (logger.enabled) {
-          logger("Session closed");
+        if (this.errorLogger.enabled) {
+          this.errorLogger("Session closed");
         }
         this.destroySession(session);
       });
 
       this.session.on("socketError", (error) => {
-        if (logger.enabled) {
-          logger(`Socket error: ${error}`);
+        if (this.errorLogger.enabled) {
+          this.errorLogger(`Socket error: ${error}`);
         }
         this.closeAndDestroySession(session);
       });
 
       this.session.on("error", (error) => {
-        if (logger.enabled) {
-          logger(`Session error: ${error}`);
+        if (this.errorLogger.enabled) {
+          this.errorLogger(`Session error: ${error}`);
         }
         this.closeAndDestroySession(session);
       });
 
       this.session.on("goaway", (errorCode, lastStreamId, opaqueData) => {
-        if (logger.enabled) {
-          logger(`GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`);
+        if (this.errorLogger.enabled) {
+          this.errorLogger(`GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`);
         }
         this.closeAndDestroySession(session);
       });
 
-      if (logger.enabled) {
+      if (this.logger.enabled) {
         this.session.on("connect", () => {
-          logger("Session connected");
+          this.logger("Session connected");
         });
 
         this.session.on("frameError", (frameType, errorCode, streamId) => {
-          logger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
+          this.errorLogger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
         });
       }
     }
@@ -159,8 +165,8 @@ module.exports = function (dependencies) {
     return new Promise ( resolve => {
       request.on("end", () => {
         try {
-          if (logger.enabled) {
-            logger(`Request ended with status ${status} and responseData: ${responseData}`);
+          if (this.logger.enabled) {
+            this.logger(`Request ended with status ${status} and responseData: ${responseData}`);
           }
 
           if (status === 200) {
@@ -183,21 +189,22 @@ module.exports = function (dependencies) {
 
             resolve({ device, status, response });
           } else {
-            let error = new VError("stream ended unexpectedly");
+            this.closeAndDestroySession();
+            let error = new VError(`stream ended unexpectedly with status ${status} and empty body`);
             resolve({ device, error });
           }
         } catch (e) {
           const error = new VError(e, 'Unexpected error processing APNs response');
-          if (logger.enabled) {
-            logger(`Unexpected error processing APNs response: ${e.message}`);
+          if (this.errorLogger.enabled) {
+            this.errorLogger(`Unexpected error processing APNs response: ${e.message}`);
           }
           resolve({ device, error });
         }
       });
 
       request.setTimeout(this.config.requestTimeout, () => {
-        if (logger.enabled) {
-          logger('Request timeout');
+        if (this.errorLogger.enabled) {
+          this.errorLogger('Request timeout');
         }
 
         status = TIMEOUT_STATUS;
@@ -208,8 +215,8 @@ module.exports = function (dependencies) {
       });
 
       request.on("aborted", () => {
-        if (logger.enabled) {
-          logger('Request aborted');
+        if (this.errorLogger.enabled) {
+          this.errorLogger('Request aborted');
         }
 
         status = ABORTED_STATUS;
@@ -218,8 +225,8 @@ module.exports = function (dependencies) {
       });
 
       request.on("error", (error) => {
-        if (logger.enabled) {
-          logger(`Request error: ${error}`);
+        if (this.errorLogger.enabled) {
+          this.errorLogger(`Request error: ${error}`);
         }
 
         status = ERROR_STATUS;
@@ -233,9 +240,9 @@ module.exports = function (dependencies) {
         resolve({ device, error });
       });
 
-      if (logger.enabled) {
+      if (this.errorLogger.enabled) {
         request.on("frameError", (frameType, errorCode, streamId) => {
-          logger(`Request frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
+          this.errorLogger(`Request frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
         });
       }
 
@@ -250,8 +257,8 @@ module.exports = function (dependencies) {
       }
       return;
     }
-    if (logger.enabled) {
-      logger('Called client.shutdown()');
+    if (this.errorLogger.enabled) {
+      this.errorLogger('Called client.shutdown()');
     }
     this.isDestroyed = true;
     if (this.healthCheckInterval) {
@@ -260,6 +267,18 @@ module.exports = function (dependencies) {
     }
     this.closeAndDestroySession(undefined, callback);
   };
+
+  Client.prototype.setLogger = function (newLogger, newErrorLogger = null) {
+    if (typeof newLogger !== 'function') {
+      throw new Error(`Expected newLogger to be a function, got ${typeof newLogger}`);
+    };
+    if (newErrorLogger && typeof newErrorLogger !== 'function') {
+      throw new Error(`Expected newErrorLogger to be a function or null, got ${typeof newErrorLogger}`);
+    }
+    this.logger = newLogger;
+    this.errorLogger = newErrorLogger || newLogger;
+  };
+
 
   return Client;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -280,6 +280,12 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
+    "@types/node": {
+      "version": "14.14.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
+      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "verror": "1.10.0"
   },
   "devDependencies": {
+    "@types/node": "^14.14.37",
     "chai": "3.x",
     "chai-as-promised": "7.1.1",
     "codecov": "3.8.1",


### PR DESCRIPTION
For the sake of backwards compatibility, continue requiring DEBUG=apn to
log either of these.

For the sake of convenience, allow applications to manually override
these loggers on a per-Client instance basis.
A more fully-featured logger such as error/warn/info/debug might be
useful but overkill if the error conditions are rare in practice.

Related to https://github.com/parse-community/node-apn/issues/59
High volume uses of node-apn may benefit from logging errors but ignore
non-errors.

Related to https://github.com/parse-community/node-apn/issues/30
- setLogger can be used by applications to set their own prefix