### PR TITLE
Proposal: Implement a round-robin MultiClient, drop support for node < 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Node.js 8
-            NODE_VERSION: 8
-          - name: Node.js 10
-            NODE_VERSION: 10
           - name: Node.js 12
             NODE_VERSION: 12
           - name: Node.js 14

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,7 @@
 ## Changelog
+5.0.0
+* Drop support for node versions prior to 12 - those node versions have bugs in the http2 library.
+* Support MultiProvider and MultiClient to use a round-robin client for HTTP2.
 
 4.1.1
 * FIX: add proxy and fix logger types

--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ var apnProvider = new apn.Provider(options);
 
 The provider will first send an HTTP CONNECT request to the specified proxy in order to establish an HTTP tunnel. Once established, it will create a new secure connection to the Apple Push Notification provider API through the tunnel.
 
+#### Using a pool of http/2 connections
+
+Because http/2 already uses multiplexing, you probably don't need to use more than one client unless you are hitting http/2 concurrent request limits.
+
+```javascript
+var options = {
+  // Round robin pool with 2 clients. More can be used if needed.
+  clientCount: 2,
+  token: {
+    key: "path/to/APNsAuthKey_XXXXXXXXXX.p8",
+    keyId: "key-id",
+    teamId: "developer-team-id"
+  },
+  proxy: {
+    host: "192.168.10.92",
+    port: 8080
+  },
+  production: false
+};
+
+var apnProvider = new apn.MultiProvider(options);
+```
+
 ### Sending a notification
 To send a notification you will first need a device token from your app as a string
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -64,6 +64,13 @@ export interface ProviderOptions {
   proxy?: { host: string, port: number|string }
 }
 
+export interface MultiProviderOptions extends ProviderOptions {
+  /**
+   * The number of clients in this round robin pool. Defaults to 2.
+   */
+  clientCount?: number
+}
+
 interface ApsAlert {
   body?: string
   "loc-key"?: string
@@ -131,7 +138,31 @@ export class Provider extends EventEmitter {
   /**
    * Indicate to node-apn that it should close all open connections when the queue of pending notifications is fully drained. This will allow your application to terminate.
    */
-  shutdown(): void;
+  shutdown(callback?: () => void): void;
+}
+
+export class MultiProvider extends EventEmitter {
+  constructor(options: MultiProviderOptions);
+  /**
+   * This is main interface for sending notifications. Create a Notification object and pass it in, along with a single recipient or an array of them and node-apn will take care of the rest, delivering a copy of the notification to each recipient.
+   *
+   * A "recipient" is a String containing the hex-encoded device token.
+   */
+  send(notification: Notification, recipients: string|string[]): Promise<Responses>;
+
+  /**
+   * Set an info logger, and optionally an errorLogger to separately log errors.
+   *
+   * In order to log, these functions must have a property '.enabled' that is true.
+   * (The default logger uses the npm 'debug' module which sets '.enabled' 
+   * based on the DEBUG environment variable)
+   */
+  setLogger(logger: (msg: string) => void, errorLogger?: (msg: string) => void): Promise<Responses>;
+
+  /**
+   * Indicate to node-apn that it should close all open connections when the queue of pending notifications is fully drained. This will allow your application to terminate.
+   */
+  shutdown(callback?: () => void): void;
 }
 
 export type NotificationPushType = 'background' | 'alert' | 'voip';

--- a/index.js
+++ b/index.js
@@ -20,9 +20,18 @@ const Client = require("./lib/client")({
   http2,
 });
 
+const MultiClient = require("./lib/multiclient")({
+  Client,
+});
+
 const Provider = require("./lib/provider")({
   logger: debug,
   Client,
+});
+
+const MultiProvider = require("./lib/provider")({
+  logger: debug,
+  Client: MultiClient,
 });
 
 const Notification = require("./lib/notification");
@@ -31,6 +40,7 @@ const token = require("./lib/token");
 
 module.exports = {
   Provider,
+  MultiProvider,
   Notification,
   token,
 };

--- a/lib/client.js
+++ b/lib/client.js
@@ -310,7 +310,7 @@ module.exports = function (dependencies) {
   Client.prototype.setLogger = function (newLogger, newErrorLogger = null) {
     if (typeof newLogger !== 'function') {
       throw new Error(`Expected newLogger to be a function, got ${typeof newLogger}`);
-    };
+    }
     if (newErrorLogger && typeof newErrorLogger !== 'function') {
       throw new Error(`Expected newErrorLogger to be a function or null, got ${typeof newErrorLogger}`);
     }

--- a/lib/multiclient.js
+++ b/lib/multiclient.js
@@ -17,9 +17,9 @@ module.exports = function (dependencies) {
    * switching to an http2 pool implementation.
    */
   function MultiClient (options) {
-    const count = options.clientCount || 2;
-    if (count < 1) {
-      throw new Error(`Expected positive client count but got ${count}`);
+    const count = parseInt(options.clientCount || 2, 10);
+    if (count < 1 || !Number.isFinite(count)) {
+      throw new Error(`Expected positive client count but got ${options.clientCount}`);
     }
     const clients = [];
     for (let i = 0; i < count; i++) {

--- a/lib/multiclient.js
+++ b/lib/multiclient.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const VError = require("verror");
+const extend = require("./util/extend");
+
+module.exports = function (dependencies) {
+  const Client = dependencies.Client;
+  /**
+   * This is a simple round-robin pool of http/2 clients.
+   * Most use cases would not need this.
+   *
+   * While http/2 itself supports multiplexing,
+   * there are limits on the number of active simultaneous requests
+   * that may be hit.
+   *
+   * This approach was chosen because it's easy to reason about compared to
+   * switching to an http2 pool implementation.
+   */
+  function MultiClient (options) {
+    const count = options.clientCount || 2;
+    if (count < 1) {
+      throw new Error(`Expected positive client count but got ${count}`);
+    }
+    const clients = [];
+    for (let i = 0; i < count; i++) {
+      clients.push(new Client(options));
+    }
+    this.clients = clients;
+    this.clientIndex = 0;
+  }
+
+  MultiClient.prototype.chooseSingleClient = function () {
+    const client = this.clients[this.clientIndex];
+    this.clientIndex = (this.clientIndex + 1) % this.clients.length;
+    return client;
+  }
+
+  MultiClient.prototype.write = function write (notification, device, count) {
+    return this.chooseSingleClient().write(notification, device, count);
+  };
+
+  MultiClient.prototype.shutdown = function shutdown(callback) {
+    let callCount = 0;
+    const multiCallback = () => {
+      callCount++;
+      if (callCount === this.clients.length) {
+        callback();
+      }
+    };
+    this.clients.forEach((client) => client.shutdown(multiCallback));
+  };
+
+  MultiClient.prototype.setLogger = function (newLogger, newErrorLogger = null) {
+    this.clients.forEach((client) => client.setLogger(newLogger, newErrorLogger));
+  };
+
+  return MultiClient;
+}

--- a/mock/client.js
+++ b/mock/client.js
@@ -2,11 +2,28 @@
 
 module.exports = function() {
 
+  // Mocks of public API methods
   function Client() {
   }
 
   Client.prototype.write = function mockWrite(notification, device) {
     return { device };
+  };
+
+  Client.prototype.setLogger = function mockSetLogger(newLogger, newErrorLogger = null) {
+    // Validate arguments but don't store the logger
+    if (typeof newLogger !== 'function') {
+      throw new Error(`Expected newLogger to be a function, got ${typeof newLogger}`);
+    }
+    if (newErrorLogger && typeof newErrorLogger !== 'function') {
+      throw new Error(`Expected newErrorLogger to be a function or null, got ${typeof newErrorLogger}`);
+    }
+  };
+
+  Client.prototype.shutdown = function mockShutdown(callback) {
+    if (callback) {
+      callback();
+    }
   };
 
   return Client;

--- a/mock/index.js
+++ b/mock/index.js
@@ -1,9 +1,18 @@
 "use strict";
 
 const Client = require("./client")();
+const MultiClient = require("../lib/multiclient")({
+  Client
+});
 
 const Provider = require("../lib/provider")({
   Client,
+});
+
+// In case the code being tested relies on the provider.client.clients array existing
+// (e.g. a health check) use the real MultiClient for this mock.
+const MultiProvider = require("../lib/provider")({
+  Client: MultiClient,
 });
 
 const Notification = require("../lib/notification");
@@ -11,6 +20,7 @@ const token = require("../lib/token");
 
 module.exports = {
   Provider,
+  MultiProvider,
   Notification,
   Client,
   token,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@parse/node-apn",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -274,6 +274,41 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
+    "@sinonjs/commons": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
+      "integrity": "sha512-xkNcLAn/wZaX14RPlwizcKicDk9G3F8m2nU3L7Ukm5zBgTwiT0wsoFAHx9Jq56fJA1z/7uKGtCRu16sOUCLIHQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -281,9 +316,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-      "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+      "version": "14.17.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.0.tgz",
+      "integrity": "sha512-w8VZUN/f7SSbvVReb9SWp6cJFevxb4/nkG65yLAya//98WgocKm5PLDAtSs5CtJJJM+kHmJjO/6mmYW4MHShZA==",
+      "dev": true
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
     "agent-base": {
@@ -305,6 +346,12 @@
         "indent-string": "^4.0.0"
       }
     },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
@@ -318,6 +365,16 @@
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "anymatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "dev": true,
+      "requires": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
       }
     },
     "append-transform": {
@@ -350,12 +407,6 @@
       "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
       "dev": true
     },
-    "array-filter": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-      "dev": true
-    },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -367,19 +418,16 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "available-typed-arrays": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.2.tgz",
-      "integrity": "sha512-XWX3OX8Onv97LMk/ftVyBibpGwY5a8SmuxZPzeOxqmuEqUCOM9ZE+uIaD1VNJ5QnvU2UQusvmKbuM1FR8QWGfQ==",
-      "dev": true,
-      "requires": {
-        "array-filter": "^1.0.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "binary-extensions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
     "brace-expansion": {
@@ -392,10 +440,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
+      }
+    },
     "browser-stdout": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "browserslist": {
@@ -441,14 +498,17 @@
       "dev": true
     },
     "chai": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
+      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.0.1",
-        "deep-eql": "^0.1.3",
-        "type-detect": "^1.0.0"
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.2",
+        "deep-eql": "^3.0.1",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.0.5"
       }
     },
     "chai-as-promised": {
@@ -493,6 +553,22 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
       "dev": true
+    },
+    "chokidar": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
+      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "dev": true,
+      "requires": {
+        "anymatch": "~3.1.1",
+        "braces": "~3.0.2",
+        "fsevents": "~2.3.1",
+        "glob-parent": "~5.1.0",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.5.0"
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -543,12 +619,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
       "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-      "dev": true
-    },
-    "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
       "dev": true
     },
     "commondir": {
@@ -618,20 +688,12 @@
       "dev": true
     },
     "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "0.1.1"
-      },
-      "dependencies": {
-        "type-detect": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
-          "dev": true
-        }
+        "type-detect": "^4.0.0"
       }
     },
     "default-require-extensions": {
@@ -643,19 +705,10 @@
         "strip-bom": "^4.0.0"
       }
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "diff": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
     "ecdsa-sig-formatter": {
@@ -677,36 +730,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
-    },
-    "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
     },
     "es6-error": {
       "version": "4.1.1",
@@ -737,6 +760,15 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
       "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-cache-dir": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
@@ -758,10 +790,10 @@
         "path-exists": "^4.0.0"
       }
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
     },
     "foreground-child": {
@@ -772,15 +804,6 @@
       "requires": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^3.0.2"
-      }
-    },
-    "formatio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
-      "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
-      "dev": true,
-      "requires": {
-        "samsam": "~1.1"
       }
     },
     "fromentries": {
@@ -795,11 +818,12 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -813,6 +837,12 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -820,9 +850,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -831,6 +861,15 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -846,30 +885,15 @@
       "dev": true
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
     "hasha": {
@@ -883,9 +907,9 @@
       }
     },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "html-escaper": {
@@ -960,22 +984,19 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
-    "is-arguments": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
-      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
-      "dev": true
+    "is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "requires": {
+        "binary-extensions": "^2.0.0"
+      }
     },
