### PR TITLE
Add support for target-content-id notification property

### DIFF
--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -86,26 +86,27 @@ The setters below provide a cleaner way to set properties defined by the Apple P
 
 This table shows the name of the setter, with the key-path of the underlying property it maps to and the expected value type.
 
-| Setter Name         | Target Property             | Type                |
-|---------------------|-----------------------------|---------------------|
-| `alert`             | `aps.alert`                 | `String` or `Object`|
-| `body`              | `aps.alert.body`            | `String`            |
-| `locKey`            | `aps.alert.loc-key`         | `String`            |
-| `locArgs`           | `aps.alert.loc-args`        | `Array`             |
-| `title`             | `aps.alert.title`           | `String`            |
-| `titleLocKey`       | `aps.alert.title-loc-key`   | `String`            |
-| `titleLocArgs`      | `aps.alert.title-loc-args`  | `Array`             |
-| `action`            | `aps.alert.action`          | `String`            |
-| `actionLocKey`      | `aps.alert.action-loc-key`  | `String`            |
-| `launchImage`       | `aps.launch-image`          | `String`            |
-| `badge`             | `aps.badge`                 | `Number`            |
-| `sound`             | `aps.sound`                 | `String` or `Object`|
-| `contentAvailable`  | `aps.content-available`     | `1`                 |
-| `mutableContent`    | `aps.mutable-content`       | `1`                 |
-| `urlArgs`           | `aps.url-args`              | `Array`             |
-| `category`          | `aps.category`              | `String`            |
-| `threadId`          | `aps.thread-id`             | `String`            |
-| `mdm`               | `mdm`                       | `String`            |
+| Setter Name                | Target Property             | Type                |
+|----------------------------|-----------------------------|---------------------|
+| `alert`                    | `aps.alert`                 | `String` or `Object`|
+| `body`                     | `aps.alert.body`            | `String`            |
+| `locKey`                   | `aps.alert.loc-key`         | `String`            |
+| `locArgs`                  | `aps.alert.loc-args`        | `Array`             |
+| `title`                    | `aps.alert.title`           | `String`            |
+| `titleLocKey`              | `aps.alert.title-loc-key`   | `String`            |
+| `titleLocArgs`             | `aps.alert.title-loc-args`  | `Array`             |
+| `action`                   | `aps.alert.action`          | `String`            |
+| `actionLocKey`             | `aps.alert.action-loc-key`  | `String`            |
+| `launchImage`              | `aps.launch-image`          | `String`            |
+| `badge`                    | `aps.badge`                 | `Number`            |
+| `sound`                    | `aps.sound`                 | `String` or `Object`|
+| `contentAvailable`         | `aps.content-available`     | `1`                 |
+| `mutableContent`           | `aps.mutable-content`       | `1`                 |
+| `urlArgs`                  | `aps.url-args`              | `Array`             |
+| `category`                 | `aps.category`              | `String`            |
+| `targetContentIdentifier`  | `aps.target-content-id`     | `String`            |
+| `threadId`                 | `aps.thread-id`             | `String`            |
+| `mdm`                      | `mdm`                       | `String`            |
 
 When the notification is transmitted these properties will be added to the output before encoding.
 

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -116,6 +116,12 @@ module.exports = {
     }
   },
 
+  set targetContentIdentifier(value) {
+    if(typeof value === "string" || value === undefined) {
+      this.aps["target-content-id"] = value;
+    }
+  },
+
   set threadId(value) {
     if(typeof value === "string" || value === undefined) {
       this.aps["thread-id"] = value;

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -27,7 +27,8 @@ Notification.prototype = require("./apsProperties");
 ["payload", "expiry", "priority", "alert", "body", "locKey",
 "locArgs", "title", "subtitle", "titleLocKey", "titleLocArgs", "action",
 "actionLocKey", "launchImage", "badge", "sound", "contentAvailable",
-"mutableContent", "mdm", "urlArgs", "category", "threadId"].forEach( propName => {
+"mutableContent", "mdm", "urlArgs", "category", "targetContentIdentifier",
+"threadId"].forEach( propName => {
   const methodName = "set" + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {
     this[propName] = value;

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -685,6 +685,35 @@ describe("Notification", function() {
       });
     });
 
+    describe("target-content-id", function() {
+      it("defaults to undefined", function() {
+        expect(compiledOutput())
+          .to.not.have.nested.property("aps.target\-content\-id");
+      });
+
+      it("can be set to a string", function() {
+        note.targetContentIdentifier = "the-target-content-id";
+
+        expect(compiledOutput()).to.have.nested.property("aps.target\-content\-id",
+          "the-target-content-id");
+      });
+
+      it("can be set to undefined", function() {
+        note.targetContentIdentifier = "the-target-content-identifier";
+        note.targetContentIdentifier = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property("aps.target\-content\-id");
+      });
+
+      describe("setTargetContentIdentifier", function () {
+        it("is chainable", function () {
+          expect(note.setTargetContentIdentifier("the-target-content-id")).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property("aps.target\-content\-id",
+            "the-target-content-id");
+        });
+      });
+    });
+
     describe("thread-id", function() {
       it("defaults to undefined", function() {
         expect(compiledOutput()).to.not.have.deep.property("aps.thread\-id");


### PR DESCRIPTION
See `target-content-id` [here](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943361) and [here](https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3235764-targetcontentidentifier).