### PR TITLE
Close client on unexpected frame error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -122,11 +122,13 @@ module.exports = function (dependencies) {
           this.logger("Session connected");
         });
       }
-      if (this.errorLogger.enabled) {
-        this.session.on("frameError", (frameType, errorCode, streamId) => {
+      this.session.on("frameError", (frameType, errorCode, streamId) => {
+        // This is a frame error not associate with any request(stream).
+        if (this.errorLogger.enabled) {
           this.errorLogger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
-        });
-      }
+        }
+        this.closeAndDestroySession(session);
+      });
     }
 
     let tokenGeneration = null;


### PR DESCRIPTION
(For frame errors not associated with a known request)

This is using the standard library's http2 library, so if there is a frame
error, something unexpectedly went wrong on this client or on the remote
server. This shouldn't happen in normal circumstances.

Try to disconnect and establish a new connection

Fixes https://github.com/parse-community/node-apn/issues/64