### PR TITLE
add support for "interruption-level" and "target-content-id"

### DIFF
--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -11,6 +11,7 @@ let notification = new apn.Notification({
   alert: "Hello, world!",
   sound: "chime.caf",
   mutableContent: 1,
+  interruptionLevel: "time-sensitive",
   payload: {
     "sender": "node-apn",
   },
@@ -102,6 +103,8 @@ This table shows the name of the setter, with the key-path of the underlying pro
 | `sound`             | `aps.sound`                 | `String` or `Object`|
 | `contentAvailable`  | `aps.content-available`     | `1`                 |
 | `mutableContent`    | `aps.mutable-content`       | `1`                 |
+| `targetContentIdentifier` | `aps.target-content-id` | `String`          |
+| `interruptionLevel` | `aps.interruption-level`    | `String`            |
 | `urlArgs`           | `aps.url-args`              | `Array`             |
 | `category`          | `aps.category`              | `String`            |
 | `threadId`          | `aps.thread-id`             | `String`            |

--- a/index.d.ts
+++ b/index.d.ts
@@ -238,9 +238,17 @@ export class Notification {
    */
   public contentAvailable: boolean;
   /**
-   *
+   * Setting this to 1 will specify "mutable-content" in the payload when it is compiled.
    */
   public mutableContent: boolean;
+  /**
+   * Specify interruption-level of a notification.
+   */
+  public interruptionLevel: string;
+  /**
+   * Specify target-content-id of a notification.
+   */
+  public targetContentIdentifier: string;
   /**
    * The value to specify for the `mdm` field where applicable.
    */

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -100,6 +100,22 @@ module.exports = {
     }
   },
 
+  set interruptionLevel(value) {
+    if (typeof value === "string") {
+      this.aps["interruption-level"] = value;
+    } else {
+      this.aps["interruption-level"] = undefined;
+    }
+  },
+
+  set targetContentIdentifier(value) {
+    if (typeof value === "string") {
+      this.aps["target-content-id"] = value;
+    } else {
+      this.aps["target-content-id"] = undefined;
+    }
+  },
+
   set mdm(value) {
     this._mdm = value;
   },

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -27,6 +27,7 @@ Notification.prototype = require("./apsProperties");
 ["payload", "expiry", "priority", "alert", "body", "locKey",
 "locArgs", "title", "subtitle", "titleLocKey", "titleLocArgs", "action",
 "actionLocKey", "launchImage", "badge", "sound", "contentAvailable",
+"targetContentIdentifier", "interruptionLevel",
 "mutableContent", "mdm", "urlArgs", "category", "threadId"].forEach( propName => {
   const methodName = "set" + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -600,6 +600,58 @@ describe("Notification", function() {
       });
     });
 
+    describe("interruption-level", function() {
+      it("defaults to undefined", function() {
+        expect(compiledOutput()).to.not.have.deep.property("aps.interruption\-level");
+      });
+
+      it("can be set to a string value", function() {
+        note.interruptionLevel = "time-sensitive";
+
+        expect(compiledOutput()).to.have.deep.property("aps.interruption\-level", "time-sensitive");
+      });
+
+      it("can be set to undefined", function() {
+        note.interruptionLevel = "passive";
+        note.interruptionLevel = undefined;
+
+        expect(compiledOutput()).to.not.have.deep.property("aps.interruption\-level");
+      });
+
+      describe("setInterruptionLevel", function () {
+        it("is chainable", function () {
+          expect(note.setInterruptionLevel("active")).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property("aps.interruption\-level", "active");
+        });
+      });
+    });
+
+    describe("target-content-id", function() {
+      it("defaults to undefined", function() {
+        expect(compiledOutput()).to.not.have.deep.property("aps.target\-content\-id");
+      });
+
+      it("can be set to a string value", function() {
+        note.interruptionLevel = "window1";
+
+        expect(compiledOutput()).to.have.deep.property("aps.target\-content\-id", "window1");
+      });
+
+      it("can be set to undefined", function() {
+        note.interruptionLevel = "window1";
+        note.interruptionLevel = undefined;
+
+        expect(compiledOutput()).to.not.have.deep.property("aps.target\-content\-id");
+      });
+
+      describe("setTargetContentIdentifier", function () {
+        it("is chainable", function () {
+          expect(note.setTargetContentIdentifier("example")).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property("aps.target\-content\-id", "example");
+        });
+      });
+    });
+
     describe("mdm", function() {
       it("defaults to undefined", function() {
         expect(compiledOutput()).to.not.have.deep.property("mdm");


### PR DESCRIPTION
Work in progress to address https://github.com/parse-community/parse-server-push-adapter/issues/196 and https://github.com/parse-community/parse-server-push-adapter/issues/155