### PR TITLE
Allow certificate validation errors to be caught instead of terminating

### DIFF
--- a/lib/credentials/certificate/prepare.js
+++ b/lib/credentials/certificate/prepare.js
@@ -17,7 +17,12 @@ module.exports = function(dependencies) {
       return loaded;
     }
     parsed.production = credentials.production;
-    validate(parsed);
+    try {
+      validate(parsed);
+    } catch(err) {
+      console.error(err);
+    }
+
     return loaded;
   }
 


### PR DESCRIPTION
This came up in the context of pushd.  If there are a lot of push notification destinations set up, all with their own certificates, it's not ideal for one expired certificate to cause a terminating failure.

This tiny change wraps the validation in a try/catch so a validation error is still logged, but execution can continue.

Joe