-    "is-callable": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
-      "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
-      "dev": true
-    },
-    "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -984,53 +1005,32 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
-    "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
-      "dev": true
-    },
-    "is-negative-zero": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
-      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "is-extglob": "^2.1.1"
       }
+    },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
     },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
-    },
-    "is-typed-array": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.3.tgz",
-      "integrity": "sha512-BSYUBOK/HJibQ30wWkWold5txYwMUXQct9YHAQJr8fSwvZoiglcqB0pd7vEN23+Tsi9IUEjztdOSzl4qLVYGTQ==",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.0",
-        "es-abstract": "^1.17.4",
-        "foreach": "^2.0.5",
-        "has-symbols": "^1.0.1"
-      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -1042,6 +1042,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "isexe": {
@@ -1220,6 +1226,12 @@
         }
       }
     },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -1260,6 +1272,12 @@
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1295,11 +1313,59 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
-    "lolex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
-      "integrity": "sha1-fD2mL/yzDw9agKJWbKJORdigHzE=",
-      "dev": true
+    "log-symbols": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+      "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "make-dir": {
       "version": "3.1.0",
@@ -1327,55 +1393,213 @@
         "brace-expansion": "^1.1.7"
       }
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
-    },
     "mocha": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.4.0.tgz",
+      "integrity": "sha512-hJaO0mwDXmZS4ghXsvPVriOhsxQ7ofcpQdm8dE+jISUOKopitvnXFQmpRR7jd2K6VBG6E26gU3IAbXXGIbu4sQ==",
       "dev": true,
       "requires": {
-        "browser-stdout": "1.3.0",
-        "commander": "2.11.0",
-        "debug": "3.1.0",
-        "diff": "3.3.1",
-        "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
-        "growl": "1.10.3",
-        "he": "1.1.1",
-        "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.1",
+        "debug": "4.3.1",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
+        "growl": "1.10.5",
+        "he": "1.2.0",
+        "js-yaml": "4.0.0",
+        "log-symbols": "4.0.0",
+        "minimatch": "3.0.4",
+        "ms": "2.1.3",
+        "nanoid": "3.1.20",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "which": "2.0.2",
+        "wide-align": "1.1.3",
+        "workerpool": "6.1.0",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "color-convert": "^2.0.1"
           }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          },
+          "dependencies": {
+            "ms": {
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+              "dev": true
+            }
+          }
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
+          "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
         }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
+    },
+    "nanoid": {
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "dev": true
+    },
+    "nise": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -1401,6 +1625,12 @@
       "version": "1.1.71",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
       "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+      "dev": true
+    },
+    "normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
     "nyc": {
@@ -1450,52 +1680,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
-    "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
-      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0",
-        "has-symbols": "^1.0.1",
-        "object-keys": "^1.1.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
-          "dev": true,
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
           }
         }
       }
