### PR TITLE
Added support for iOS 15 property interruption-level

### DIFF
--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -105,6 +105,7 @@ This table shows the name of the setter, with the key-path of the underlying pro
 | `urlArgs`           | `aps.url-args`              | `Array`             |
 | `category`          | `aps.category`              | `String`            |
 | `threadId`          | `aps.thread-id`             | `String`            |
+| `interruptionLevel` | `aps.interruption-level`    | `String`            |
 | `mdm`               | `mdm`                       | `String`            |
 
 When the notification is transmitted these properties will be added to the output before encoding.

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -122,6 +122,12 @@ module.exports = {
     }
   },
 
+  set interruptionLevel(value) {
+    if(typeof value === "string" || value === undefined) {
+      this.aps["interruption-level"] = value;
+    }
+  },
+
   prepareAlert: function () {
     if (typeof this.aps.alert !== "object") {
       this.aps.alert = {"body": this.aps.alert};

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -27,7 +27,7 @@ Notification.prototype = require("./apsProperties");
 ["payload", "expiry", "priority", "alert", "body", "locKey",
 "locArgs", "title", "subtitle", "titleLocKey", "titleLocArgs", "action",
 "actionLocKey", "launchImage", "badge", "sound", "contentAvailable",
-"mutableContent", "mdm", "urlArgs", "category", "threadId"].forEach( propName => {
+"mutableContent", "mdm", "urlArgs", "category", "threadId", "interruptionLevel"].forEach( propName => {
   const methodName = "set" + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {
     this[propName] = value;

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -711,6 +711,32 @@ describe("Notification", function() {
       });
     });
 
+    describe("interruption-level", function() {
+      it("defaults to undefined", function() {
+        expect(compiledOutput()).to.not.have.nested.property("aps.interruption\-level");
+      });
+
+      it("can be set to a string", function() {
+        note.interruptionLevel = "the-interruption-level";
+
+        expect(compiledOutput()).to.have.nested.property("aps.interruption\-level", "the-interruption-level");
+      });
+
+      it("can be set to undefined", function() {
+        note.interruptionLevel = "the-interruption-level";
+        note.interruptionLevel = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property("aps.interruption\-level");
+      });
+
+      describe("setInterruptionLevel", function () {
+        it("is chainable", function () {
+          expect(note.setInterruptionLevel("the-interruption-level")).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property("aps.interruption\-level", "the-interruption-level");
+        });
+      });
+    });
+
     context("when no aps properties are set", function() {
       it("is not present", function() {
         expect(compiledOutput().aps).to.be.undefined;


### PR DESCRIPTION
A copy of the PR on https://github.com/Netatmo/node-apn/pull/6

See more [here](https://developer.apple.com/videos/play/wwdc2021/10091/), [here](https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel?changes=la) and [here](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification).