@@ -1572,6 +1756,27 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      }
+    },
+    "pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true
+    },
+    "picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -1588,6 +1793,24 @@
       "dev": true,
       "requires": {
         "fromentries": "^1.2.0"
+      }
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
+    "readdirp": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "dev": true,
+      "requires": {
+        "picomatch": "^2.2.1"
       }
     },
     "release-zalgo": {
@@ -1647,16 +1870,19 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
-    "samsam": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
-      "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
-      "dev": true
-    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
+      }
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -1686,21 +1912,40 @@
       "dev": true
     },
     "sinon": {
-      "version": "1.17.7",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.7.tgz",
-      "integrity": "sha1-RUKk9JugxFwF6y6d2dID4rjv4L8=",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-10.0.0.tgz",
+      "integrity": "sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==",
       "dev": true,
       "requires": {
-        "formatio": "1.1.1",
-        "lolex": "1.3.2",
-        "samsam": "1.1.2",
-        "util": ">=0.10.3 <1"
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "sinon-chai": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
-      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.6.0.tgz",
+      "integrity": "sha512-bk2h+0xyKnmvazAnc7HE5esttqmCerSMcBtuB2PS2T4tG6x8woXAxZeJaOJWD+8reXHngnXn0RtIbfEW9OTHFg==",
       "dev": true
     },
     "source-map": {
@@ -1749,26 +1994,6 @@
         "strip-ansi": "^6.0.0"
       }
     },
-    "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
     "strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -1784,6 +2009,12 @@
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
     "stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
@@ -1791,12 +2022,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "^4.0.0"
       }
     },
     "teeny-request": {
@@ -1845,10 +2076,19 @@
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "type-detect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "type-fest": {
@@ -1871,20 +2111,6 @@
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
       "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
       "dev": true
-    },
-    "util": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-      "integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "is-arguments": "^1.0.4",
-        "is-generator-function": "^1.0.7",
-        "is-typed-array": "^1.1.3",
-        "safe-buffer": "^5.1.2",
-        "which-typed-array": "^1.1.2"
-      }
     },
     "uuid": {
       "version": "3.4.0",
@@ -1917,19 +2143,53 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "which-typed-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.2.tgz",
-      "integrity": "sha512-KT6okrd1tE6JdZAy3o2VhMoYPh3+J6EMZLyrxBQsZflI1QCZIxMrIYLkosd8Twf+YfknVIHmYQPgJt238p8dnQ==",
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "available-typed-arrays": "^1.0.2",
-        "es-abstract": "^1.17.5",
-        "foreach": "^2.0.5",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.1",
-        "is-typed-array": "^1.1.3"
+        "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        }
       }
+    },
+    "workerpool": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
+      "integrity": "sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "6.2.0",
@@ -2020,6 +2280,38 @@
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        }
+      }
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@parse/node-apn",
   "description": "An interface to the Apple Push Notification service for Node.js",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "author": "Andrew Naylor <argon@mkbot.net>",
   "keywords": [
     "apple",
@@ -24,14 +24,14 @@
     "verror": "1.10.0"
   },
   "devDependencies": {
-    "@types/node": "^14.14.37",
-    "chai": "3.x",
+    "@types/node": "^14.14.40",
+    "chai": "^4.3.4",
     "chai-as-promised": "7.1.1",
     "codecov": "3.8.1",
-    "mocha": "4.0.1",
+    "mocha": "^8.3.2",
     "nyc": "15.1.0",
-    "sinon": "1.17.7",
-    "sinon-chai": "2.14.0"
+    "sinon": "^10.0.0",
+    "sinon-chai": "^3.6.0"
   },
   "publishConfig": {
     "access": "public"
@@ -51,7 +51,7 @@
     }
   },
   "engines": {
-    "node": ">= 8.9.1"
+    "node": ">= 12"
   },
   "license": "MIT"
 }

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -130,6 +130,16 @@ describe("MultiClient", () => {
     }
   });
 
+  it("rejects invalid clientCount", () => {
+    [-1, 'invalid'].forEach((clientCount) => {
+      expect(() => new MultiClient({
+        port: TEST_PORT,
+        address: '127.0.0.1',
+        clientCount,
+      })).to.throw(`Expected positive client count but got ${clientCount}`);
+    });
+  });
+
   it("Treats HTTP 200 responses as successful", async () => {
     let didRequest = false;
     let establishedConnections = 0;

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -1,0 +1,1256 @@
+"use strict";
+// Tests of MultiClient, copied from test/client.js with modifications of
+// expected connection counts.
+
+const VError = require("verror");
+const http2 = require("http2");
+const util = require("util");
+
+const debug = require("debug")("apn");
+const credentials = require("../lib/credentials")({
+  logger: debug
+});
+
+const TEST_PORT = 30939;
+const LOAD_TEST_BATCH_SIZE = 2000;
+
+const config = require("../lib/config")({
+  logger: debug,
+  prepareCertificate: () => ({}),  // credentials.certificate,
+  prepareToken: credentials.token,
+  prepareCA: credentials.ca,
+});
+const Client = require("../lib/client")({
+  logger: debug,
+  config,
+  http2,
+});
+const MultiClient = require("../lib/multiclient")({
+  Client,
+});
+debug.log = console.log.bind(console);
+
+// function builtNotification() {
+//   return {
+//     headers: {},
+//     body: JSON.stringify({ aps: { badge: 1 } }),
+//   };
+// }
+
+// function FakeStream(deviceId, statusCode, response) {
+//   const fakeStream = new stream.Transform({
+//     transform: sinon.spy(function(chunk, encoding, callback) {
+//       expect(this.headers).to.be.calledOnce;
+//
+//       const headers = this.headers.firstCall.args[0];
+//       expect(headers[":path"].substring(10)).to.equal(deviceId);
+//
+//       this.emit("headers", {
+//         ":status": statusCode
+//       });
+//       callback(null, Buffer.from(JSON.stringify(response) || ""));
+//     })
+//   });
+//   fakeStream.headers = sinon.stub();
+//
+//   return fakeStream;
+// }
+
+// XXX these may be flaky in CI due to being sensitive to timing,
+// and if a test case crashes, then others may get stuck.
+//
+// Try to fix this if any issues come up.
+describe("MultiClient", () => {
+  let server;
+  let client;
+  const MOCK_BODY = '{"mock-key":"mock-value"}';
+  const MOCK_DEVICE_TOKEN = 'abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123';
+
+  // Create an insecure http2 client for unit testing.
+  // (APNS would use https://, not http://)
+  // (It's probably possible to allow accepting invalid certificates instead,
+  // but that's not the most important point of these tests)
+  const createClient = (port, timeout = 500) => {
+    let mc = new MultiClient({
+      port: TEST_PORT,
+      address: '127.0.0.1',
+      clientCount: 2,
+    });
+    mc.clients.forEach((c) => {
+      c._mockOverrideUrl = `http://127.0.0.1:${port}`;
+      c.config.port = port;
+      c.config.address = '127.0.0.1';
+      c.config.requestTimeout = timeout;
+    });
+    return mc;
+  };
+  // Create an insecure server for unit testing.
+  const createAndStartMockServer = (port, cb) => {
+    server = http2.createServer((req, res) => {
+      var buffers = [];
+      req.on('data', (data) => buffers.push(data));
+      req.on('end', () => {
+        const requestBody = Buffer.concat(buffers).toString('utf-8');
+        cb(req, res, requestBody);
+      });
+    });
+    server.listen(port);
+    server.on('error', (err) => {
+      expect.fail(`unexpected error ${err}`);
+    });
+    // Don't block the tests if this server doesn't shut down properly
+    server.unref();
+    return server;
+  };
+  const createAndStartMockLowLevelServer = (port, cb) => {
+    server = http2.createServer();
+    server.on('stream', cb);
+    server.listen(port);
+    server.on('error', (err) => {
+      expect.fail(`unexpected error ${err}`);
+    });
+    // Don't block the tests if this server doesn't shut down properly
+    server.unref();
+    return server;
+  };
+
+  afterEach((done) => {
+    let closeServer = () => {
+      if (server) {
+        server.close();
+        server = null;
+      }
+      done();
+    };
+    if (client) {
+      client.shutdown(closeServer);
+      client = null;
+    } else {
+      closeServer();
+    }
+  });
+
+  it("Treats HTTP 200 responses as successful", async () => {
+    let didRequest = false;
+    let establishedConnections = 0;
+    let requestsServed = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(req.headers).to.deep.equal({
+        ':authority': '127.0.0.1',
+        ':method': 'POST',
+        ':path': `/3/device/${MOCK_DEVICE_TOKEN}`,
+        ':scheme': 'https',
+        'apns-someheader': 'somevalue',
+      });
+      expect(requestBody).to.equal(MOCK_BODY);
+      // res.setHeader('X-Foo', 'bar');
+      // res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.writeHead(200);
+      res.end('');
+      requestsServed += 1;
+      didRequest = true;
+    });
+    server.on('connection', () => establishedConnections += 1);
+    await new Promise((resolve) => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runSuccessfulRequest = async () => {
+      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const mockDevice = MOCK_DEVICE_TOKEN;
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      expect(result).to.deep.equal({ device: MOCK_DEVICE_TOKEN });
+      expect(didRequest).to.be.true;
+    };
+    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
+    // Validate that when multiple valid requests arrive concurrently,
+    // only one HTTP/2 connection gets established
+    await Promise.all([
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+    ]);
+    didRequest = false;
+    await runSuccessfulRequest();
+    expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
+    expect(requestsServed).to.equal(6);
+  });
+
+  // Assert that this doesn't crash when a large batch of requests are requested simultaneously
+  it("Treats HTTP 200 responses as successful (load test for a batch of requests)", async function () {
+    this.timeout(10000);
+    let establishedConnections = 0;
+    let requestsServed = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(req.headers).to.deep.equal({
+        ':authority': '127.0.0.1',
+        ':method': 'POST',
+        ':path': `/3/device/${MOCK_DEVICE_TOKEN}`,
+        ':scheme': 'https',
+        'apns-someheader': 'somevalue',
+      });
+      expect(requestBody).to.equal(MOCK_BODY);
+      // Set a timeout of 100 to simulate latency to a remote server.
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('');
+        requestsServed += 1;
+      }, 100);
+    });
+    server.on('connection', () => establishedConnections += 1);
+    await new Promise((resolve) => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT, 1500);
+
+    const runSuccessfulRequest = async () => {
+      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const mockDevice = MOCK_DEVICE_TOKEN;
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      expect(result).to.deep.equal({ device: MOCK_DEVICE_TOKEN });
+    };
+    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
+    // Validate that when multiple valid requests arrive concurrently,
+    // only one HTTP/2 connection gets established
+    const promises = [];
+    for (let i = 0; i < LOAD_TEST_BATCH_SIZE; i++) {
+      promises.push(runSuccessfulRequest());
+    }
+
+    await Promise.all(promises);
+    expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
+    expect(requestsServed).to.equal(LOAD_TEST_BATCH_SIZE);
+  });
+
+  // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
+  it("JSON decodes HTTP 400 responses", async () => {
+    let didRequest = false;
+    let establishedConnections = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(requestBody).to.equal(MOCK_BODY);
+      // res.setHeader('X-Foo', 'bar');
+      // res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.writeHead(400);
+      res.end('{"reason": "BadDeviceToken"}');
+      didRequest = true;
+    });
+    server.on('connection', () => establishedConnections += 1);
+    await new Promise((resolve) => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+    const infoMessages = [];
+    const errorMessages = [];
+    const mockInfoLogger = (message) => { infoMessages.push(message); };
+    const mockErrorLogger = (message) => { errorMessages.push(message); };
+    mockInfoLogger.enabled = true;
+    mockErrorLogger.enabled = true;
+    client.setLogger(mockInfoLogger, mockErrorLogger);
+
+    const runRequestWithBadDeviceToken = async () => {
+      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const mockDevice = MOCK_DEVICE_TOKEN;
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      expect(result).to.deep.equal({
+        device: MOCK_DEVICE_TOKEN,
+        response: {
+          "reason": "BadDeviceToken",
+        },
+        status: 400,
+      });
+      expect(didRequest).to.be.true;
+      didRequest = false;
+    };
+    await runRequestWithBadDeviceToken();
+    await runRequestWithBadDeviceToken();
+    expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
+    expect(infoMessages).to.deep.equal([
+      'Session connected',
+      "Request ended with status 400 and responseData: {\"reason\": \"BadDeviceToken\"}",
+      'Session connected',
+      "Request ended with status 400 and responseData: {\"reason\": \"BadDeviceToken\"}",
+    ]);
+    expect(errorMessages).to.deep.equal([]);
+  });
+
+  // node-apn started closing connections in response to a bug report where HTTP 500 responses
+  // persisted until a new connection was reopened
+  it("Closes connections when HTTP 500 responses are received", async () => {
+    let establishedConnections = 0;
+    let responseDelay = 50;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      // Wait 50ms before sending the responses in parallel
+      setTimeout(() => {
+        expect(requestBody).to.equal(MOCK_BODY);
+        res.writeHead(500);
+        res.end('{"reason": "InternalServerError"}');
+      }, responseDelay);
+    });
+    server.on('connection', () => establishedConnections += 1);
+    await new Promise((resolve) => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runRequestWithInternalServerError = async () => {
+      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const mockDevice = MOCK_DEVICE_TOKEN;
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      expect(result).to.exist;
+      expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
+      expect(result.error).to.be.an.instanceof(VError);
+      expect(result.error.message).to.have.string('stream ended unexpectedly');
+    };
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    expect(establishedConnections).to.equal(3); // should close and establish new connections on http 500
+    // Validate that nothing wrong happens when multiple HTTP 500s are received simultaneously.
+    // (no segfaults, all promises get resolved, etc.)
+    responseDelay = 50;
+    await Promise.all([
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+    ]);
+    expect(establishedConnections).to.equal(5); // should close and establish new connections on http 500
+  });
+
+  it("Handles unexpected invalid JSON responses", async () => {
+    let establishedConnections = 0;
+    let responseDelay = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      // Wait 50ms before sending the responses in parallel
+      setTimeout(() => {
+        expect(requestBody).to.equal(MOCK_BODY);
+        res.writeHead(500);
+        res.end('PC LOAD LETTER');
+      }, responseDelay);
+    });
+    server.on('connection', () => establishedConnections += 1);
+    await new Promise((resolve) => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runRequestWithInternalServerError = async () => {
+      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const mockDevice = MOCK_DEVICE_TOKEN;
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      // Should not happen, but if it does, the promise should resolve with an error
+      expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
+      expect(result.error.message).to.equal('Unexpected error processing APNs response: Unexpected token P in JSON at position 0');
+    };
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    expect(establishedConnections).to.equal(2); // Currently reuses the connections.
+  });
+
+  it("Handles APNs timeouts", async () => {
+    let didGetRequest = false;
+    let didGetResponse = false;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      didGetRequest = true;
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('');
+        didGetResponse = true;
+      }, 1900);
+    });
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    await onListeningPromise;
+
+    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const mockDevice = MOCK_DEVICE_TOKEN;
+    const performRequestExpectingTimeout = async () => {
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      expect(result).to.deep.equal({
+        device: MOCK_DEVICE_TOKEN,
+        error: new VError('apn write timeout'),
+      });
+      expect(didGetRequest).to.be.true;
+      expect(didGetResponse).to.be.false;
+    };
+    await performRequestExpectingTimeout();
+    didGetResponse = false;
+    didGetRequest = false;
+    // Should be able to have multiple in flight requests all get notified that the server is shutting down
+    await Promise.all([
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+    ]);
+  });
+
+  it("Handles goaway frames", async () => {
+    let didGetRequest = false;
+    let establishedConnections = 0;
+    server = createAndStartMockLowLevelServer(TEST_PORT, (stream) => {
+      const session = stream.session;
+      const errorCode = 1;
+      didGetRequest = true;
+      session.goaway(errorCode);
+    });
+    server.on('connection', () => establishedConnections += 1);
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    await onListeningPromise;
+
+    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const mockDevice = MOCK_DEVICE_TOKEN;
+    const performRequestExpectingGoAway = async () => {
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      expect(result).to.deep.equal({
+        device: MOCK_DEVICE_TOKEN,
+        error: new VError('stream ended unexpectedly with status null and empty body'),
+      });
+      expect(didGetRequest).to.be.true;
+      didGetRequest = false;
+    };
+    await performRequestExpectingGoAway();
+    await performRequestExpectingGoAway();
+    expect(establishedConnections).to.equal(2);
+  });
+
+  it("Handles unexpected protocol errors (no response sent)", async () => {
+    let didGetRequest = false;
+    let establishedConnections = 0;
+    let responseTimeout = 0;
+    server = createAndStartMockLowLevelServer(TEST_PORT, (stream) => {
+      setTimeout(() => {
+        const session = stream.session;
+        didGetRequest = true;
+        if (session) {
+          session.destroy();
+        }
+      }, responseTimeout);
+    });
+    server.on('connection', () => establishedConnections += 1);
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    await onListeningPromise;
+
+    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const mockDevice = MOCK_DEVICE_TOKEN;
+    const performRequestExpectingDisconnect = async () => {
+      const result = await client.write(
+        mockNotification,
+        mockDevice,
+      );
+      expect(result).to.deep.equal({
+        device: MOCK_DEVICE_TOKEN,
+        error: new VError('stream ended unexpectedly with status null and empty body'),
+      });
+      expect(didGetRequest).to.be.true;
+    };
+    await performRequestExpectingDisconnect();
+    didGetRequest = false;
+    await performRequestExpectingDisconnect();
+    didGetRequest = false;
+    expect(establishedConnections).to.equal(2);
+    responseTimeout = 10;
+    await Promise.all([
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+    ]);
+    expect(establishedConnections).to.equal(4);
+  });
+
+  // let fakes, MultiClient;
+
+  // beforeEach(() => {
+  //   fakes = {
+  //     config: sinon.stub(),
+  //     EndpointManager: sinon.stub(),
+  //     endpointManager: new EventEmitter(),
+  //   };
+
+  //   fakes.EndpointManager.returns(fakes.endpointManager);
+  //   fakes.endpointManager.shutdown = sinon.stub();
+
+  //   MultiClient = require("../lib/client")(fakes);
+  // });
+
+  // describe("constructor", () => {
+  //   it("prepares the configuration with passed options", () => {
+  //     let options = { production: true };
+  //     let client = new MultiClient(options);
+
+  //     expect(fakes.config).to.be.calledWith(options);
+  //   });
+
+  //   describe("EndpointManager instance", function() {
+  //     it("is created", () => {
+  //       let client = new MultiClient();
+
+  //       expect(fakes.EndpointManager).to.be.calledOnce;
+  //       expect(fakes.EndpointManager).to.be.calledWithNew;
+  //     });
+
+  //     it("is passed the prepared configuration", () => {
+  //       const returnSentinel = { "configKey": "configValue"};
+  //       fakes.config.returns(returnSentinel);
+
+  //       let client = new MultiClient({});
+  //       expect(fakes.EndpointManager).to.be.calledWith(returnSentinel);
+  //     });
+  //   });
+  // });
+
+  describe("write", () => {
+    // beforeEach(() => {
+    //   fakes.config.returnsArg(0);
+    //   fakes.endpointManager.getStream = sinon.stub();
+
+    //   fakes.EndpointManager.returns(fakes.endpointManager);
+    // });
+
+    // context("a stream is available", () => {
+    //   let client;
+
+    //   context("transmission succeeds", () => {
+    //     beforeEach( () => {
+    //       client = new MultiClient( { address: "testapi" } );
+
+    //       fakes.stream = new FakeStream("abcd1234", "200");
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+    //     });
+
+    //     it("attempts to acquire one stream", () => {
+    //       return client.write(builtNotification(), "abcd1234")
+    //         .then(() => {
+    //           expect(fakes.endpointManager.getStream).to.be.calledOnce;
+    //         });
+    //     });
+
+    //     describe("headers", () => {
+
+    //       it("sends the required HTTP/2 headers", () => {
+    //         return client.write(builtNotification(), "abcd1234")
+    //           .then(() => {
+    //             expect(fakes.stream.headers).to.be.calledWithMatch( {
+    //               ":scheme": "https",
+    //               ":method": "POST",
+    //               ":authority": "testapi",
+    //               ":path": "/3/device/abcd1234",
+    //             });
+    //           });
+    //       });
+
+    //       it("does not include apns headers when not required", () => {
+    //         return client.write(builtNotification(), "abcd1234")
+    //           .then(() => {
+    //             ["apns-id", "apns-priority", "apns-expiration", "apns-topic"].forEach( header => {
+    //               expect(fakes.stream.headers).to.not.be.calledWithMatch(sinon.match.has(header));
+    //             });
+    //           });
+    //       });
+
+    //       it("sends the notification-specific apns headers when specified", () => {
+    //         let notification = builtNotification();
+
+    //         notification.headers = {
+    //           "apns-id": "123e4567-e89b-12d3-a456-42665544000",
+    //           "apns-priority": 5,
+    //           "apns-expiration": 123,
+    //           "apns-topic": "io.apn.node",
+    //         };
+
+    //         return client.write(notification, "abcd1234")
+    //           .then(() => {
+    //             expect(fakes.stream.headers).to.be.calledWithMatch( {
+    //               "apns-id": "123e4567-e89b-12d3-a456-42665544000",
+    //               "apns-priority": 5,
+    //               "apns-expiration": 123,
+    //               "apns-topic": "io.apn.node",
+    //             });
+    //           });
+    //       });
+
+    //       context("when token authentication is enabled", () => {
+    //         beforeEach(() => {
+    //           fakes.token = {
+    //             generation: 0,
+    //             current: "fake-token",
+    //             regenerate: sinon.stub(),
+    //             isExpired: sinon.stub()
+    //           };
+
+    //           client = new MultiClient( { address: "testapi", token: fakes.token } );
+
+    //           fakes.stream = new FakeStream("abcd1234", "200");
+    //           fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+    //         });
+
+    //         it("sends the bearer token", () => {
+    //           let notification = builtNotification();
+
+    //           return client.write(notification, "abcd1234").then(() => {
+    //             expect(fakes.stream.headers).to.be.calledWithMatch({
+    //               authorization: "bearer fake-token",
+    //             });
+    //           });
+    //         });
+    //       });
+
+    //       context("when token authentication is disabled", () => {
+    //         beforeEach(() => {
+    //           client = new MultiClient( { address: "testapi" } );
+
+    //           fakes.stream = new FakeStream("abcd1234", "200");
+    //           fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+    //         });
+
+    //         it("does not set an authorization header", () => {
+    //           let notification = builtNotification();
+
+    //           return client.write(notification, "abcd1234").then(() => {
+    //             expect(fakes.stream.headers.firstCall.args[0]).to.not.have.property("authorization");
+    //           })
+    //         });
+    //       })
+    //     });
+
+    //     it("writes the notification data to the pipe", () => {
+    //       const notification = builtNotification();
+    //       return client.write(notification, "abcd1234")
+    //         .then(() => {
+    //           expect(fakes.stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(notification.body)));
+    //         });
+    //     });
+
+    //     it("ends the stream", () => {
+    //       sinon.spy(fakes.stream, "end");
+    //       return client.write(builtNotification(), "abcd1234")
+    //         .then(() => {
+    //           expect(fakes.stream.end).to.be.calledOnce;
+    //         });
+    //     });
+
+    //     it("resolves with the device token", () => {
+    //       return expect(client.write(builtNotification(), "abcd1234"))
+    //         .to.become({ device: "abcd1234" });
+    //     });
+    //   });
+
+    //   context("error occurs", () => {
+    //     let promise;
+
+    //     context("general case", () => {
+    //       beforeEach(() => {
+    //         const client = new MultiClient( { address: "testapi" } );
+
+    //         fakes.stream = new FakeStream("abcd1234", "400", { "reason" : "BadDeviceToken" });
+    //         fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+
+    //         promise = client.write(builtNotification(), "abcd1234");
+    //       });
+
+    //       it("resolves with the device token, status code and response", () => {
+    //         return expect(promise).to.eventually.deep.equal({ status: "400", device: "abcd1234", response: { reason: "BadDeviceToken" }});
+    //       });
+    //     })
+
+    //     context("ExpiredProviderToken", () => {
+    //       beforeEach(() => {
+    //         let tokenGenerator = sinon.stub().returns("fake-token");
+    //         const client = new MultiClient( { address: "testapi", token: tokenGenerator });
+    //       })
+    //     });
+    //   });
+
+    //   context("stream ends without completing request", () => {
+    //     let promise;
+
+    //     beforeEach(() => {
+    //       const client = new MultiClient( { address: "testapi" } );
+    //       fakes.stream = new stream.Transform({
+    //         transform: function(chunk, encoding, callback) {}
+    //       });
+    //       fakes.stream.headers = sinon.stub();
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+
+    //       promise = client.write(builtNotification(), "abcd1234");
+
+    //       fakes.stream.push(null);
+    //     });
+
+    //     it("resolves with an object containing the device token", () => {
+    //       return expect(promise).to.eventually.have.property("device", "abcd1234");
+    //     });
+
+    //     it("resolves with an object containing an error", () => {
+    //       return promise.then( (response) => {
+    //         expect(response).to.have.property("error");
+    //         expect(response.error).to.be.an.instanceOf(Error);
+    //         expect(response.error).to.match(/stream ended unexpectedly/);
+    //       });
+    //     });
+    //   });
+
+    //   context("stream is unprocessed", () => {
+    //     let promise;
+
+    //     beforeEach(() => {
+    //       const client = new MultiClient( { address: "testapi" } );
+    //       fakes.stream = new stream.Transform({
+    //         transform: function(chunk, encoding, callback) {}
+    //       });
+    //       fakes.stream.headers = sinon.stub();
+
+    //       fakes.secondStream = FakeStream("abcd1234", "200");
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+    //       fakes.endpointManager.getStream.onCall(1).returns(fakes.secondStream);
+
+    //       promise = client.write(builtNotification(), "abcd1234");
+
+    //       setImmediate(() => {
+    //         fakes.stream.emit("unprocessed");
+    //       });
+    //     });
+
+    //     it("attempts to resend on a new stream", function (done) {
+    //       setImmediate(() => {
+    //         expect(fakes.endpointManager.getStream).to.be.calledTwice;
+    //         done();
+    //       });
+    //     });
+
+    //     it("fulfills the promise", () => {
+    //       return expect(promise).to.eventually.deep.equal({ device: "abcd1234"  });
+    //     });
+    //   });
+
+    //   context("stream error occurs", () => {
+    //     let promise;
+
+    //     beforeEach(() => {
+    //       const client = new MultiClient( { address: "testapi" } );
+    //       fakes.stream = new stream.Transform({
+    //         transform: function(chunk, encoding, callback) {}
+    //       });
+    //       fakes.stream.headers = sinon.stub();
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+
+    //       promise = client.write(builtNotification(), "abcd1234");
+    //     });
+
+    //     context("passing an Error", () => {
+    //       beforeEach(() => {
+    //         fakes.stream.emit("error", new Error("stream error"));
+    //       });
+
+    //       it("resolves with an object containing the device token", () => {
+    //         return expect(promise).to.eventually.have.property("device", "abcd1234");
+    //       });
+
+    //       it("resolves with an object containing a wrapped error", () => {
+    //         return promise.then( (response) => {
+    //           expect(response.error).to.be.an.instanceOf(Error);
+    //           expect(response.error).to.match(/apn write failed/);
+    //           expect(response.error.cause()).to.be.an.instanceOf(Error).and.match(/stream error/);
+    //         });
+    //       });
+    //     });
+
+    //     context("passing a string", () => {
+    //       it("resolves with the device token and an error", () => {
+    //         fakes.stream.emit("error", "stream error");
+    //         return promise.then( (response) => {
+    //             expect(response).to.have.property("device", "abcd1234");
+    //             expect(response.error).to.to.be.an.instanceOf(Error);
+    //             expect(response.error).to.match(/apn write failed/);
+    //             expect(response.error).to.match(/stream error/);
+    //         });
+    //       });
+    //     });
+    //   });
+    // });
+
+    // context("no new stream is returned but the endpoint later wakes up", () => {
+    //   let notification, promise;
+
+    //   beforeEach( () => {
+    //     const client = new MultiClient( { address: "testapi" } );
+
+    //     fakes.stream = new FakeStream("abcd1234", "200");
+    //     fakes.endpointManager.getStream.onCall(0).returns(null);
+    //     fakes.endpointManager.getStream.onCall(1).returns(fakes.stream);
+
+    //     notification = builtNotification();
+    //     promise = client.write(notification, "abcd1234");
+
+    //     expect(fakes.stream.headers).to.not.be.called;
+
+    //     fakes.endpointManager.emit("wakeup");
+
+    //     return promise;
+    //   });
+
+    //   it("sends the required headers to the newly available stream", () => {
+    //     expect(fakes.stream.headers).to.be.calledWithMatch( {
+    //       ":scheme": "https",
+    //       ":method": "POST",
+    //       ":authority": "testapi",
+    //       ":path": "/3/device/abcd1234",
+    //     });
+    //   });
+
+    //   it("writes the notification data to the pipe", () => {
+    //     expect(fakes.stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(notification.body)));
+    //   });
+    // });
+
+    // context("when 5 successive notifications are sent", () => {
+
+    //   beforeEach(() => {
+    //       fakes.streams = [
+    //         new FakeStream("abcd1234", "200"),
+    //         new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
+    //         new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
+    //         new FakeStream("bcfe4433", "200"),
+    //         new FakeStream("aabbc788", "413", { reason: "PayloadTooLarge" }),
+    //       ];
+    //   });
+
+    //   context("streams are always returned", () => {
+    //     let promises;
+
+    //     beforeEach( () => {
+    //       const client = new MultiClient( { address: "testapi" } );
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+    //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
+    //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
+    //       fakes.endpointManager.getStream.onCall(3).returns(fakes.streams[3]);
+    //       fakes.endpointManager.getStream.onCall(4).returns(fakes.streams[4]);
+
+    //       promises = Promise.all([
+    //         client.write(builtNotification(), "abcd1234"),
+    //         client.write(builtNotification(), "adfe5969"),
+    //         client.write(builtNotification(), "abcd1335"),
+    //         client.write(builtNotification(), "bcfe4433"),
+    //         client.write(builtNotification(), "aabbc788"),
+    //       ]);
+
+    //       return promises;
+    //     });
+
+    //     it("sends the required headers for each stream", () => {
+    //       expect(fakes.streams[0].headers).to.be.calledWithMatch( { ":path": "/3/device/abcd1234" } );
+    //       expect(fakes.streams[1].headers).to.be.calledWithMatch( { ":path": "/3/device/adfe5969" } );
+    //       expect(fakes.streams[2].headers).to.be.calledWithMatch( { ":path": "/3/device/abcd1335" } );
+    //       expect(fakes.streams[3].headers).to.be.calledWithMatch( { ":path": "/3/device/bcfe4433" } );
+    //       expect(fakes.streams[4].headers).to.be.calledWithMatch( { ":path": "/3/device/aabbc788" } );
+    //     });
+
+    //     it("writes the notification data for each stream", () => {
+    //       fakes.streams.forEach( stream => {
+    //         expect(stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(builtNotification().body)));
+    //       });
+    //     });
+
+    //     it("resolves with the notification outcomes", () => {
+    //       return expect(promises).to.eventually.deep.equal([
+    //           { device: "abcd1234"},
+    //           { device: "adfe5969", status: "400", response: { reason: "MissingTopic" } },
+    //           { device: "abcd1335", status: "410", response: { reason: "BadDeviceToken", timestamp: 123456789 } },
+    //           { device: "bcfe4433"},
+    //           { device: "aabbc788", status: "413", response: { reason: "PayloadTooLarge" } },
+    //       ]);
+    //     });
+    //   });
+
+    //   context("some streams return, others wake up later", () => {
+    //     let promises;
+
+    //     beforeEach( function() {
+    //       const client = new MultiClient( { address: "testapi" } );
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+    //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
+
+    //       promises = Promise.all([
+    //         client.write(builtNotification(), "abcd1234"),
+    //         client.write(builtNotification(), "adfe5969"),
+    //         client.write(builtNotification(), "abcd1335"),
+    //         client.write(builtNotification(), "bcfe4433"),
+    //         client.write(builtNotification(), "aabbc788"),
+    //       ]);
+
+    //       setTimeout(() => {
+    //         fakes.endpointManager.getStream.reset();
+    //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[2]);
+    //         fakes.endpointManager.getStream.onCall(1).returns(null);
+    //         fakes.endpointManager.emit("wakeup");
+    //       }, 1);
+
+    //       setTimeout(() => {
+    //         fakes.endpointManager.getStream.reset();
+    //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
+    //         fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
+    //         fakes.endpointManager.emit("wakeup");
+    //       }, 2);
+
+    //       return promises;
+    //     });
+
+    //     it("sends the correct device ID for each stream", () => {
+    //       expect(fakes.streams[0].headers).to.be.calledWithMatch({":path": "/3/device/abcd1234"});
+    //       expect(fakes.streams[1].headers).to.be.calledWithMatch({":path": "/3/device/adfe5969"});
+    //       expect(fakes.streams[2].headers).to.be.calledWithMatch({":path": "/3/device/abcd1335"});
+    //       expect(fakes.streams[3].headers).to.be.calledWithMatch({":path": "/3/device/bcfe4433"});
+    //       expect(fakes.streams[4].headers).to.be.calledWithMatch({":path": "/3/device/aabbc788"});
+    //     });
+
+    //     it("writes the notification data for each stream", () => {
+    //       fakes.streams.forEach( stream => {
+    //         expect(stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(builtNotification().body)));
+    //       });
+    //     });
+
+    //     it("resolves with the notification reponses", () => {
+    //       return expect(promises).to.eventually.deep.equal([
+    //           { device: "abcd1234"},
+    //           { device: "adfe5969", status: "400", response: { reason: "MissingTopic" } },
+    //           { device: "abcd1335", status: "410", response: { reason: "BadDeviceToken", timestamp: 123456789 } },
+    //           { device: "bcfe4433"},
+    //           { device: "aabbc788", status: "413", response: { reason: "PayloadTooLarge" } },
+    //       ]);
+    //     });
+    //   });
+
+    //   context("connection fails", () => {
+    //     let promises, client;
+
+    //     beforeEach( function() {
+    //       client = new MultiClient( { address: "testapi" } );
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+
+    //       promises = Promise.all([
+    //         client.write(builtNotification(), "abcd1234"),
+    //         client.write(builtNotification(), "adfe5969"),
+    //         client.write(builtNotification(), "abcd1335"),
+    //       ]);
+
+    //       setTimeout(() => {
+    //         fakes.endpointManager.getStream.reset();
+    //         fakes.endpointManager.emit("error", new Error("endpoint failed"));
+    //       }, 1);
+
+    //       return promises;
+    //     });
+
+    //     it("resolves with 1 success", () => {
+    //       return promises.then( response => {
+    //         expect(response[0]).to.deep.equal({ device: "abcd1234" });
+    //       });
+    //     });
+
+    //     it("resolves with 2 errors", () => {
+    //       return promises.then( response => {
+    //         expect(response[1]).to.deep.equal({ device: "adfe5969", error: new Error("endpoint failed") });
+    //         expect(response[2]).to.deep.equal({ device: "abcd1335", error: new Error("endpoint failed") });
+    //       })
+    //     });
+
+    //     it("clears the queue", () => {
+    //       return promises.then( () => {
+    //         expect(client.queue.length).to.equal(0);
+    //       });
+    //     });
+    //   });
+
+    // });
+
+    // describe("token generator behaviour", () => {
+    //   beforeEach(() => {
+    //     fakes.token = {
+    //       generation: 0,
+    //       current: "fake-token",
+    //       regenerate: sinon.stub(),
+    //       isExpired: sinon.stub()
+    //     }
+
+    //     fakes.streams = [
+    //       new FakeStream("abcd1234", "200"),
+    //       new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
+    //       new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
+    //     ];
+    //   });
+
+    //   it("reuses the token", () => {
+    //     const client = new MultiClient( { address: "testapi", token: fakes.token } );
+
+    //     fakes.token.regenerate = () => {
+    //       fakes.token.generation = 1;
+    //       fakes.token.current = "second-token";
+    //     }
+
+    //     fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+    //     fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
+    //     fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
+
+    //     return Promise.all([
+    //       client.write(builtNotification(), "abcd1234"),
+    //       client.write(builtNotification(), "adfe5969"),
+    //       client.write(builtNotification(), "abcd1335"),
+    //     ]).then(() => {
+    //       expect(fakes.streams[0].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
+    //       expect(fakes.streams[1].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
+    //       expect(fakes.streams[2].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
+    //     });
+    //   });
+
+    //   context("token expires", () => {
+
+    //     beforeEach(() => {
+    //       fakes.token.regenerate = function (generation) {
+    //         if (generation === fakes.token.generation) {
+    //           fakes.token.generation += 1;
+    //           fakes.token.current = "token-" + fakes.token.generation;
+    //         }
+    //       }
+    //     });
+
+    //     it("resends the notification with a new token", () => {
+    //       fakes.streams = [
+    //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
+    //         new FakeStream("adfe5969", "200"),
+    //       ];
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+
+    //       const client = new MultiClient( { address: "testapi", token: fakes.token } );
+
+    //       const promise = client.write(builtNotification(), "adfe5969");
+
+    //       setTimeout(() => {
+    //         fakes.endpointManager.getStream.reset();
+    //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[1]);
+    //         fakes.endpointManager.emit("wakeup");
+    //       }, 1);
+
+    //       return promise.then(() => {
+    //         expect(fakes.streams[0].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
+    //         expect(fakes.streams[1].headers).to.be.calledWithMatch({ authorization: "bearer token-1" });
+    //       });
+    //     });
+
+    //     it("only regenerates the token once per-expiry", () => {
+    //       fakes.streams = [
+    //         new FakeStream("abcd1234", "200"),
+    //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
+    //         new FakeStream("abcd1335", "403", { reason: "ExpiredProviderToken" }),
+    //         new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
+    //         new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
+    //       ];
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+    //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
+    //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
+
+    //       const client = new MultiClient( { address: "testapi", token: fakes.token } );
+
+    //       const promises = Promise.all([
+    //         client.write(builtNotification(), "abcd1234"),
+    //         client.write(builtNotification(), "adfe5969"),
+    //         client.write(builtNotification(), "abcd1335"),
+    //       ]);
+
+    //       setTimeout(() => {
+    //         fakes.endpointManager.getStream.reset();
+    //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
+    //         fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
+    //         fakes.endpointManager.emit("wakeup");
+    //       }, 1);
+
+    //       return promises.then(() => {
+    //         expect(fakes.streams[0].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
+    //         expect(fakes.streams[1].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
+    //         expect(fakes.streams[2].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
+    //         expect(fakes.streams[3].headers).to.be.calledWithMatch({ authorization: "bearer token-1" });
+    //         expect(fakes.streams[4].headers).to.be.calledWithMatch({ authorization: "bearer token-1" });
+    //       });
+    //     });
+
+    //     it("abandons sending after 3 ExpiredProviderToken failures", () => {
+    //       fakes.streams = [
+    //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
+    //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
+    //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
+    //       ];
+
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+    //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
+    //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
+
+    //       const client = new MultiClient( { address: "testapi", token: fakes.token } );
+
+    //       return expect(client.write(builtNotification(), "adfe5969")).to.eventually.have.property("status", "403");
+    //     });
+
+    //     it("regenerate token", () => {
+    //       fakes.stream = new FakeStream("abcd1234", "200");
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+
+    //       fakes.token.isExpired = function (current, validSeconds) {
+    //         return true;
+    //       }
+
+    //       let client = new MultiClient({
+    //         address: "testapi",
+    //         token: fakes.token
+    //       });
+
+    //       return client.write(builtNotification(), "abcd1234")
+    //         .then(() => {
+    //           expect(fakes.token.generation).to.equal(1);
+    //         });
+    //     });
+
+    //     it("internal server error", () => {
+    //       fakes.stream = new FakeStream("abcd1234", "500", { reason: "InternalServerError" });
+    //       fakes.stream.connection = sinon.stub();
+    //       fakes.stream.connection.close = sinon.stub();
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
+
+    //       let client = new MultiClient({
+    //         address: "testapi",
+    //         token: fakes.token
+    //       });
+
+    //       return expect(client.write(builtNotification(), "abcd1234")).to.eventually.have.deep.property("error.jse_shortmsg","Error 500, stream ended unexpectedly");
+    //     });
+    //   });
+    // });
+  });
+
+  describe("shutdown", () => {
+    // beforeEach(() => {
+    //   fakes.config.returnsArg(0);
+    //   fakes.endpointManager.getStream = sinon.stub();
+
+    //   fakes.EndpointManager.returns(fakes.endpointManager);
+    // });
+
+    // context("with no pending notifications", () => {
+    //   it("invokes shutdown on endpoint manager", () => {
+    //     let client = new MultiClient();
+    //     client.shutdown();
+
+    //     expect(fakes.endpointManager.shutdown).to.be.calledOnce;
+    //   });
+    // });
+
+    // context("with pending notifications", () => {
+    //   it("invokes shutdown on endpoint manager after queue drains", () => {
+    //     let client = new MultiClient({ address: "none" });
+
+    //     fakes.streams = [
+    //       new FakeStream("abcd1234", "200"),
+    //       new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
+    //       new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
+    //       new FakeStream("bcfe4433", "200"),
+    //       new FakeStream("aabbc788", "413", { reason: "PayloadTooLarge" }),
+    //     ];
+
+    //     fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
+    //     fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
+
+    //     let promises = Promise.all([
+    //       client.write(builtNotification(), "abcd1234"),
+    //       client.write(builtNotification(), "adfe5969"),
+    //       client.write(builtNotification(), "abcd1335"),
+    //       client.write(builtNotification(), "bcfe4433"),
+    //       client.write(builtNotification(), "aabbc788"),
+    //     ]);
+
+    //     client.shutdown();
+
+    //     expect(fakes.endpointManager.shutdown).to.not.be.called;
+
+    //     setTimeout(() => {
+    //       fakes.endpointManager.getStream.reset();
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[2]);
+    //       fakes.endpointManager.getStream.onCall(1).returns(null);
+    //       fakes.endpointManager.emit("wakeup");
+    //     }, 1);
+
+    //     setTimeout(() => {
+    //       fakes.endpointManager.getStream.reset();
+    //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
+    //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
+    //       fakes.endpointManager.emit("wakeup");
+    //     }, 2);
+
+    //     return promises.then( () => {
+    //       expect(fakes.endpointManager.shutdown).to.have.been.called;
+    //     });
+    //   });
+    // });
+  });
+});

--- a/test/provider.js
+++ b/test/provider.js
@@ -125,7 +125,7 @@ describe("Provider", function() {
           const provider = new Provider( { address: "testapi" } );
 
           for(let i=0; i < fakes.resolutions.length; i++) {
-            fakes.client.write.onCall(i).returns(Promise.resolve(fakes.resolutions[i])); 
+            fakes.client.write.onCall(i).returns(Promise.resolve(fakes.resolutions[i]));
           }
 
           promise = provider.send(notificationDouble(), fakes.resolutions.map( res => res.device ));
@@ -141,12 +141,14 @@ describe("Provider", function() {
 
         it("resolves with the device token, status code and response or error of the unsent notifications", function () {
           return promise.then( (response) => {
+            expect(response.failed[3].error).to.be.an.instanceof(Error);
+            response.failed[3].error = { message: response.failed[3].error.message };
             expect(response.failed).to.deep.equal([
               { device: "adfe5969", status: "400", response: { reason: "MissingTopic" }},
               { device: "abcd1335", status: "410", response: { reason: "BadDeviceToken", timestamp: 123456789 }},
               { device: "aabbc788", status: "413", response: { reason: "PayloadTooLarge" }},
-              { device: "fbcde238", error: new Error("connection failed") },
-            ]);
+              { device: "fbcde238", error: { message: "connection failed" }},
+            ], `Unexpected result: ${JSON.stringify(response.failed)}`);
           });
         });
       });
@@ -154,7 +156,7 @@ describe("Provider", function() {
   });
 
   describe("shutdown", function () {
-    it("invokes shutdown on the client", function () { 
+    it("invokes shutdown on the client", function () {
       let provider = new Provider({});
       provider.shutdown();
 


### PR DESCRIPTION
It is possible for some use cases to run into limits on the number of
in-flight requests to APNs at a time, especially when sending out bursts
of push notifications.

It seems like this is only necessary when sending out over a hundred
pushes per second, though that may depend on the burstiness, cpu speed or
internet reliability.

And drop support for node < 12 - they have known crashes/bugs with http2 that I don't expect to get fixed (security fixes only).
Refactorings such as this PR may make those bugs more likely.

https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns/ mentions the following

> Avoid push burst over selective connections. Diversifying push traffic over many connections distributes push traffic for your application across all APNs servers.



Closes https://github.com/parse-community/node-apn/issues/34