### PR TITLE
Set up an eslint&prettier config to standardize style. Automatically fix lint warnings and manually fix others

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,29 @@
+module.exports = {
+  env: {
+    commonjs: true,
+    es2021: true,
+    node: true,
+    mocha: true,
+  },
+  extends: [
+    'eslint:recommended',
+  ],
+  parserOptions: {
+    ecmaVersion: 13,
+    sourceType: 'module',
+  },
+  rules: {
+    /* Check variables but not function arguments. */
+    'eol-last': 2,
+    'linebreak-style': ['error', 'unix'],
+    'no-multiple-empty-lines': 1,
+    'no-trailing-spaces': 2,
+    'no-unused-vars': ['error', {args: 'none'}],
+    'no-var': 'error',
+    'prefer-const': 'error',
+    'require-atomic-updates': 'off',
+    'space-infix-ops': 'error',
+    'space-in-parens': ['error', 'never'],
+    'strict': ['error', 'never'],
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
             NODE_VERSION: 12
           - name: Node.js 14
             NODE_VERSION: 14
+          - name: Node.js 16
+            NODE_VERSION: 16
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     steps:
@@ -31,5 +33,6 @@ jobs:
           restore-keys: |
               ${{ runner.os }}-node-${{ matrix.NODE_VERSION }}-
       - run: npm ci
+      - run: npm run lint
       - run: npm run coverage
       - run: bash <(curl -s https://codecov.io/bash)

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+semi: true
+trailingComma: "es5"
+singleQuote: true
+arrowParens: "avoid"
+printWidth: 100

--- a/examples/sending-multiple-notifications.js
+++ b/examples/sending-multiple-notifications.js
@@ -5,7 +5,7 @@ Send individualised notifications
 i.e. Account updates for users with one-or-more device tokens
 */
 
-const apn = require('apn');
+const apn = require('@parse/node-apn');
 
 const users = [
   { name: 'Wendy', devices: ['<insert device token>', '<insert device token>'] },

--- a/examples/sending-multiple-notifications.js
+++ b/examples/sending-multiple-notifications.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
 
 Send individualised notifications
@@ -7,33 +5,35 @@ Send individualised notifications
 i.e. Account updates for users with one-or-more device tokens
 */
 
-const apn = require("apn");
+const apn = require('apn');
 
-let users = [
-  { name: "Wendy", "devices": ["<insert device token>", "<insert device token>"]},
-  { name: "John",  "devices": ["<insert device token>"]},
+const users = [
+  { name: 'Wendy', devices: ['<insert device token>', '<insert device token>'] },
+  { name: 'John', devices: ['<insert device token>'] },
 ];
 
-let service = new apn.Provider({
-  cert: "certificates/cert.pem",
-  key: "certificates/key.pem",
+const service = new apn.Provider({
+  cert: 'certificates/cert.pem',
+  key: 'certificates/key.pem',
 });
 
-Promise.all(users.map(user => {
-  let note = new apn.Notification();
-  note.alert = `Hey ${user.name}, I just sent my first Push Notification`;
+Promise.all(
+  users.map(user => {
+    const note = new apn.Notification();
+    note.alert = `Hey ${user.name}, I just sent my first Push Notification`;
 
-  // The topic is usually the bundle identifier of your application.
-  note.topic = "<bundle identifier>";
+    // The topic is usually the bundle identifier of your application.
+    note.topic = '<bundle identifier>';
 
-  console.log(`Sending: ${note.compile()} to ${user.devices}`);
+    console.log(`Sending: ${note.compile()} to ${user.devices}`);
 
-  return service.send(note, user.devices).then( result => {
-      console.log("sent:", result.sent.length);
-      console.log("failed:", result.failed.length);
+    return service.send(note, user.devices).then(result => {
+      console.log('sent:', result.sent.length);
+      console.log('failed:', result.failed.length);
       console.log(result.failed);
-  });
-})).then(() => {
+    });
+  })
+).then(() => {
   // For one-shot notification tasks you may wish to shutdown the connection
   // after everything is sent, but only call shutdown if you need your
   // application to terminate.

--- a/examples/sending-to-multiple-devices.js
+++ b/examples/sending-to-multiple-devices.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
 
 Send an identical notification to multiple devices.
@@ -11,30 +9,30 @@ Possible use cases:
  - Sport results
 */
 
-const apn = require("apn");
+const apn = require('apn');
 
-let tokens = ["<insert token here>", "<insert token here>"];
+const tokens = ['<insert token here>', '<insert token here>'];
 
-let service = new apn.Provider({
-  cert: "certificates/cert.pem",
-  key: "certificates/key.pem",
+const service = new apn.Provider({
+  cert: 'certificates/cert.pem',
+  key: 'certificates/key.pem',
 });
 
-let note = new apn.Notification({
-	alert:  "Breaking News: I just sent my first Push Notification",
+const note = new apn.Notification({
+  alert: 'Breaking News: I just sent my first Push Notification',
 });
 
 // The topic is usually the bundle identifier of your application.
-note.topic = "<bundle identifier>";
+note.topic = '<bundle identifier>';
 
 console.log(`Sending: ${note.compile()} to ${tokens}`);
 service.send(note, tokens).then(result => {
-    console.log("sent:", result.sent.length);
-    console.log("failed:", result.failed.length);
-    console.log(result.failed);
+  console.log('sent:', result.sent.length);
+  console.log('failed:', result.failed.length);
+  console.log(result.failed);
 
-    // For one-shot notification tasks you may wish to shutdown the connection
-    // after everything is sent, but only call shutdown if you need your 
-    // application to terminate.
-    service.shutdown();
+  // For one-shot notification tasks you may wish to shutdown the connection
+  // after everything is sent, but only call shutdown if you need your
+  // application to terminate.
+  service.shutdown();
 });

--- a/examples/sending-to-multiple-devices.js
+++ b/examples/sending-to-multiple-devices.js
@@ -9,7 +9,7 @@ Possible use cases:
  - Sport results
 */
 
-const apn = require('apn');
+const apn = require('@parse/node-apn');
 
 const tokens = ['<insert token here>', '<insert token here>'];
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
+const http2 = require('http2');
 const debug = require('debug')('apn');
+
 debug.log = console.log.bind(console);
 
 const credentials = require('./lib/credentials')({
@@ -11,8 +13,6 @@ const config = require('./lib/config')({
   prepareToken: credentials.token,
   prepareCA: credentials.ca,
 });
-
-const http2 = require('http2');
 
 const Client = require('./lib/client')({
   logger: debug,

--- a/index.js
+++ b/index.js
@@ -1,42 +1,42 @@
-const debug = require("debug")("apn");
+const debug = require('debug')('apn');
 debug.log = console.log.bind(console);
 
-const credentials = require("./lib/credentials")({
-  logger: debug
+const credentials = require('./lib/credentials')({
+  logger: debug,
 });
 
-const config = require("./lib/config")({
+const config = require('./lib/config')({
   logger: debug,
   prepareCertificate: credentials.certificate,
   prepareToken: credentials.token,
   prepareCA: credentials.ca,
 });
 
-const http2 = require("http2");
+const http2 = require('http2');
 
-const Client = require("./lib/client")({
+const Client = require('./lib/client')({
   logger: debug,
   config,
   http2,
 });
 
-const MultiClient = require("./lib/multiclient")({
+const MultiClient = require('./lib/multiclient')({
   Client,
 });
 
-const Provider = require("./lib/provider")({
+const Provider = require('./lib/provider')({
   logger: debug,
   Client,
 });
 
-const MultiProvider = require("./lib/provider")({
+const MultiProvider = require('./lib/provider')({
   logger: debug,
   Client: MultiClient,
 });
 
-const Notification = require("./lib/notification");
+const Notification = require('./lib/notification');
 
-const token = require("./lib/token");
+const token = require('./lib/token');
 
 module.exports = {
   Provider,

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,8 +9,7 @@ module.exports = function (dependencies) {
   // Used for unexpected events that should be rare under normal circumstances,
   // e.g. connection errors.
   const defaultErrorLogger = dependencies.errorLogger || defaultLogger;
-  const config = dependencies.config;
-  const http2 = dependencies.http2;
+  const { config, http2 } = dependencies;
 
   const {
     HTTP2_HEADER_STATUS,

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,9 +1,7 @@
-"use strict";
-
-const VError = require("verror");
-const tls = require("tls");
-const extend = require("./util/extend");
-const createProxySocket = require("./util/proxy");
+const VError = require('verror');
+const tls = require('tls');
+const extend = require('./util/extend');
+const createProxySocket = require('./util/proxy');
 
 module.exports = function (dependencies) {
   // Used for routine logs such as HTTP status codes, etc.
@@ -28,7 +26,7 @@ module.exports = function (dependencies) {
   const ABORTED_STATUS = '(aborted)';
   const ERROR_STATUS = '(error)';
 
-  function Client (options) {
+  function Client(options) {
     this.config = config(options);
     this.logger = defaultLogger;
     this.errorLogger = defaultErrorLogger;
@@ -36,10 +34,12 @@ module.exports = function (dependencies) {
       if (this.session && !this.session.closed && !this.session.destroyed && !this.isDestroyed) {
         this.session.ping((error, duration) => {
           if (error) {
-            this.errorLogger("No Ping response after " + duration + " ms with error:" + error.message);
+            this.errorLogger(
+              'No Ping response after ' + duration + ' ms with error:' + error.message
+            );
             return;
           }
-          this.logger("Ping response after " + duration + " ms");
+          this.logger('Ping response after ' + duration + ' ms');
         });
       }
     }, this.config.heartBeat).unref();
@@ -61,7 +61,7 @@ module.exports = function (dependencies) {
     if (callback) {
       callback();
     }
-  }
+  };
 
   // Session should be passed except when destroying the client
   Client.prototype.closeAndDestroySession = function (session, callback) {
@@ -75,16 +75,16 @@ module.exports = function (dependencies) {
       if (!session.closed) {
         session.close(() => this.destroySession(session, callback));
       } else {
-        this.destroySession(session, callback)
+        this.destroySession(session, callback);
       }
     } else if (callback) {
       callback();
     }
-  }
+  };
 
-  Client.prototype.write = function write (notification, device, count) {
+  Client.prototype.write = function write(notification, device, count) {
     if (this.isDestroyed) {
-      return Promise.resolve({ device, error: new VError("client is destroyed") });
+      return Promise.resolve({ device, error: new VError('client is destroyed') });
     }
 
     // Connect session
@@ -92,9 +92,9 @@ module.exports = function (dependencies) {
       return this.connect().then(() => this.request(notification, device, count));
     }
     return this.request(notification, device, count);
-  }
+  };
 
-  Client.prototype.connect = function connect () {
+  Client.prototype.connect = function connect() {
     if (this.sessionPromise) return this.sessionPromise;
 
     const proxySocketPromise = this.config.proxy
@@ -107,77 +107,87 @@ module.exports = function (dependencies) {
     this.sessionPromise = proxySocketPromise.then(socket => {
       this.sessionPromise = null;
       if (socket) {
-        this.config.createConnection = (authority) =>
-          authority.protocol === "http:"
-          ? socket
-          : authority.protocol === "https:"
-          ? tls.connect(+authority.port || 443, authority.hostname, {
-              socket,
-              servername: authority.hostname,
-              ALPNProtocols: ["h2"],
-            })
-          : null
+        this.config.createConnection = authority =>
+          authority.protocol === 'http:'
+            ? socket
+            : authority.protocol === 'https:'
+            ? tls.connect(+authority.port || 443, authority.hostname, {
+                socket,
+                servername: authority.hostname,
+                ALPNProtocols: ['h2'],
+              })
+            : null;
       }
 
-      const session = this.session = http2.connect(this._mockOverrideUrl || `https://${this.config.address}`, this.config);
+      const session = (this.session = http2.connect(
+        this._mockOverrideUrl || `https://${this.config.address}`,
+        this.config
+      ));
 
-      this.session.on("close", () => {
+      this.session.on('close', () => {
         if (this.errorLogger.enabled) {
-          this.errorLogger("Session closed");
+          this.errorLogger('Session closed');
         }
         this.destroySession(session);
       });
 
-      this.session.on("socketError", (error) => {
+      this.session.on('socketError', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`Socket error: ${error}`);
         }
         this.closeAndDestroySession(session);
       });
 
-      this.session.on("error", (error) => {
+      this.session.on('error', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`Session error: ${error}`);
         }
         this.closeAndDestroySession(session);
       });
 
-      this.session.on("goaway", (errorCode, lastStreamId, opaqueData) => {
+      this.session.on('goaway', (errorCode, lastStreamId, opaqueData) => {
         if (this.errorLogger.enabled) {
-          this.errorLogger(`GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`);
+          this.errorLogger(
+            `GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`
+          );
         }
         this.closeAndDestroySession(session);
       });
 
       if (this.logger.enabled) {
-        this.session.on("connect", () => {
-          this.logger("Session connected");
+        this.session.on('connect', () => {
+          this.logger('Session connected');
         });
       }
-      this.session.on("frameError", (frameType, errorCode, streamId) => {
+      this.session.on('frameError', (frameType, errorCode, streamId) => {
         // This is a frame error not associate with any request(stream).
         if (this.errorLogger.enabled) {
-          this.errorLogger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
+          this.errorLogger(
+            `Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
+          );
         }
         this.closeAndDestroySession(session);
       });
     });
 
     return this.sessionPromise;
-  }
+  };
 
-  Client.prototype.request = function request (notification, device, count) {
+  Client.prototype.request = function request(notification, device, count) {
     let tokenGeneration = null;
     let status = null;
-    let responseData = "";
-    let retryCount = count || 0;
+    let responseData = '';
+    const retryCount = count || 0;
 
-    const headers = extend({
-      [HTTP2_HEADER_SCHEME]: "https",
-      [HTTP2_HEADER_METHOD]: HTTP2_METHOD_POST,
-      [HTTP2_HEADER_AUTHORITY]: this.config.address,
-      [HTTP2_HEADER_PATH]: `/3/device/${device}`,
-    }, notification.headers);
+    const headers = extend(
+      {
+        [HTTP2_HEADER_SCHEME]: 'https',
+        [HTTP2_HEADER_METHOD]: HTTP2_METHOD_POST,
+        [HTTP2_HEADER_AUTHORITY]: this.config.address,
+        [HTTP2_HEADER_PATH]: `/3/device/${device}`,
+      },
+      notification.headers
+    );
 
     if (this.config.token) {
       if (this.config.token.isExpired(3300)) {
@@ -187,22 +197,22 @@ module.exports = function (dependencies) {
       tokenGeneration = this.config.token.generation;
     }
 
-    const request = this.session.request(headers)
+    const request = this.session.request(headers);
 
-    request.setEncoding("utf8");
+    request.setEncoding('utf8');
 
-    request.on("response", (headers) => {
+    request.on('response', headers => {
       status = headers[HTTP2_HEADER_STATUS];
     });
 
-    request.on("data", (data) => {
+    request.on('data', data => {
       responseData += data;
     });
 
     request.write(notification.body);
 
-    return new Promise ( resolve => {
-      request.on("end", () => {
+    return new Promise(resolve => {
+      request.on('end', () => {
         try {
           if (this.logger.enabled) {
             this.logger(`Request ended with status ${status} and responseData: ${responseData}`);
@@ -212,16 +222,16 @@ module.exports = function (dependencies) {
             resolve({ device });
           } else if ([TIMEOUT_STATUS, ABORTED_STATUS, ERROR_STATUS].includes(status)) {
             return;
-          } else if (responseData !== "") {
+          } else if (responseData !== '') {
             const response = JSON.parse(responseData);
 
-            if (status === 403 && response.reason === "ExpiredProviderToken" && retryCount < 2) {
+            if (status === 403 && response.reason === 'ExpiredProviderToken' && retryCount < 2) {
               this.config.token.regenerate(tokenGeneration);
               resolve(this.write(notification, device, retryCount + 1));
               return;
-            } else if (status === 500 && response.reason === "InternalServerError") {
+            } else if (status === 500 && response.reason === 'InternalServerError') {
               this.closeAndDestroySession();
-              let error = new VError("Error 500, stream ended unexpectedly");
+              const error = new VError('Error 500, stream ended unexpectedly');
               resolve({ device, error });
               return;
             }
@@ -229,7 +239,9 @@ module.exports = function (dependencies) {
             resolve({ device, status, response });
           } else {
             this.closeAndDestroySession();
-            let error = new VError(`stream ended unexpectedly with status ${status} and empty body`);
+            const error = new VError(
+              `stream ended unexpectedly with status ${status} and empty body`
+            );
             resolve({ device, error });
           }
         } catch (e) {
@@ -250,38 +262,40 @@ module.exports = function (dependencies) {
 
         request.close(NGHTTP2_CANCEL);
 
-        resolve({ device, error: new VError("apn write timeout") });
+        resolve({ device, error: new VError('apn write timeout') });
       });
 
-      request.on("aborted", () => {
+      request.on('aborted', () => {
         if (this.errorLogger.enabled) {
           this.errorLogger('Request aborted');
         }
 
         status = ABORTED_STATUS;
 
-        resolve({ device, error: new VError("apn write aborted") });
+        resolve({ device, error: new VError('apn write aborted') });
       });
 
-      request.on("error", (error) => {
+      request.on('error', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`Request error: ${error}`);
         }
 
         status = ERROR_STATUS;
 
-        if (typeof error === "string") {
-          error = new VError("apn write failed: %s", error);
+        if (typeof error === 'string') {
+          error = new VError('apn write failed: %s', error);
         } else {
-          error = new VError(error, "apn write failed");
+          error = new VError(error, 'apn write failed');
         }
 
         resolve({ device, error });
       });
 
       if (this.errorLogger.enabled) {
-        request.on("frameError", (frameType, errorCode, streamId) => {
-          this.errorLogger(`Request frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
+        request.on('frameError', (frameType, errorCode, streamId) => {
+          this.errorLogger(
+            `Request frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
+          );
         });
       }
 
@@ -312,12 +326,13 @@ module.exports = function (dependencies) {
       throw new Error(`Expected newLogger to be a function, got ${typeof newLogger}`);
     }
     if (newErrorLogger && typeof newErrorLogger !== 'function') {
-      throw new Error(`Expected newErrorLogger to be a function or null, got ${typeof newErrorLogger}`);
+      throw new Error(
+        `Expected newErrorLogger to be a function or null, got ${typeof newErrorLogger}`
+      );
     }
     this.logger = newLogger;
     this.errorLogger = newErrorLogger || newLogger;
   };
 
-
   return Client;
-}
+};

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,27 +1,25 @@
-"use strict";
+const extend = require('./util/extend');
 
-const extend = require("./util/extend");
-
-let EndpointAddress = {
-  production: "api.push.apple.com",
-  development: "api.sandbox.push.apple.com"
+const EndpointAddress = {
+  production: 'api.push.apple.com',
+  development: 'api.sandbox.push.apple.com',
 };
 
-module.exports = function(dependencies) {
+module.exports = function (dependencies) {
   const logger = dependencies.logger;
   const prepareCertificate = dependencies.prepareCertificate;
   const prepareToken = dependencies.prepareToken;
   const prepareCA = dependencies.prepareCA;
 
   function config(options) {
-    let config = {
+    const config = {
       token: null,
-      cert: "cert.pem",
-      key: "key.pem",
+      cert: 'cert.pem',
+      key: 'key.pem',
       ca: null,
       pfx: null,
       passphrase: null,
-      production: (process.env.NODE_ENV === "production"),
+      production: process.env.NODE_ENV === 'production',
       address: null,
       port: 443,
       proxy: null,
@@ -56,15 +54,17 @@ module.exports = function(dependencies) {
   }
 
   function validateOptions(options) {
-    for (var key in options) {
+    for (const key in options) {
       if (options[key] === null || options[key] === undefined) {
-        logger("Option [" + key + "] is " +  options[key] + ". This may cause unexpected behaviour.");
+        logger(
+          'Option [' + key + '] is ' + options[key] + '. This may cause unexpected behaviour.'
+        );
       }
     }
 
     if (options) {
-      if (options.passphrase && typeof options.passphrase !== "string") {
-        throw new Error("Passphrase must be a string");
+      if (options.passphrase && typeof options.passphrase !== 'string') {
+        throw new Error('Passphrase must be a string');
       }
 
       if (options.token) {
@@ -78,15 +78,15 @@ module.exports = function(dependencies) {
 
 function validateToken(token) {
   if (!token.keyId) {
-    throw new Error("token.keyId is missing");
-  } else if(typeof token.keyId !== "string") {
-    throw new Error("token.keyId must be a string");
+    throw new Error('token.keyId is missing');
+  } else if (typeof token.keyId !== 'string') {
+    throw new Error('token.keyId must be a string');
   }
 
   if (!token.teamId) {
-    throw new Error("token.teamId is missing");
-  } else if(typeof token.teamId !== "string") {
-    throw new Error("token.teamId must be a string");
+    throw new Error('token.teamId is missing');
+  } else if (typeof token.teamId !== 'string') {
+    throw new Error('token.teamId must be a string');
   }
 }
 
@@ -94,17 +94,14 @@ function configureAddress(options) {
   if (!options.address) {
     if (options.production) {
       options.address = EndpointAddress.production;
-    }
-    else {
+    } else {
       options.address = EndpointAddress.development;
     }
-  }
-  else {
+  } else {
     if (options.address === EndpointAddress.production) {
       options.production = true;
-    }
-    else {
+    } else {
       options.production = false;
     }
   }
-};
+}

--- a/lib/credentials/ca/prepare.js
+++ b/lib/credentials/ca/prepare.js
@@ -1,5 +1,5 @@
 module.exports = function (dependencies) {
-  const resolve = dependencies.resolve;
+  const { resolve } = dependencies;
 
   function prepareCA(credentials) {
     // Prepare Certificate Authority data if available.

--- a/lib/credentials/ca/prepare.js
+++ b/lib/credentials/ca/prepare.js
@@ -1,17 +1,15 @@
-"use strict";
-
-module.exports = function(dependencies) {
+module.exports = function (dependencies) {
   const resolve = dependencies.resolve;
 
   function prepareCA(credentials) {
     // Prepare Certificate Authority data if available.
-    var ca = [];
+    let ca = [];
 
     if (credentials.ca !== null) {
-      if(!Array.isArray(credentials.ca)) {
-        credentials.ca = [ credentials.ca ];
+      if (!Array.isArray(credentials.ca)) {
+        credentials.ca = [credentials.ca];
       }
-      ca = credentials.ca.map( resolve );
+      ca = credentials.ca.map(resolve);
     }
     if (ca.length === 0) {
       ca = undefined;

--- a/lib/credentials/certificate/APNCertificate.js
+++ b/lib/credentials/certificate/APNCertificate.js
@@ -1,32 +1,30 @@
-"use strict";
-
-const APNKey = require("./APNKey");
-const oids = require("./oids");
+const APNKey = require('./APNKey');
+const oids = require('./oids');
 
 function APNCertificate(cert) {
-  if(!cert.publicKey || !cert.validity || !cert.subject) {
-    throw new Error("certificate object is invalid");
+  if (!cert.publicKey || !cert.validity || !cert.subject) {
+    throw new Error('certificate object is invalid');
   }
 
   this._cert = cert;
 }
 
-APNCertificate.prototype.key = function() {
+APNCertificate.prototype.key = function () {
   return new APNKey(this._cert.publicKey);
 };
 
-APNCertificate.prototype.validity = function() {
+APNCertificate.prototype.validity = function () {
   return this._cert.validity;
 };
 
-APNCertificate.prototype.environment = function() {
-  let environment = { sandbox: false, production: false };
+APNCertificate.prototype.environment = function () {
+  const environment = { sandbox: false, production: false };
 
-  if (this._cert.getExtension({ "id": oids.applePushServiceClientDevelopment })) {
+  if (this._cert.getExtension({ id: oids.applePushServiceClientDevelopment })) {
     environment.sandbox = true;
   }
 
-  if (this._cert.getExtension({ "id": oids.applePushServiceClientProduction })) {
+  if (this._cert.getExtension({ id: oids.applePushServiceClientProduction })) {
     environment.production = true;
   }
   return environment;

--- a/lib/credentials/certificate/APNKey.js
+++ b/lib/credentials/certificate/APNKey.js
@@ -1,17 +1,15 @@
-"use strict";
-
-var forge = require("node-forge");
+const forge = require('node-forge');
 
 function APNKey(key) {
-  if(!key || !key.n || !key.e) {
-    throw new Error("key is not a valid public key");
+  if (!key || !key.n || !key.e) {
+    throw new Error('key is not a valid public key');
   }
 
   this._key = key;
 }
 
-APNKey.prototype.fingerprint = function() {
-  return forge.pki.getPublicKeyFingerprint(this._key, {encoding: "hex"});
+APNKey.prototype.fingerprint = function () {
+  return forge.pki.getPublicKeyFingerprint(this._key, { encoding: 'hex' });
 };
 
 module.exports = APNKey;

--- a/lib/credentials/certificate/load.js
+++ b/lib/credentials/certificate/load.js
@@ -1,18 +1,15 @@
-"use strict";
-
-module.exports = function(dependencies) {
+module.exports = function (dependencies) {
   const resolve = dependencies.resolve;
 
   function loadCredentials(credentials) {
-
     // Prepare PKCS#12 data if available
-    var pfx = resolve(credentials.pfx || credentials.pfxData);
+    const pfx = resolve(credentials.pfx || credentials.pfxData);
 
     // Prepare Certificate data if available.
-    var cert = resolve(credentials.cert || credentials.certData);
+    const cert = resolve(credentials.cert || credentials.certData);
 
     // Prepare Key data if available
-    var key = resolve(credentials.key || credentials.keyData);
+    const key = resolve(credentials.key || credentials.keyData);
 
     return { pfx: pfx, cert: cert, key: key, passphrase: credentials.passphrase };
   }

--- a/lib/credentials/certificate/load.js
+++ b/lib/credentials/certificate/load.js
@@ -1,5 +1,5 @@
 module.exports = function (dependencies) {
-  const resolve = dependencies.resolve;
+  const { resolve } = dependencies;
 
   function loadCredentials(credentials) {
     // Prepare PKCS#12 data if available
@@ -11,7 +11,7 @@ module.exports = function (dependencies) {
     // Prepare Key data if available
     const key = resolve(credentials.key || credentials.keyData);
 
-    return { pfx: pfx, cert: cert, key: key, passphrase: credentials.passphrase };
+    return { pfx, cert, key, passphrase: credentials.passphrase };
   }
 
   return loadCredentials;

--- a/lib/credentials/certificate/oids.js
+++ b/lib/credentials/certificate/oids.js
@@ -1,8 +1,6 @@
-"use strict";
-
-var oids = {
-  "applePushServiceClientDevelopment" : "1.2.840.113635.100.6.3.1",
-  "applePushServiceClientProduction"  : "1.2.840.113635.100.6.3.2",
+const oids = {
+  applePushServiceClientDevelopment: '1.2.840.113635.100.6.3.1',
+  applePushServiceClientProduction: '1.2.840.113635.100.6.3.2',
 };
 
 module.exports = oids;

--- a/lib/credentials/certificate/parse.js
+++ b/lib/credentials/certificate/parse.js
@@ -1,7 +1,5 @@
 module.exports = function (dependencies) {
-  const parsePkcs12 = dependencies.parsePkcs12;
-  const parsePemKey = dependencies.parsePemKey;
-  const parsePemCert = dependencies.parsePemCert;
+  const { parsePkcs12, parsePemKey, parsePemCert } = dependencies;
   function parse(credentials) {
     const parsed = {};
 

--- a/lib/credentials/certificate/parse.js
+++ b/lib/credentials/certificate/parse.js
@@ -1,16 +1,14 @@
-"use strict";
-
 module.exports = function (dependencies) {
   const parsePkcs12 = dependencies.parsePkcs12;
   const parsePemKey = dependencies.parsePemKey;
   const parsePemCert = dependencies.parsePemCert;
   function parse(credentials) {
-    var parsed = {};
+    const parsed = {};
 
     parsed.key = parsePemKey(credentials.key, credentials.passphrase);
     parsed.certificates = parsePemCert(credentials.cert);
 
-    var pkcs12Parsed = parsePkcs12(credentials.pfx, credentials.passphrase);
+    const pkcs12Parsed = parsePkcs12(credentials.pfx, credentials.passphrase);
     if (pkcs12Parsed) {
       parsed.key = pkcs12Parsed.key;
       parsed.certificates = pkcs12Parsed.certificates;

--- a/lib/credentials/certificate/parsePemCertificate.js
+++ b/lib/credentials/certificate/parsePemCertificate.js
@@ -18,7 +18,7 @@ function apnCertificateFromPem(certData) {
   const certificates = [];
 
   pemMessages.forEach(function (message) {
-    if (!message.type.match(new RegExp('CERTIFICATE$'))) {
+    if (!message.type.match(/CERTIFICATE$/)) {
       return;
     }
     const certAsn1 = forge.asn1.fromDer(message.body);

--- a/lib/credentials/certificate/parsePemCertificate.js
+++ b/lib/credentials/certificate/parsePemCertificate.js
@@ -1,31 +1,28 @@
-"use strict";
+const forge = require('node-forge');
 
-const forge = require("node-forge");
-
-const APNCertificate = require("./APNCertificate");
+const APNCertificate = require('./APNCertificate');
 
 function apnCertificateFromPem(certData) {
   if (!certData) {
     return null;
   }
 
-  var pemMessages;
+  let pemMessages;
   try {
     pemMessages = forge.pem.decode(certData);
-  }
-  catch (e) {
-    if (e.message.match("Invalid PEM formatted message.")) {
-      throw new Error("unable to parse certificate, not a valid PEM file");
+  } catch (e) {
+    if (e.message.match('Invalid PEM formatted message.')) {
+      throw new Error('unable to parse certificate, not a valid PEM file');
     }
   }
-  var certificates = [];
+  const certificates = [];
 
-  pemMessages.forEach(function(message) {
-    if (!message.type.match(new RegExp("CERTIFICATE$"))) {
+  pemMessages.forEach(function (message) {
+    if (!message.type.match(new RegExp('CERTIFICATE$'))) {
       return;
     }
-    var certAsn1 = forge.asn1.fromDer(message.body);
-    var forgeCertificate = forge.pki.certificateFromAsn1(certAsn1);
+    const certAsn1 = forge.asn1.fromDer(message.body);
+    const forgeCertificate = forge.pki.certificateFromAsn1(certAsn1);
 
     certificates.push(new APNCertificate(forgeCertificate));
   });

--- a/lib/credentials/certificate/parsePemKey.js
+++ b/lib/credentials/certificate/parsePemKey.js
@@ -1,27 +1,26 @@
-"use strict";
+const forge = require('node-forge');
 
-const forge = require("node-forge");
-
-const APNKey = require("./APNKey");
+const APNKey = require('./APNKey');
 
 function findAndDecryptKey(pemMessages, passphrase) {
   let apnKey = null;
-  pemMessages.forEach(function(message) {
+  pemMessages.forEach(function (message) {
     if (!message.type.match(/KEY/)) {
       return;
     }
 
-    let key = forge.pki.decryptRsaPrivateKey(forge.pem.encode(message), passphrase);
+    const key = forge.pki.decryptRsaPrivateKey(forge.pem.encode(message), passphrase);
 
-    if(!key) {
-      if ((message.procType && message.procType.type === "ENCRYPTED") || message.type.match(/ENCRYPTED/)) {
-        throw new Error("unable to parse key, incorrect passphrase");
+    if (!key) {
+      if (
+        (message.procType && message.procType.type === 'ENCRYPTED') ||
+        message.type.match(/ENCRYPTED/)
+      ) {
+        throw new Error('unable to parse key, incorrect passphrase');
       }
-    }
-    else if(apnKey) {
-      throw new Error("multiple keys found in PEM file");
-    }
-    else {
+    } else if (apnKey) {
+      throw new Error('multiple keys found in PEM file');
+    } else {
       apnKey = new APNKey(key);
     }
   });
@@ -34,27 +33,23 @@ function apnKeyFromPem(keyPem, passphrase) {
   }
 
   try {
-    let pemMessages = forge.pem.decode(keyPem);
-    let apnKey = findAndDecryptKey(pemMessages, passphrase);
+    const pemMessages = forge.pem.decode(keyPem);
+    const apnKey = findAndDecryptKey(pemMessages, passphrase);
     if (apnKey) {
       return apnKey;
     }
-  }
-  catch (e) {
+  } catch (e) {
     if (e.message.match(/Unsupported OID/)) {
-      throw new Error("unable to parse key, unsupported format: " + e.oid);
-    }
-    else if(e.message.match(/Invalid PEM formatted message/)) {
-      throw new Error("unable to parse key, not a valid PEM file");
-    }
-    else if (e.message.match(/multiple keys/)) {
+      throw new Error('unable to parse key, unsupported format: ' + e.oid);
+    } else if (e.message.match(/Invalid PEM formatted message/)) {
+      throw new Error('unable to parse key, not a valid PEM file');
+    } else if (e.message.match(/multiple keys/)) {
       throw e;
-    }
-    else if (e.message.match(/unable to parse key/)) {
+    } else if (e.message.match(/unable to parse key/)) {
       throw e;
     }
   }
-  throw new Error("unable to parse key, no private key found");
+  throw new Error('unable to parse key, no private key found');
 }
 
 module.exports = apnKeyFromPem;

--- a/lib/credentials/certificate/parsePkcs12.js
+++ b/lib/credentials/certificate/parsePkcs12.js
@@ -18,7 +18,7 @@ function decryptPkcs12FromAsn1(asn1, passphrase) {
 
 function apnCredentialsFromPkcs12(p12Data, passphrase) {
   if (!p12Data) {
-    return;
+    return undefined;
   }
 
   const asn1 = forge.asn1.fromDer(p12Data.toString('binary'), false);

--- a/lib/credentials/certificate/parsePkcs12.js
+++ b/lib/credentials/certificate/parsePkcs12.js
@@ -1,21 +1,18 @@
-"use strict";
+const forge = require('node-forge');
 
-let forge = require("node-forge");
-
-let APNKey = require("./APNKey");
-let APNCertificate = require("./APNCertificate");
+const APNKey = require('./APNKey');
+const APNCertificate = require('./APNCertificate');
 
 function decryptPkcs12FromAsn1(asn1, passphrase) {
   try {
     return forge.pkcs12.pkcs12FromAsn1(asn1, false, passphrase);
-  }
-  catch (e) {
+  } catch (e) {
     // OpenSSL-exported files need an empty string, if no password was specified
     // during export.
     if (passphrase) {
       throw e;
     }
-    return forge.pkcs12.pkcs12FromAsn1(asn1, false, "");
+    return forge.pkcs12.pkcs12FromAsn1(asn1, false, '');
   }
 }
 
@@ -24,30 +21,27 @@ function apnCredentialsFromPkcs12(p12Data, passphrase) {
     return;
   }
 
-  let asn1 = forge.asn1.fromDer(p12Data.toString("binary"), false);
+  const asn1 = forge.asn1.fromDer(p12Data.toString('binary'), false);
   let pkcs12;
   try {
     pkcs12 = decryptPkcs12FromAsn1(asn1, passphrase);
-  }
-  catch(e) {
-    if (e.message.match("Invalid password")) {
-      throw new Error("unable to parse credentials, incorrect passphrase");
-    }
-    else {
-      throw new Error("unable to parse credentials, not a PFX/P12 file");
+  } catch (e) {
+    if (e.message.match('Invalid password')) {
+      throw new Error('unable to parse credentials, incorrect passphrase');
+    } else {
+      throw new Error('unable to parse credentials, not a PFX/P12 file');
     }
   }
 
-  let credentials = { "key": null, "certificates": []};
-  pkcs12.safeContents.forEach(function(safeContents) {
-    safeContents.safeBags.forEach(function(safeBag) {
-      if(safeBag.type === forge.pki.oids.pkcs8ShroudedKeyBag) {
-        if(credentials.key) {
-          throw new Error("multiple keys found in PFX/P12 file");
+  const credentials = { key: null, certificates: [] };
+  pkcs12.safeContents.forEach(function (safeContents) {
+    safeContents.safeBags.forEach(function (safeBag) {
+      if (safeBag.type === forge.pki.oids.pkcs8ShroudedKeyBag) {
+        if (credentials.key) {
+          throw new Error('multiple keys found in PFX/P12 file');
         }
         credentials.key = new APNKey(safeBag.key);
-      }
-      else if(safeBag.type === forge.pki.oids.certBag) {
+      } else if (safeBag.type === forge.pki.oids.certBag) {
         credentials.certificates.push(new APNCertificate(safeBag.cert));
       }
     });

--- a/lib/credentials/certificate/prepare.js
+++ b/lib/credentials/certificate/prepare.js
@@ -1,6 +1,4 @@
-"use strict";
-
-module.exports = function(dependencies) {
+module.exports = function (dependencies) {
   const load = dependencies.load;
   const parse = dependencies.parse;
   const validate = dependencies.validate;
@@ -12,7 +10,7 @@ module.exports = function(dependencies) {
     let parsed;
     try {
       parsed = parse(loaded);
-    } catch(err) {
+    } catch (err) {
       logger(err);
       return loaded;
     }

--- a/lib/credentials/certificate/prepare.js
+++ b/lib/credentials/certificate/prepare.js
@@ -1,9 +1,5 @@
 module.exports = function (dependencies) {
-  const load = dependencies.load;
-  const parse = dependencies.parse;
-  const validate = dependencies.validate;
-
-  const logger = dependencies.logger;
+  const { load, parse, validate, logger } = dependencies;
 
   function loadAndValidate(credentials) {
     const loaded = load(credentials);

--- a/lib/credentials/certificate/validate.js
+++ b/lib/credentials/certificate/validate.js
@@ -1,22 +1,24 @@
-"use strict";
-
 function validateCredentials(credentials) {
-  let certificate = credentials.certificates[0];
+  const certificate = credentials.certificates[0];
 
   if (credentials.key.fingerprint() !== certificate.key().fingerprint()) {
-    throw new Error("certificate and key do not match");
+    throw new Error('certificate and key do not match');
   }
 
-  let validity = certificate.validity();
+  const validity = certificate.validity();
   if (validity.notAfter.getTime() < Date.now()) {
-    throw new Error("certificate has expired: " + validity.notAfter.toJSON());
+    throw new Error('certificate has expired: ' + validity.notAfter.toJSON());
   }
 
   if (credentials.production !== undefined) {
-    let environment = certificate.environment();
-    if ( (credentials.production && !environment.production) ||
-      (!credentials.production && !environment.sandbox)) {
-      throw new Error("certificate does not support configured environment, production: " + credentials.production);
+    const environment = certificate.environment();
+    if (
+      (credentials.production && !environment.production) ||
+      (!credentials.production && !environment.sandbox)
+    ) {
+      throw new Error(
+        'certificate does not support configured environment, production: ' + credentials.production
+      );
     }
   }
 }

--- a/lib/credentials/index.js
+++ b/lib/credentials/index.js
@@ -1,37 +1,35 @@
-"use strict";
-
 module.exports = function (dependencies) {
   const logger = dependencies.logger;
 
-  const resolve = require("./resolve");
+  const resolve = require('./resolve');
 
-  const parseCertificate = require("./certificate/parse")({
-    parsePkcs12:  require("./certificate/parsePkcs12"),
-    parsePemKey:  require("./certificate/parsePemKey"),
-    parsePemCert: require("./certificate/parsePemCertificate"),
+  const parseCertificate = require('./certificate/parse')({
+    parsePkcs12: require('./certificate/parsePkcs12'),
+    parsePemKey: require('./certificate/parsePemKey'),
+    parsePemCert: require('./certificate/parsePemCertificate'),
   });
 
-  const loadCertificate = require("./certificate/load")({
-    resolve
+  const loadCertificate = require('./certificate/load')({
+    resolve,
   });
 
-  const prepareCertificate = require("./certificate/prepare")({
+  const prepareCertificate = require('./certificate/prepare')({
     load: loadCertificate,
     parse: parseCertificate,
-    validate: require("./certificate/validate"),
+    validate: require('./certificate/validate'),
     logger: logger,
   });
 
-    const sign = require("jsonwebtoken/sign");
-    const decode = require("jsonwebtoken/decode");
+  const sign = require('jsonwebtoken/sign');
+  const decode = require('jsonwebtoken/decode');
 
-  const prepareToken = require("./token/prepare")({
+  const prepareToken = require('./token/prepare')({
     sign,
     resolve,
-    decode
+    decode,
   });
 
-  const prepareCA = require("./ca/prepare")({
+  const prepareCA = require('./ca/prepare')({
     resolve,
   });
 

--- a/lib/credentials/index.js
+++ b/lib/credentials/index.js
@@ -1,5 +1,5 @@
 module.exports = function (dependencies) {
-  const logger = dependencies.logger;
+  const { logger } = dependencies;
 
   const resolve = require('./resolve');
 
@@ -17,7 +17,7 @@ module.exports = function (dependencies) {
     load: loadCertificate,
     parse: parseCertificate,
     validate: require('./certificate/validate'),
-    logger: logger,
+    logger,
   });
 
   const sign = require('jsonwebtoken/sign');

--- a/lib/credentials/resolve.js
+++ b/lib/credentials/resolve.js
@@ -1,18 +1,14 @@
-"use strict";
-
-const fs = require("fs");
+const fs = require('fs');
 
 function resolveCredential(value) {
   if (!value) {
     return value;
   }
-  if(/-----BEGIN ([A-Z\s*]+)-----/.test(value)) {
+  if (/-----BEGIN ([A-Z\s*]+)-----/.test(value)) {
     return value;
-  }
-  else if(Buffer.isBuffer(value)) {
+  } else if (Buffer.isBuffer(value)) {
     return value;
-  }
-  else {
+  } else {
     return fs.readFileSync(value);
   }
 }

--- a/lib/credentials/token/prepare.js
+++ b/lib/credentials/token/prepare.js
@@ -1,6 +1,4 @@
-"use strict";
-
-const VError = require("verror");
+const VError = require('verror');
 
 module.exports = function (dependencies) {
   const sign = dependencies.sign;
@@ -12,14 +10,14 @@ module.exports = function (dependencies) {
     try {
       keyData = resolve(options.key);
     } catch (err) {
-      throw new VError(err, "Failed loading token key");
+      throw new VError(err, 'Failed loading token key');
     }
 
     try {
-      let token = sign.bind(null, {}, keyData, {
-        algorithm: "ES256", 
-        issuer: options.teamId, 
-        header: { kid: options.keyId }
+      const token = sign.bind(null, {}, keyData, {
+        algorithm: 'ES256',
+        issuer: options.teamId,
+        header: { kid: options.keyId },
       });
 
       return {
@@ -35,14 +33,14 @@ module.exports = function (dependencies) {
         },
         isExpired(validSeconds) {
           if (this.iat == null) {
-            let decoded = decode(this.current);
+            const decoded = decode(this.current);
             this.iat = decoded.iat;
           }
-          return (Math.floor(Date.now() / 1000) - this.iat) >= validSeconds;
-        }
+          return Math.floor(Date.now() / 1000) - this.iat >= validSeconds;
+        },
       };
     } catch (err) {
-      throw new VError(err, "Failed to generate token");
+      throw new VError(err, 'Failed to generate token');
     }
   }
 

--- a/lib/credentials/token/prepare.js
+++ b/lib/credentials/token/prepare.js
@@ -1,9 +1,7 @@
 const VError = require('verror');
 
 module.exports = function (dependencies) {
-  const sign = dependencies.sign;
-  const decode = dependencies.decode;
-  const resolve = dependencies.resolve;
+  const { sign, decode, resolve } = dependencies;
 
   function prepareToken(options) {
     let keyData;

--- a/lib/multiclient.js
+++ b/lib/multiclient.js
@@ -1,8 +1,5 @@
-const VError = require('verror');
-const extend = require('./util/extend');
-
 module.exports = function (dependencies) {
-  const Client = dependencies.Client;
+  const { Client } = dependencies;
   /**
    * This is a simple round-robin pool of http/2 clients.
    * Most use cases would not need this.

--- a/lib/multiclient.js
+++ b/lib/multiclient.js
@@ -1,7 +1,5 @@
-"use strict";
-
-const VError = require("verror");
-const extend = require("./util/extend");
+const VError = require('verror');
+const extend = require('./util/extend');
 
 module.exports = function (dependencies) {
   const Client = dependencies.Client;
@@ -16,7 +14,7 @@ module.exports = function (dependencies) {
    * This approach was chosen because it's easy to reason about compared to
    * switching to an http2 pool implementation.
    */
-  function MultiClient (options) {
+  function MultiClient(options) {
     const count = parseInt(options.clientCount || 2, 10);
     if (count < 1 || !Number.isFinite(count)) {
       throw new Error(`Expected positive client count but got ${options.clientCount}`);
@@ -33,9 +31,9 @@ module.exports = function (dependencies) {
     const client = this.clients[this.clientIndex];
     this.clientIndex = (this.clientIndex + 1) % this.clients.length;
     return client;
-  }
+  };
 
-  MultiClient.prototype.write = function write (notification, device, count) {
+  MultiClient.prototype.write = function write(notification, device, count) {
     return this.chooseSingleClient().write(notification, device, count);
   };
 
@@ -47,12 +45,12 @@ module.exports = function (dependencies) {
         callback();
       }
     };
-    this.clients.forEach((client) => client.shutdown(multiCallback));
+    this.clients.forEach(client => client.shutdown(multiCallback));
   };
 
   MultiClient.prototype.setLogger = function (newLogger, newErrorLogger = null) {
-    this.clients.forEach((client) => client.setLogger(newLogger, newErrorLogger));
+    this.clients.forEach(client => client.setLogger(newLogger, newErrorLogger));
   };
 
   return MultiClient;
-}
+};

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -1,5 +1,3 @@
-"use strict";
-
 module.exports = {
   set alert(value) {
     this.aps.alert = value;
@@ -13,10 +11,9 @@ module.exports = {
   },
 
   set body(value) {
-    if (typeof this.aps.alert !== "object") {
+    if (typeof this.aps.alert !== 'object') {
       this.aps.alert = value;
-    }
-    else {
+    } else {
       this.prepareAlert();
       this.aps.alert.body = value;
     }
@@ -24,12 +21,12 @@ module.exports = {
 
   set locKey(value) {
     this.prepareAlert();
-    this.aps.alert["loc-key"] = value;
+    this.aps.alert['loc-key'] = value;
   },
 
   set locArgs(value) {
     this.prepareAlert();
-    this.aps.alert["loc-args"] = value;
+    this.aps.alert['loc-args'] = value;
   },
 
   set title(value) {
@@ -44,12 +41,12 @@ module.exports = {
 
   set titleLocKey(value) {
     this.prepareAlert();
-    this.aps.alert["title-loc-key"] = value;
+    this.aps.alert['title-loc-key'] = value;
   },
 
   set titleLocArgs(value) {
     this.prepareAlert();
-    this.aps.alert["title-loc-args"] = value;
+    this.aps.alert['title-loc-args'] = value;
   },
 
   set action(value) {
@@ -59,44 +56,46 @@ module.exports = {
 
   set actionLocKey(value) {
     this.prepareAlert();
-    this.aps.alert["action-loc-key"] = value;
+    this.aps.alert['action-loc-key'] = value;
   },
 
   set launchImage(value) {
     this.prepareAlert();
-    this.aps.alert["launch-image"] = value;
+    this.aps.alert['launch-image'] = value;
   },
 
   set badge(value) {
-    if (typeof value === "number" || value === undefined) {
+    if (typeof value === 'number' || value === undefined) {
       this.aps.badge = value;
     }
   },
 
   set sound(value) {
-    if (typeof value === "string" || value === undefined) {
+    if (typeof value === 'string' || value === undefined) {
       this.aps.sound = value;
-    } else if (typeof value === "object"
-      && typeof value.name === "string"
-      && typeof value.critical === "number"
-      && typeof value.volume === "number") {
+    } else if (
+      typeof value === 'object' &&
+      typeof value.name === 'string' &&
+      typeof value.critical === 'number' &&
+      typeof value.volume === 'number'
+    ) {
       this.aps.sound = value;
     }
   },
 
   set contentAvailable(value) {
     if (value === true || value === 1) {
-      this.aps["content-available"] = 1;
+      this.aps['content-available'] = 1;
     } else {
-      this.aps["content-available"] = undefined;
+      this.aps['content-available'] = undefined;
     }
   },
 
   set mutableContent(value) {
     if (value === true || value === 1) {
-      this.aps["mutable-content"] = 1;
+      this.aps['mutable-content'] = 1;
     } else {
-      this.aps["mutable-content"] = undefined;
+      this.aps['mutable-content'] = undefined;
     }
   },
 
@@ -106,37 +105,37 @@ module.exports = {
 
   set urlArgs(value) {
     if (Array.isArray(value) || value === undefined) {
-      this.aps["url-args"] = value;
+      this.aps['url-args'] = value;
     }
   },
 
   set category(value) {
-    if (typeof value === "string" || value === undefined) {
+    if (typeof value === 'string' || value === undefined) {
       this.aps.category = value;
     }
   },
 
   set targetContentIdentifier(value) {
-    if(typeof value === "string" || value === undefined) {
-      this.aps["target-content-id"] = value;
+    if (typeof value === 'string' || value === undefined) {
+      this.aps['target-content-id'] = value;
     }
   },
 
   set threadId(value) {
-    if(typeof value === "string" || value === undefined) {
-      this.aps["thread-id"] = value;
+    if (typeof value === 'string' || value === undefined) {
+      this.aps['thread-id'] = value;
     }
   },
 
   set interruptionLevel(value) {
-    if(typeof value === "string" || value === undefined) {
-      this.aps["interruption-level"] = value;
+    if (typeof value === 'string' || value === undefined) {
+      this.aps['interruption-level'] = value;
     }
   },
 
   prepareAlert: function () {
-    if (typeof this.aps.alert !== "object") {
-      this.aps.alert = {"body": this.aps.alert};
+    if (typeof this.aps.alert !== 'object') {
+      this.aps.alert = { body: this.aps.alert };
     }
-  }
+  },
 };

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -12,8 +12,9 @@ function Notification(payload) {
   this.priority = 10;
 
   if (payload) {
+    /* TODO: consider using Object.entries in a separate change from introducing linting. */
     for (const key in payload) {
-      if (payload.hasOwnProperty(key)) {
+      if (Object.hasOwnProperty.call(payload, key)) {
         this[key] = payload[key];
       }
     }
@@ -109,7 +110,7 @@ Notification.prototype.length = function () {
  * @private
  */
 Notification.prototype.apsPayload = function () {
-  const aps = this.aps;
+  const { aps } = this;
 
   return Object.keys(aps).find(key => aps[key] !== undefined) ? aps : undefined;
 };
@@ -123,7 +124,7 @@ Notification.prototype.toJSON = function () {
     return { mdm: this._mdm };
   }
 
-  return Object.assign({}, this.payload, { aps: this.apsPayload() });
+  return { ...this.payload, aps: this.apsPayload() };
 };
 
 module.exports = Notification;

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -1,10 +1,9 @@
-"use strict";
 /**
  * Create a notification
  * @constructor
  */
-function Notification (payload) {
-  this.encoding = "utf8";
+function Notification(payload) {
+  this.encoding = 'utf8';
   this.payload = {};
   this.compiled = false;
 
@@ -13,7 +12,7 @@ function Notification (payload) {
   this.priority = 10;
 
   if (payload) {
-    for(let key in payload) {
+    for (const key in payload) {
       if (payload.hasOwnProperty(key)) {
         this[key] = payload[key];
       }
@@ -21,15 +20,35 @@ function Notification (payload) {
   }
 }
 
-Notification.prototype = require("./apsProperties");
+Notification.prototype = require('./apsProperties');
 
 // Create setter methods for properties
-["payload", "expiry", "priority", "alert", "body", "locKey",
-"locArgs", "title", "subtitle", "titleLocKey", "titleLocArgs", "action",
-"actionLocKey", "launchImage", "badge", "sound", "contentAvailable",
-"mutableContent", "mdm", "urlArgs", "category", "targetContentIdentifier", 
-"threadId", "interruptionLevel"].forEach( propName => {
-  const methodName = "set" + propName[0].toUpperCase() + propName.slice(1);
+[
+  'payload',
+  'expiry',
+  'priority',
+  'alert',
+  'body',
+  'locKey',
+  'locArgs',
+  'title',
+  'subtitle',
+  'titleLocKey',
+  'titleLocArgs',
+  'action',
+  'actionLocKey',
+  'launchImage',
+  'badge',
+  'sound',
+  'contentAvailable',
+  'mutableContent',
+  'mdm',
+  'urlArgs',
+  'category',
+  'threadId',
+  'interruptionLevel',
+].forEach(propName => {
+  const methodName = 'set' + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {
     this[propName] = value;
     return this;
@@ -37,30 +56,30 @@ Notification.prototype = require("./apsProperties");
 });
 
 Notification.prototype.headers = function headers() {
-  let headers = {};
+  const headers = {};
 
   if (this.priority !== 10) {
-    headers["apns-priority"] = this.priority;
+    headers['apns-priority'] = this.priority;
   }
 
   if (this.id) {
-    headers["apns-id"] = this.id;
+    headers['apns-id'] = this.id;
   }
 
   if (this.expiry >= 0) {
-    headers["apns-expiration"] = this.expiry;
+    headers['apns-expiration'] = this.expiry;
   }
 
   if (this.topic) {
-    headers["apns-topic"] = this.topic;
+    headers['apns-topic'] = this.topic;
   }
 
   if (this.collapseId) {
-    headers["apns-collapse-id"] = this.collapseId;
+    headers['apns-collapse-id'] = this.collapseId;
   }
 
   if (this.pushType) {
-    headers["apns-push-type"] = this.pushType;
+    headers['apns-push-type'] = this.pushType;
   }
 
   return headers;
@@ -72,7 +91,7 @@ Notification.prototype.headers = function headers() {
  * @since v1.3.0
  */
 Notification.prototype.compile = function () {
-  if(!this.compiled) {
+  if (!this.compiled) {
     this.compiled = JSON.stringify(this);
   }
   return this.compiled;
@@ -83,16 +102,16 @@ Notification.prototype.compile = function () {
  * @since v1.2.0
  */
 Notification.prototype.length = function () {
-  return Buffer.byteLength(this.compile(), this.encoding || "utf8");
+  return Buffer.byteLength(this.compile(), this.encoding || 'utf8');
 };
 
 /**
  * @private
  */
-Notification.prototype.apsPayload = function() {
-  var aps = this.aps;
+Notification.prototype.apsPayload = function () {
+  const aps = this.aps;
 
-  return Object.keys(aps).find( key => aps[key] !== undefined ) ? aps : undefined;
+  return Object.keys(aps).find(key => aps[key] !== undefined) ? aps : undefined;
 };
 
 Notification.prototype.toJSON = function () {
@@ -100,11 +119,11 @@ Notification.prototype.toJSON = function () {
     return this.rawPayload;
   }
 
-  if (typeof this._mdm === "string") {
-    return { "mdm": this._mdm };
+  if (typeof this._mdm === 'string') {
+    return { mdm: this._mdm };
   }
 
-  return Object.assign({}, this.payload, {aps: this.apsPayload()});
+  return Object.assign({}, this.payload, { aps: this.apsPayload() });
 };
 
 module.exports = Notification;

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,11 +1,10 @@
-"use strict";
-const EventEmitter = require("events");
+const EventEmitter = require('events');
 
-module.exports = function(dependencies) {
+module.exports = function (dependencies) {
   const Client = dependencies.Client;
 
-  function Provider (options) {
-    if(false === (this instanceof Provider)) {
+  function Provider(options) {
+    if (false === this instanceof Provider) {
       return new Provider(options);
     }
 
@@ -19,27 +18,28 @@ module.exports = function(dependencies) {
   Provider.prototype.send = function send(notification, recipients) {
     const builtNotification = {
       headers: notification.headers(),
-      body:    notification.compile(),
+      body: notification.compile(),
     };
 
     if (!Array.isArray(recipients)) {
       recipients = [recipients];
     }
 
-    return Promise.all( recipients.map( token => this.client.write(builtNotification, token) ))
-      .then( responses => {
-      let sent = [];
-      let failed = [];
+    return Promise.all(recipients.map(token => this.client.write(builtNotification, token))).then(
+      responses => {
+        const sent = [];
+        const failed = [];
 
-      responses.forEach( response => {
-        if (response.status || response.error) {
-          failed.push(response);
-        } else {
-          sent.push(response);
-        }
-      });
-      return {sent, failed};
-    });
+        responses.forEach(response => {
+          if (response.status || response.error) {
+            failed.push(response);
+          } else {
+            sent.push(response);
+          }
+        });
+        return { sent, failed };
+      }
+    );
   };
 
   Provider.prototype.shutdown = function shutdown() {

--- a/lib/token.js
+++ b/lib/token.js
@@ -1,4 +1,3 @@
-"use strict";
 /**
  * Validates a device token
  *
@@ -6,17 +5,17 @@
  */
 function token(input) {
   let token;
-  
-  if (typeof input === "string") {
+
+  if (typeof input === 'string') {
     token = input;
   } else if (Buffer.isBuffer(input)) {
-    token = input.toString("hex");
+    token = input.toString('hex');
   }
 
-  token = token.replace(/[^0-9a-f]/gi, "");
+  token = token.replace(/[^0-9a-f]/gi, '');
 
   if (token.length === 0) {
-    throw new Error("Token has invalid length");
+    throw new Error('Token has invalid length');
   }
 
   return token;

--- a/lib/util/extend.js
+++ b/lib/util/extend.js
@@ -1,4 +1,5 @@
 module.exports = function extend(target, source) {
+  /* FIXME consider using Object.entries instead - this will also include keys in the prototype if the prototype is an object with properties. Changing this may be backwards incompatible in edge cases. */
   for (const key in source) {
     if (source[key] !== undefined) {
       target[key] = source[key];

--- a/lib/util/extend.js
+++ b/lib/util/extend.js
@@ -1,7 +1,5 @@
-"use strict";
-
 module.exports = function extend(target, source) {
-  for (var key in source) {
+  for (const key in source) {
     if (source[key] !== undefined) {
       target[key] = source[key];
     }

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -1,20 +1,18 @@
-"use strict";
-
-const http = require("http");
+const http = require('http');
 
 module.exports = function createProxySocket(proxy, target) {
   return new Promise((resolve, reject) => {
     const req = http.request({
       host: proxy.host,
       port: proxy.port,
-      method: "connect",
-      path: target.host + ":" + target.port,
-      headers: { Connection: "Keep-Alive" },
+      method: 'connect',
+      path: target.host + ':' + target.port,
+      headers: { Connection: 'Keep-Alive' },
     });
-    req.on("error", reject);
-    req.on("connect", (res, socket, head) => {
+    req.on('error', reject);
+    req.on('connect', (res, socket, head) => {
       resolve(socket);
     });
     req.end();
   });
-}
+};

--- a/mock/client.js
+++ b/mock/client.js
@@ -1,10 +1,6 @@
-
-
-module.exports = function() {
-
+module.exports = function () {
   // Mocks of public API methods
-  function Client() {
-  }
+  function Client() {}
 
   Client.prototype.write = function mockWrite(notification, device) {
     return { device };
@@ -16,7 +12,9 @@ module.exports = function() {
       throw new Error(`Expected newLogger to be a function, got ${typeof newLogger}`);
     }
     if (newErrorLogger && typeof newErrorLogger !== 'function') {
-      throw new Error(`Expected newErrorLogger to be a function or null, got ${typeof newErrorLogger}`);
+      throw new Error(
+        `Expected newErrorLogger to be a function or null, got ${typeof newErrorLogger}`
+      );
     }
   };
 

--- a/mock/client.js
+++ b/mock/client.js
@@ -1,4 +1,4 @@
-"use strict";
+
 
 module.exports = function() {
 

--- a/mock/index.js
+++ b/mock/index.js
@@ -1,22 +1,20 @@
-
-
-const Client = require("./client")();
-const MultiClient = require("../lib/multiclient")({
-  Client
+const Client = require('./client')();
+const MultiClient = require('../lib/multiclient')({
+  Client,
 });
 
-const Provider = require("../lib/provider")({
+const Provider = require('../lib/provider')({
   Client,
 });
 
 // In case the code being tested relies on the provider.client.clients array existing
 // (e.g. a health check) use the real MultiClient for this mock.
-const MultiProvider = require("../lib/provider")({
+const MultiProvider = require('../lib/provider')({
   Client: MultiClient,
 });
 
-const Notification = require("../lib/notification");
-const token = require("../lib/token");
+const Notification = require('../lib/notification');
+const token = require('../lib/token');
 
 module.exports = {
   Provider,

--- a/mock/index.js
+++ b/mock/index.js
@@ -1,4 +1,4 @@
-"use strict";
+
 
 const Client = require("./client")();
 const MultiClient = require("../lib/multiclient")({

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,6 +255,72 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@eslint/eslintrc": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
+      "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.0.0",
+        "globals": "^13.9.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "globals": {
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "@humanwhocodes/config-array": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
+      "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
+      "dev": true,
+      "requires": {
+        "@humanwhocodes/object-schema": "^1.2.0",
+        "debug": "^4.1.1",
+        "minimatch": "^3.0.4"
+      }
+    },
+    "@humanwhocodes/object-schema": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -327,6 +393,18 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "acorn": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
+      "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true
+    },
     "agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -346,6 +424,18 @@
         "indent-string": "^4.0.0"
       }
     },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -353,9 +443,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -498,6 +588,12 @@
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
       }
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camelcase": {
       "version": "5.3.1",
@@ -704,6 +800,12 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "default-require-extensions": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
@@ -719,6 +821,15 @@
       "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -732,6 +843,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
     },
     "es6-error": {
       "version": "4.1.1",
@@ -751,16 +871,282 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
+      "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
+      "dev": true,
+      "requires": {
+        "@eslint/eslintrc": "^1.0.4",
+        "@humanwhocodes/config-array": "^0.6.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^6.0.0",
+        "eslint-utils": "^3.0.0",
+        "eslint-visitor-keys": "^3.0.0",
+        "espree": "^9.0.0",
+        "esquery": "^1.4.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^6.0.1",
+        "globals": "^13.6.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.2.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.1",
+        "strip-json-comments": "^3.1.0",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "glob-parent": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+          "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.3"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+              "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+              "dev": true,
+              "requires": {
+                "is-extglob": "^2.1.1"
+              }
+            }
+          }
+        },
+        "globals": {
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
+          "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
+      "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      }
+    },
+    "eslint-utils": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^2.0.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "dev": true
+    },
+    "espree": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
+      "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
+      "dev": true,
+      "requires": {
+        "acorn": "^8.5.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^3.0.0"
+      }
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
+    "esquery": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+      "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
+    },
     "extsprintf": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
       "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8="
+    },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
     },
     "fill-range": {
       "version": "7.0.1",
@@ -798,6 +1184,22 @@
       "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
       "dev": true
     },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
+      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "dev": true
+    },
     "foreground-child": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
@@ -826,6 +1228,12 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "optional": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -949,6 +1357,12 @@
         }
       }
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
     "ignore-walk": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
@@ -956,6 +1370,24 @@
       "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
+      }
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+          "dev": true
+        }
       }
     },
     "imurmurhash": {
@@ -1187,6 +1619,18 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -1253,6 +1697,16 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
+    },
     "locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -1309,6 +1763,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
     },
     "lodash.once": {
       "version": "4.1.1",
@@ -1367,6 +1827,15 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
       }
     },
     "make-dir": {
@@ -1590,6 +2059,12 @@
       "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
       "dev": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "nise": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
@@ -1695,6 +2170,20 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -1738,6 +2227,15 @@
         "hasha": "^5.0.0",
         "lodash.flattendeep": "^4.4.0",
         "release-zalgo": "^1.0.0"
+      }
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
       }
     },
     "path-exists": {
@@ -1788,6 +2286,18 @@
         "find-up": "^4.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.4.1.tgz",
+      "integrity": "sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==",
+      "dev": true
+    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -1796,6 +2306,18 @@
       "requires": {
         "fromentries": "^1.2.0"
       }
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -1814,6 +2336,12 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "regexpp": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
     },
     "release-zalgo": {
       "version": "1.0.0",
@@ -2072,6 +2600,12 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -2085,6 +2619,15 @@
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
+      }
+    },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
       }
     },
     "type-detect": {
@@ -2108,6 +2651,15 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "urlgrey": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
@@ -2118,6 +2670,12 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "dev": true
+    },
+    "v8-compile-cache": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+      "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
     },
     "verror": {
@@ -2187,6 +2745,12 @@
         }
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "workerpool": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.1.0.tgz",
@@ -2252,6 +2816,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
       "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "coverage": "node_modules/.bin/nyc --reporter=lcov node_modules/.bin/mocha",
     "lint": "npm run eslint && npm run prettier",
     "eslint": "eslint .",
-    "prettier": "prettier --write {lib,test,examples}/{**/*,*}.js index.js",
+    "prettier": "prettier --write {lib,test,examples,mock}/{**/*,*}.js index.js",
     "test": "node_modules/.bin/mocha"
   },
   "jshintConfig": {

--- a/package.json
+++ b/package.json
@@ -28,8 +28,10 @@
     "chai": "^4.3.4",
     "chai-as-promised": "7.1.1",
     "codecov": "3.8.1",
+    "eslint": "^8.2.0",
     "mocha": "^8.3.2",
     "nyc": "15.1.0",
+    "prettier": "^2.4.1",
     "sinon": "^10.0.0",
     "sinon-chai": "^3.6.0"
   },
@@ -38,6 +40,9 @@
   },
   "scripts": {
     "coverage": "node_modules/.bin/nyc --reporter=lcov node_modules/.bin/mocha",
+    "lint": "npm run eslint && npm run prettier",
+    "eslint": "eslint .",
+    "prettier": "prettier --write {lib,test,examples}/{**/*,*}.js index.js",
     "test": "node_modules/.bin/mocha"
   },
   "jshintConfig": {

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,19 @@
+module.exports = {
+  env: {
+    mocha: true,
+  },
+  globals: {
+    expect: true,
+  },
+  rules: {
+    /* unit tests will use chai expressions and construct classes to check for side effects */
+    'no-unused-expressions': 'off',
+    'no-new': 'off',
+    'no-use-before-define': 'off',
+    /* TODO: Change `=> call()` to `=> { call() }` in tests. */
+    'no-promise-executor-return': 'off',
+    /* TODO: Change `=> foo += 1` to `=> { foo += 1; }` in tests. */
+    'no-return-assign': 'off',
+    'no-console': 'off',
+  },
+};

--- a/test/client.js
+++ b/test/client.js
@@ -1,7 +1,6 @@
 const VError = require('verror');
 const net = require('net');
 const http2 = require('http2');
-const util = require('util');
 
 const debug = require('debug')('apn');
 const credentials = require('../lib/credentials')({
@@ -22,6 +21,7 @@ const Client = require('../lib/client')({
   config,
   http2,
 });
+
 debug.log = console.log.bind(console);
 
 // function builtNotification() {
@@ -408,7 +408,7 @@ describe('Client', () => {
     let didGetRequest = false;
     let establishedConnections = 0;
     server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
-      const session = stream.session;
+      const { session } = stream;
       const errorCode = 1;
       didGetRequest = true;
       session.goaway(errorCode);
@@ -445,7 +445,7 @@ describe('Client', () => {
     let responseTimeout = 0;
     server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
       setTimeout(() => {
-        const session = stream.session;
+        const { session } = stream;
         didGetRequest = true;
         if (session) {
           session.destroy();

--- a/test/client.js
+++ b/test/client.js
@@ -1,25 +1,23 @@
-"use strict";
+const VError = require('verror');
+const net = require('net');
+const http2 = require('http2');
+const util = require('util');
 
-const VError = require("verror");
-const net = require("net");
-const http2 = require("http2");
-const util = require("util");
-
-const debug = require("debug")("apn");
-const credentials = require("../lib/credentials")({
-  logger: debug
+const debug = require('debug')('apn');
+const credentials = require('../lib/credentials')({
+  logger: debug,
 });
 
 const TEST_PORT = 30939;
 const LOAD_TEST_BATCH_SIZE = 2000;
 
-const config = require("../lib/config")({
+const config = require('../lib/config')({
   logger: debug,
-  prepareCertificate: () => ({}),  // credentials.certificate,
+  prepareCertificate: () => ({}), // credentials.certificate,
   prepareToken: credentials.token,
   prepareCA: credentials.ca,
 });
-const Client = require("../lib/client")({
+const Client = require('../lib/client')({
   logger: debug,
   config,
   http2,
@@ -56,7 +54,7 @@ debug.log = console.log.bind(console);
 // and if a test case crashes, then others may get stuck.
 //
 // Try to fix this if any issues come up.
-describe("Client", () => {
+describe('Client', () => {
   let server;
   let client;
   const MOCK_BODY = '{"mock-key":"mock-value"}';
@@ -67,7 +65,7 @@ describe("Client", () => {
   // (It's probably possible to allow accepting invalid certificates instead,
   // but that's not the most important point of these tests)
   const createClient = (port, timeout = 500) => {
-    let c = new Client({
+    const c = new Client({
       port: TEST_PORT,
       address: '127.0.0.1',
     });
@@ -80,15 +78,15 @@ describe("Client", () => {
   // Create an insecure server for unit testing.
   const createAndStartMockServer = (port, cb) => {
     server = http2.createServer((req, res) => {
-      var buffers = [];
-      req.on('data', (data) => buffers.push(data));
+      const buffers = [];
+      req.on('data', data => buffers.push(data));
       req.on('end', () => {
         const requestBody = Buffer.concat(buffers).toString('utf-8');
         cb(req, res, requestBody);
       });
     });
     server.listen(port);
-    server.on('error', (err) => {
+    server.on('error', err => {
       expect.fail(`unexpected error ${err}`);
     });
     // Don't block the tests if this server doesn't shut down properly
@@ -99,7 +97,7 @@ describe("Client", () => {
     server = http2.createServer();
     server.on('stream', cb);
     server.listen(port);
-    server.on('error', (err) => {
+    server.on('error', err => {
       expect.fail(`unexpected error ${err}`);
     });
     // Don't block the tests if this server doesn't shut down properly
@@ -107,8 +105,8 @@ describe("Client", () => {
     return server;
   };
 
-  afterEach((done) => {
-    let closeServer = () => {
+  afterEach(done => {
+    const closeServer = () => {
       if (server) {
         server.close();
         server = null;
@@ -123,7 +121,7 @@ describe("Client", () => {
     }
   });
 
-  it("Treats HTTP 200 responses as successful", async () => {
+  it('Treats HTTP 200 responses as successful', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     let requestsServed = 0;
@@ -143,22 +141,19 @@ describe("Client", () => {
       requestsServed += 1;
       didRequest = true;
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
 
     const runSuccessfulRequest = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({ device: MOCK_DEVICE_TOKEN });
       expect(didRequest).to.be.true;
     };
@@ -179,7 +174,7 @@ describe("Client", () => {
   });
 
   // Assert that this doesn't crash when a large batch of requests are requested simultaneously
-  it("Treats HTTP 200 responses as successful (load test for a batch of requests)", async function () {
+  it('Treats HTTP 200 responses as successful (load test for a batch of requests)', async function () {
     this.timeout(10000);
     let establishedConnections = 0;
     let requestsServed = 0;
@@ -199,22 +194,19 @@ describe("Client", () => {
         requestsServed += 1;
       }, 100);
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT, 1500);
 
     const runSuccessfulRequest = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({ device: MOCK_DEVICE_TOKEN });
     };
     expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
@@ -231,7 +223,7 @@ describe("Client", () => {
   });
 
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
-  it("JSON decodes HTTP 400 responses", async () => {
+  it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -242,33 +234,34 @@ describe("Client", () => {
       res.end('{"reason": "BadDeviceToken"}');
       didRequest = true;
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
     const infoMessages = [];
     const errorMessages = [];
-    const mockInfoLogger = (message) => { infoMessages.push(message); };
-    const mockErrorLogger = (message) => { errorMessages.push(message); };
+    const mockInfoLogger = message => {
+      infoMessages.push(message);
+    };
+    const mockErrorLogger = message => {
+      errorMessages.push(message);
+    };
     mockInfoLogger.enabled = true;
     mockErrorLogger.enabled = true;
     client.setLogger(mockInfoLogger, mockErrorLogger);
 
     const runRequestWithBadDeviceToken = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         response: {
-          "reason": "BadDeviceToken",
+          reason: 'BadDeviceToken',
         },
         status: 400,
       });
@@ -280,15 +273,15 @@ describe("Client", () => {
     expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
     expect(infoMessages).to.deep.equal([
       'Session connected',
-      "Request ended with status 400 and responseData: {\"reason\": \"BadDeviceToken\"}",
-      "Request ended with status 400 and responseData: {\"reason\": \"BadDeviceToken\"}",
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
 
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
-  it("Closes connections when HTTP 500 responses are received", async () => {
+  it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     let responseDelay = 50;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -299,22 +292,19 @@ describe("Client", () => {
         res.end('{"reason": "InternalServerError"}');
       }, responseDelay);
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.exist;
       expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
       expect(result.error).to.be.an.instanceof(VError);
@@ -336,9 +326,9 @@ describe("Client", () => {
     expect(establishedConnections).to.equal(4); // should close and establish new connections on http 500
   });
 
-  it("Handles unexpected invalid JSON responses", async () => {
+  it('Handles unexpected invalid JSON responses', async () => {
     let establishedConnections = 0;
-    let responseDelay = 0;
+    const responseDelay = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
       // Wait 50ms before sending the responses in parallel
       setTimeout(() => {
@@ -347,32 +337,31 @@ describe("Client", () => {
         res.end('PC LOAD LETTER');
       }, responseDelay);
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       // Should not happen, but if it does, the promise should resolve with an error
       expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
-      expect(result.error.message).to.equal('Unexpected error processing APNs response: Unexpected token P in JSON at position 0');
+      expect(result.error.message).to.equal(
+        'Unexpected error processing APNs response: Unexpected token P in JSON at position 0'
+      );
     };
     await runRequestWithInternalServerError();
     await runRequestWithInternalServerError();
     expect(establishedConnections).to.equal(1); // Currently reuses the connection.
   });
 
-  it("Handles APNs timeouts", async () => {
+  it('Handles APNs timeouts', async () => {
     let didGetRequest = false;
     let didGetResponse = false;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -385,20 +374,17 @@ describe("Client", () => {
     });
     client = createClient(TEST_PORT);
 
-    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
 
-    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
     const mockNotification = {
       headers: mockHeaders,
       body: MOCK_BODY,
     };
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingTimeout = async () => {
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         error: new VError('apn write timeout'),
@@ -418,32 +404,29 @@ describe("Client", () => {
     ]);
   });
 
-  it("Handles goaway frames", async () => {
+  it('Handles goaway frames', async () => {
     let didGetRequest = false;
     let establishedConnections = 0;
-    server = createAndStartMockLowLevelServer(TEST_PORT, (stream) => {
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
       const session = stream.session;
       const errorCode = 1;
       didGetRequest = true;
       session.goaway(errorCode);
     });
-    server.on('connection', () => establishedConnections += 1);
+    server.on('connection', () => (establishedConnections += 1));
     client = createClient(TEST_PORT);
 
-    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
 
-    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
     const mockNotification = {
       headers: mockHeaders,
       body: MOCK_BODY,
     };
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingGoAway = async () => {
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         error: new VError('stream ended unexpectedly with status null and empty body'),
@@ -456,11 +439,11 @@ describe("Client", () => {
     expect(establishedConnections).to.equal(2);
   });
 
-  it("Handles unexpected protocol errors (no response sent)", async () => {
+  it('Handles unexpected protocol errors (no response sent)', async () => {
     let didGetRequest = false;
     let establishedConnections = 0;
     let responseTimeout = 0;
-    server = createAndStartMockLowLevelServer(TEST_PORT, (stream) => {
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
       setTimeout(() => {
         const session = stream.session;
         didGetRequest = true;
@@ -469,23 +452,20 @@ describe("Client", () => {
         }
       }, responseTimeout);
     });
-    server.on('connection', () => establishedConnections += 1);
+    server.on('connection', () => (establishedConnections += 1));
     client = createClient(TEST_PORT);
 
-    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
 
-    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
     const mockNotification = {
       headers: mockHeaders,
       body: MOCK_BODY,
     };
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingDisconnect = async () => {
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         error: new VError('stream ended unexpectedly with status null and empty body'),
@@ -507,7 +487,7 @@ describe("Client", () => {
     expect(establishedConnections).to.equal(3);
   });
 
-  it("Establishes a connection through a proxy server", async () => {
+  it('Establishes a connection through a proxy server', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     let requestsServed = 0;
@@ -527,11 +507,11 @@ describe("Client", () => {
       requestsServed += 1;
       didRequest = true;
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.once('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.once('listening', resolve));
 
     // Proxy forwards all connections to TEST_PORT
-    const proxy = net.createServer((clientSocket) => {
+    const proxy = net.createServer(clientSocket => {
       clientSocket.once('data', () => {
         const serverSocket = net.createConnection(TEST_PORT, () => {
           clientSocket.write('HTTP/1.1 200 OK\r\n\r\n');
@@ -542,23 +522,20 @@ describe("Client", () => {
         });
       });
     });
-    await new Promise((resolve) => proxy.listen(3128, resolve));
-    
+    await new Promise(resolve => proxy.listen(3128, resolve));
+
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT + 1);
     // So without adding a proxy config request will fail with a network error
-    client.config.proxy = { host: "127.0.0.1", port: 3128 }
+    client.config.proxy = { host: '127.0.0.1', port: 3128 };
     const runSuccessfulRequest = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({ device: MOCK_DEVICE_TOKEN });
       expect(didRequest).to.be.true;
     };
@@ -578,7 +555,7 @@ describe("Client", () => {
     expect(requestsServed).to.equal(6);
 
     proxy.close();
-  })
+  });
 
   // let fakes, Client;
 
@@ -621,34 +598,27 @@ describe("Client", () => {
   //   });
   // });
 
-  describe("write", () => {
+  describe('write', () => {
     // beforeEach(() => {
     //   fakes.config.returnsArg(0);
     //   fakes.endpointManager.getStream = sinon.stub();
-
     //   fakes.EndpointManager.returns(fakes.endpointManager);
     // });
-
     // context("a stream is available", () => {
     //   let client;
-
     //   context("transmission succeeds", () => {
     //     beforeEach( () => {
     //       client = new Client( { address: "testapi" } );
-
     //       fakes.stream = new FakeStream("abcd1234", "200");
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //     });
-
     //     it("attempts to acquire one stream", () => {
     //       return client.write(builtNotification(), "abcd1234")
     //         .then(() => {
     //           expect(fakes.endpointManager.getStream).to.be.calledOnce;
     //         });
     //     });
-
     //     describe("headers", () => {
-
     //       it("sends the required HTTP/2 headers", () => {
     //         return client.write(builtNotification(), "abcd1234")
     //           .then(() => {
@@ -660,7 +630,6 @@ describe("Client", () => {
     //             });
     //           });
     //       });
-
     //       it("does not include apns headers when not required", () => {
     //         return client.write(builtNotification(), "abcd1234")
     //           .then(() => {
@@ -669,17 +638,14 @@ describe("Client", () => {
     //             });
     //           });
     //       });
-
     //       it("sends the notification-specific apns headers when specified", () => {
     //         let notification = builtNotification();
-
     //         notification.headers = {
     //           "apns-id": "123e4567-e89b-12d3-a456-42665544000",
     //           "apns-priority": 5,
     //           "apns-expiration": 123,
     //           "apns-topic": "io.apn.node",
     //         };
-
     //         return client.write(notification, "abcd1234")
     //           .then(() => {
     //             expect(fakes.stream.headers).to.be.calledWithMatch( {
@@ -690,7 +656,6 @@ describe("Client", () => {
     //             });
     //           });
     //       });
-
     //       context("when token authentication is enabled", () => {
     //         beforeEach(() => {
     //           fakes.token = {
@@ -699,16 +664,12 @@ describe("Client", () => {
     //             regenerate: sinon.stub(),
     //             isExpired: sinon.stub()
     //           };
-
     //           client = new Client( { address: "testapi", token: fakes.token } );
-
     //           fakes.stream = new FakeStream("abcd1234", "200");
     //           fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //         });
-
     //         it("sends the bearer token", () => {
     //           let notification = builtNotification();
-
     //           return client.write(notification, "abcd1234").then(() => {
     //             expect(fakes.stream.headers).to.be.calledWithMatch({
     //               authorization: "bearer fake-token",
@@ -716,25 +677,20 @@ describe("Client", () => {
     //           });
     //         });
     //       });
-
     //       context("when token authentication is disabled", () => {
     //         beforeEach(() => {
     //           client = new Client( { address: "testapi" } );
-
     //           fakes.stream = new FakeStream("abcd1234", "200");
     //           fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //         });
-
     //         it("does not set an authorization header", () => {
     //           let notification = builtNotification();
-
     //           return client.write(notification, "abcd1234").then(() => {
     //             expect(fakes.stream.headers.firstCall.args[0]).to.not.have.property("authorization");
     //           })
     //         });
     //       })
     //     });
-
     //     it("writes the notification data to the pipe", () => {
     //       const notification = builtNotification();
     //       return client.write(notification, "abcd1234")
@@ -742,7 +698,6 @@ describe("Client", () => {
     //           expect(fakes.stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(notification.body)));
     //         });
     //     });
-
     //     it("ends the stream", () => {
     //       sinon.spy(fakes.stream, "end");
     //       return client.write(builtNotification(), "abcd1234")
@@ -750,31 +705,24 @@ describe("Client", () => {
     //           expect(fakes.stream.end).to.be.calledOnce;
     //         });
     //     });
-
     //     it("resolves with the device token", () => {
     //       return expect(client.write(builtNotification(), "abcd1234"))
     //         .to.become({ device: "abcd1234" });
     //     });
     //   });
-
     //   context("error occurs", () => {
     //     let promise;
-
     //     context("general case", () => {
     //       beforeEach(() => {
     //         const client = new Client( { address: "testapi" } );
-
     //         fakes.stream = new FakeStream("abcd1234", "400", { "reason" : "BadDeviceToken" });
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //         promise = client.write(builtNotification(), "abcd1234");
     //       });
-
     //       it("resolves with the device token, status code and response", () => {
     //         return expect(promise).to.eventually.deep.equal({ status: "400", device: "abcd1234", response: { reason: "BadDeviceToken" }});
     //       });
     //     })
-
     //     context("ExpiredProviderToken", () => {
     //       beforeEach(() => {
     //         let tokenGenerator = sinon.stub().returns("fake-token");
@@ -782,28 +730,21 @@ describe("Client", () => {
     //       })
     //     });
     //   });
-
     //   context("stream ends without completing request", () => {
     //     let promise;
-
     //     beforeEach(() => {
     //       const client = new Client( { address: "testapi" } );
     //       fakes.stream = new stream.Transform({
     //         transform: function(chunk, encoding, callback) {}
     //       });
     //       fakes.stream.headers = sinon.stub();
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       promise = client.write(builtNotification(), "abcd1234");
-
     //       fakes.stream.push(null);
     //     });
-
     //     it("resolves with an object containing the device token", () => {
     //       return expect(promise).to.eventually.have.property("device", "abcd1234");
     //     });
-
     //     it("resolves with an object containing an error", () => {
     //       return promise.then( (response) => {
     //         expect(response).to.have.property("error");
@@ -812,65 +753,50 @@ describe("Client", () => {
     //       });
     //     });
     //   });
-
     //   context("stream is unprocessed", () => {
     //     let promise;
-
     //     beforeEach(() => {
     //       const client = new Client( { address: "testapi" } );
     //       fakes.stream = new stream.Transform({
     //         transform: function(chunk, encoding, callback) {}
     //       });
     //       fakes.stream.headers = sinon.stub();
-
     //       fakes.secondStream = FakeStream("abcd1234", "200");
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.secondStream);
-
     //       promise = client.write(builtNotification(), "abcd1234");
-
     //       setImmediate(() => {
     //         fakes.stream.emit("unprocessed");
     //       });
     //     });
-
     //     it("attempts to resend on a new stream", function (done) {
     //       setImmediate(() => {
     //         expect(fakes.endpointManager.getStream).to.be.calledTwice;
     //         done();
     //       });
     //     });
-
     //     it("fulfills the promise", () => {
     //       return expect(promise).to.eventually.deep.equal({ device: "abcd1234"  });
     //     });
     //   });
-
     //   context("stream error occurs", () => {
     //     let promise;
-
     //     beforeEach(() => {
     //       const client = new Client( { address: "testapi" } );
     //       fakes.stream = new stream.Transform({
     //         transform: function(chunk, encoding, callback) {}
     //       });
     //       fakes.stream.headers = sinon.stub();
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       promise = client.write(builtNotification(), "abcd1234");
     //     });
-
     //     context("passing an Error", () => {
     //       beforeEach(() => {
     //         fakes.stream.emit("error", new Error("stream error"));
     //       });
-
     //       it("resolves with an object containing the device token", () => {
     //         return expect(promise).to.eventually.have.property("device", "abcd1234");
     //       });
-
     //       it("resolves with an object containing a wrapped error", () => {
     //         return promise.then( (response) => {
     //           expect(response.error).to.be.an.instanceOf(Error);
@@ -879,7 +805,6 @@ describe("Client", () => {
     //         });
     //       });
     //     });
-
     //     context("passing a string", () => {
     //       it("resolves with the device token and an error", () => {
     //         fakes.stream.emit("error", "stream error");
@@ -893,27 +818,19 @@ describe("Client", () => {
     //     });
     //   });
     // });
-
     // context("no new stream is returned but the endpoint later wakes up", () => {
     //   let notification, promise;
-
     //   beforeEach( () => {
     //     const client = new Client( { address: "testapi" } );
-
     //     fakes.stream = new FakeStream("abcd1234", "200");
     //     fakes.endpointManager.getStream.onCall(0).returns(null);
     //     fakes.endpointManager.getStream.onCall(1).returns(fakes.stream);
-
     //     notification = builtNotification();
     //     promise = client.write(notification, "abcd1234");
-
     //     expect(fakes.stream.headers).to.not.be.called;
-
     //     fakes.endpointManager.emit("wakeup");
-
     //     return promise;
     //   });
-
     //   it("sends the required headers to the newly available stream", () => {
     //     expect(fakes.stream.headers).to.be.calledWithMatch( {
     //       ":scheme": "https",
@@ -922,14 +839,11 @@ describe("Client", () => {
     //       ":path": "/3/device/abcd1234",
     //     });
     //   });
-
     //   it("writes the notification data to the pipe", () => {
     //     expect(fakes.stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(notification.body)));
     //   });
     // });
-
     // context("when 5 successive notifications are sent", () => {
-
     //   beforeEach(() => {
     //       fakes.streams = [
     //         new FakeStream("abcd1234", "200"),
@@ -939,19 +853,15 @@ describe("Client", () => {
     //         new FakeStream("aabbc788", "413", { reason: "PayloadTooLarge" }),
     //       ];
     //   });
-
     //   context("streams are always returned", () => {
     //     let promises;
-
     //     beforeEach( () => {
     //       const client = new Client( { address: "testapi" } );
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
     //       fakes.endpointManager.getStream.onCall(3).returns(fakes.streams[3]);
     //       fakes.endpointManager.getStream.onCall(4).returns(fakes.streams[4]);
-
     //       promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
@@ -959,10 +869,8 @@ describe("Client", () => {
     //         client.write(builtNotification(), "bcfe4433"),
     //         client.write(builtNotification(), "aabbc788"),
     //       ]);
-
     //       return promises;
     //     });
-
     //     it("sends the required headers for each stream", () => {
     //       expect(fakes.streams[0].headers).to.be.calledWithMatch( { ":path": "/3/device/abcd1234" } );
     //       expect(fakes.streams[1].headers).to.be.calledWithMatch( { ":path": "/3/device/adfe5969" } );
@@ -970,13 +878,11 @@ describe("Client", () => {
     //       expect(fakes.streams[3].headers).to.be.calledWithMatch( { ":path": "/3/device/bcfe4433" } );
     //       expect(fakes.streams[4].headers).to.be.calledWithMatch( { ":path": "/3/device/aabbc788" } );
     //     });
-
     //     it("writes the notification data for each stream", () => {
     //       fakes.streams.forEach( stream => {
     //         expect(stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(builtNotification().body)));
     //       });
     //     });
-
     //     it("resolves with the notification outcomes", () => {
     //       return expect(promises).to.eventually.deep.equal([
     //           { device: "abcd1234"},
@@ -987,16 +893,12 @@ describe("Client", () => {
     //       ]);
     //     });
     //   });
-
     //   context("some streams return, others wake up later", () => {
     //     let promises;
-
     //     beforeEach( function() {
     //       const client = new Client( { address: "testapi" } );
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
-
     //       promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
@@ -1004,24 +906,20 @@ describe("Client", () => {
     //         client.write(builtNotification(), "bcfe4433"),
     //         client.write(builtNotification(), "aabbc788"),
     //       ]);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[2]);
     //         fakes.endpointManager.getStream.onCall(1).returns(null);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 1);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
     //         fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 2);
-
     //       return promises;
     //     });
-
     //     it("sends the correct device ID for each stream", () => {
     //       expect(fakes.streams[0].headers).to.be.calledWithMatch({":path": "/3/device/abcd1234"});
     //       expect(fakes.streams[1].headers).to.be.calledWithMatch({":path": "/3/device/adfe5969"});
@@ -1029,13 +927,11 @@ describe("Client", () => {
     //       expect(fakes.streams[3].headers).to.be.calledWithMatch({":path": "/3/device/bcfe4433"});
     //       expect(fakes.streams[4].headers).to.be.calledWithMatch({":path": "/3/device/aabbc788"});
     //     });
-
     //     it("writes the notification data for each stream", () => {
     //       fakes.streams.forEach( stream => {
     //         expect(stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(builtNotification().body)));
     //       });
     //     });
-
     //     it("resolves with the notification reponses", () => {
     //       return expect(promises).to.eventually.deep.equal([
     //           { device: "abcd1234"},
@@ -1046,51 +942,40 @@ describe("Client", () => {
     //       ]);
     //     });
     //   });
-
     //   context("connection fails", () => {
     //     let promises, client;
-
     //     beforeEach( function() {
     //       client = new Client( { address: "testapi" } );
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
-
     //       promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
     //         client.write(builtNotification(), "abcd1335"),
     //       ]);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.emit("error", new Error("endpoint failed"));
     //       }, 1);
-
     //       return promises;
     //     });
-
     //     it("resolves with 1 success", () => {
     //       return promises.then( response => {
     //         expect(response[0]).to.deep.equal({ device: "abcd1234" });
     //       });
     //     });
-
     //     it("resolves with 2 errors", () => {
     //       return promises.then( response => {
     //         expect(response[1]).to.deep.equal({ device: "adfe5969", error: new Error("endpoint failed") });
     //         expect(response[2]).to.deep.equal({ device: "abcd1335", error: new Error("endpoint failed") });
     //       })
     //     });
-
     //     it("clears the queue", () => {
     //       return promises.then( () => {
     //         expect(client.queue.length).to.equal(0);
     //       });
     //     });
     //   });
-
     // });
-
     // describe("token generator behaviour", () => {
     //   beforeEach(() => {
     //     fakes.token = {
@@ -1099,26 +984,21 @@ describe("Client", () => {
     //       regenerate: sinon.stub(),
     //       isExpired: sinon.stub()
     //     }
-
     //     fakes.streams = [
     //       new FakeStream("abcd1234", "200"),
     //       new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
     //       new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
     //     ];
     //   });
-
     //   it("reuses the token", () => {
     //     const client = new Client( { address: "testapi", token: fakes.token } );
-
     //     fakes.token.regenerate = () => {
     //       fakes.token.generation = 1;
     //       fakes.token.current = "second-token";
     //     }
-
     //     fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //     fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //     fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
-
     //     return Promise.all([
     //       client.write(builtNotification(), "abcd1234"),
     //       client.write(builtNotification(), "adfe5969"),
@@ -1129,9 +1009,7 @@ describe("Client", () => {
     //       expect(fakes.streams[2].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
     //     });
     //   });
-
     //   context("token expires", () => {
-
     //     beforeEach(() => {
     //       fakes.token.regenerate = function (generation) {
     //         if (generation === fakes.token.generation) {
@@ -1140,31 +1018,24 @@ describe("Client", () => {
     //         }
     //       }
     //     });
-
     //     it("resends the notification with a new token", () => {
     //       fakes.streams = [
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //         new FakeStream("adfe5969", "200"),
     //       ];
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
-
     //       const client = new Client( { address: "testapi", token: fakes.token } );
-
     //       const promise = client.write(builtNotification(), "adfe5969");
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[1]);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 1);
-
     //       return promise.then(() => {
     //         expect(fakes.streams[0].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
     //         expect(fakes.streams[1].headers).to.be.calledWithMatch({ authorization: "bearer token-1" });
     //       });
     //     });
-
     //     it("only regenerates the token once per-expiry", () => {
     //       fakes.streams = [
     //         new FakeStream("abcd1234", "200"),
@@ -1173,26 +1044,21 @@ describe("Client", () => {
     //         new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
     //         new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
     //       ];
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
-
     //       const client = new Client( { address: "testapi", token: fakes.token } );
-
     //       const promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
     //         client.write(builtNotification(), "abcd1335"),
     //       ]);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
     //         fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 1);
-
     //       return promises.then(() => {
     //         expect(fakes.streams[0].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
     //         expect(fakes.streams[1].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
@@ -1201,80 +1067,64 @@ describe("Client", () => {
     //         expect(fakes.streams[4].headers).to.be.calledWithMatch({ authorization: "bearer token-1" });
     //       });
     //     });
-
     //     it("abandons sending after 3 ExpiredProviderToken failures", () => {
     //       fakes.streams = [
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //       ];
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
-
     //       const client = new Client( { address: "testapi", token: fakes.token } );
-
     //       return expect(client.write(builtNotification(), "adfe5969")).to.eventually.have.property("status", "403");
     //     });
-
     //     it("regenerate token", () => {
     //       fakes.stream = new FakeStream("abcd1234", "200");
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       fakes.token.isExpired = function (current, validSeconds) {
     //         return true;
     //       }
-
     //       let client = new Client({
     //         address: "testapi",
     //         token: fakes.token
     //       });
-
     //       return client.write(builtNotification(), "abcd1234")
     //         .then(() => {
     //           expect(fakes.token.generation).to.equal(1);
     //         });
     //     });
-
     //     it("internal server error", () => {
     //       fakes.stream = new FakeStream("abcd1234", "500", { reason: "InternalServerError" });
     //       fakes.stream.connection = sinon.stub();
     //       fakes.stream.connection.close = sinon.stub();
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       let client = new Client({
     //         address: "testapi",
     //         token: fakes.token
     //       });
-
     //       return expect(client.write(builtNotification(), "abcd1234")).to.eventually.have.deep.property("error.jse_shortmsg","Error 500, stream ended unexpectedly");
     //     });
     //   });
     // });
   });
 
-  describe("shutdown", () => {
+  describe('shutdown', () => {
     // beforeEach(() => {
     //   fakes.config.returnsArg(0);
     //   fakes.endpointManager.getStream = sinon.stub();
-
     //   fakes.EndpointManager.returns(fakes.endpointManager);
     // });
-
     // context("with no pending notifications", () => {
     //   it("invokes shutdown on endpoint manager", () => {
     //     let client = new Client();
     //     client.shutdown();
-
     //     expect(fakes.endpointManager.shutdown).to.be.calledOnce;
     //   });
     // });
-
     // context("with pending notifications", () => {
     //   it("invokes shutdown on endpoint manager after queue drains", () => {
     //     let client = new Client({ address: "none" });
-
     //     fakes.streams = [
     //       new FakeStream("abcd1234", "200"),
     //       new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
@@ -1282,10 +1132,8 @@ describe("Client", () => {
     //       new FakeStream("bcfe4433", "200"),
     //       new FakeStream("aabbc788", "413", { reason: "PayloadTooLarge" }),
     //     ];
-
     //     fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //     fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
-
     //     let promises = Promise.all([
     //       client.write(builtNotification(), "abcd1234"),
     //       client.write(builtNotification(), "adfe5969"),
@@ -1293,25 +1141,20 @@ describe("Client", () => {
     //       client.write(builtNotification(), "bcfe4433"),
     //       client.write(builtNotification(), "aabbc788"),
     //     ]);
-
     //     client.shutdown();
-
     //     expect(fakes.endpointManager.shutdown).to.not.be.called;
-
     //     setTimeout(() => {
     //       fakes.endpointManager.getStream.reset();
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[2]);
     //       fakes.endpointManager.getStream.onCall(1).returns(null);
     //       fakes.endpointManager.emit("wakeup");
     //     }, 1);
-
     //     setTimeout(() => {
     //       fakes.endpointManager.getStream.reset();
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
     //       fakes.endpointManager.emit("wakeup");
     //     }, 2);
-
     //     return promises.then( () => {
     //       expect(fakes.endpointManager.shutdown).to.have.been.called;
     //     });

--- a/test/config.js
+++ b/test/config.js
@@ -1,11 +1,9 @@
-"use strict";
+const sinon = require('sinon');
 
-const sinon = require("sinon");
-
-describe("config", function () {
+describe('config', function () {
   let config, fakes;
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakes = {
       logger: sinon.spy(),
       prepareCertificate: sinon.stub(),
@@ -13,19 +11,19 @@ describe("config", function () {
       prepareCA: sinon.stub(),
     };
 
-    config = require("../lib/config")(fakes);
+    config = require('../lib/config')(fakes);
   });
 
-  it("supplies sensible defaults", function () {
+  it('supplies sensible defaults', function () {
     expect(config()).to.deep.equal({
       token: null,
-      cert: "cert.pem",
-      key: "key.pem",
+      cert: 'cert.pem',
+      key: 'key.pem',
       ca: null,
       pfx: null,
       passphrase: null,
       production: false,
-      address: "api.sandbox.push.apple.com",
+      address: 'api.sandbox.push.apple.com',
       port: 443,
       proxy: null,
       rejectUnauthorized: true,
@@ -35,222 +33,250 @@ describe("config", function () {
     });
   });
 
-  describe("address configuration", function () {
+  describe('address configuration', function () {
     let originalEnv;
 
-    before(function() {
+    before(function () {
       originalEnv = process.env.NODE_ENV;
     });
 
-    after(function() {
+    after(function () {
       process.env.NODE_ENV = originalEnv;
     });
 
-    beforeEach(function() {
-      process.env.NODE_ENV = "";
+    beforeEach(function () {
+      process.env.NODE_ENV = '';
     });
 
-    it("should use api.sandbox.push.apple.com as the default connection address", function () {
-      expect(config()).to.have.property("address", "api.sandbox.push.apple.com");
+    it('should use api.sandbox.push.apple.com as the default connection address', function () {
+      expect(config()).to.have.property('address', 'api.sandbox.push.apple.com');
     });
 
-    it("should use api.push.apple.com when NODE_ENV=production", function () {
-      process.env.NODE_ENV = "production";
-      expect(config()).to.have.property("address", "api.push.apple.com");
+    it('should use api.push.apple.com when NODE_ENV=production', function () {
+      process.env.NODE_ENV = 'production';
+      expect(config()).to.have.property('address', 'api.push.apple.com');
     });
 
-    it("should give precedence to production flag over NODE_ENV=production", function () {
-      process.env.NODE_ENV = "production";
-      expect(config({ production: false })).to.have.property("address", "api.sandbox.push.apple.com");
+    it('should give precedence to production flag over NODE_ENV=production', function () {
+      process.env.NODE_ENV = 'production';
+      expect(config({ production: false })).to.have.property(
+        'address',
+        'api.sandbox.push.apple.com'
+      );
     });
 
-    it("should use api.push.apple.com when production:true", function () {
-      expect(config({production:true})).to.have.property("address", "api.push.apple.com");
+    it('should use api.push.apple.com when production:true', function () {
+      expect(config({ production: true })).to.have.property('address', 'api.push.apple.com');
     });
 
-    it("should use a custom address when passed", function () {
-      expect(config({address: "testaddress"})).to.have.property("address", "testaddress");
+    it('should use a custom address when passed', function () {
+      expect(config({ address: 'testaddress' })).to.have.property('address', 'testaddress');
     });
 
-    describe("address is passed", function() {
-      it("sets production to true when using production address", function() {
-        expect(config({address: "api.push.apple.com"})).to.have.property("production", true);
+    describe('address is passed', function () {
+      it('sets production to true when using production address', function () {
+        expect(config({ address: 'api.push.apple.com' })).to.have.property('production', true);
       });
 
-      it("sets production to false when using sandbox address", function() {
-        process.env.NODE_ENV = "production";
-        expect(config({address: "api.sandbox.push.apple.com"})).to.have.property("production", false);
+      it('sets production to false when using sandbox address', function () {
+        process.env.NODE_ENV = 'production';
+        expect(config({ address: 'api.sandbox.push.apple.com' })).to.have.property(
+          'production',
+          false
+        );
       });
     });
   });
 
-  describe("credentials", function () {
-
-    context("`token` not supplied, use certificate", function () {
-      describe("passphrase", function () {
-        it("throws an error when supplied passphrase is not a string", function () {
-          expect(() => config({ passphrase: 123 }) ).to.throw("Passphrase must be a string");
+  describe('credentials', function () {
+    context('`token` not supplied, use certificate', function () {
+      describe('passphrase', function () {
+        it('throws an error when supplied passphrase is not a string', function () {
+          expect(() => config({ passphrase: 123 })).to.throw('Passphrase must be a string');
         });
 
-        it("does not throw when passphrase is a string", function () {
-          expect(() => config({ passphrase: "seekrit" }) ).to.not.throw();
+        it('does not throw when passphrase is a string', function () {
+          expect(() => config({ passphrase: 'seekrit' })).to.not.throw();
         });
 
-        it("does not throw when passphrase is not supplied", function () {
-          expect(() => config({ }) ).to.not.throw();
-        });
-      });
-
-      context("pfx value is supplied without cert and key", function () {
-        it("includes the value of `pfx`", function () {
-          expect(config( { pfx: "apn.pfx" } )).to.have.property("pfx", "apn.pfx");
-        });
-
-        it("does not include a value for `cert`", function () {
-          expect(config( { pfx: "apn.pfx" }).cert).to.be.undefined;
-        });
-
-        it("does not include a value for `key`", function () {
-          expect(config( { pfx: "apn.pfx" }).key).to.be.undefined;
+        it('does not throw when passphrase is not supplied', function () {
+          expect(() => config({})).to.not.throw();
         });
       });
 
-      context("pfx value is supplied along with a cert and key", function () {
-        it("includes the value of `pfx`", function () {
-          expect(config( { pfx: "apn.pfx", cert: "cert.pem", key: "key.pem" } )).to.have.property("pfx", "apn.pfx");
+      context('pfx value is supplied without cert and key', function () {
+        it('includes the value of `pfx`', function () {
+          expect(config({ pfx: 'apn.pfx' })).to.have.property('pfx', 'apn.pfx');
         });
 
-        it("does not include a value for `cert`", function () {
-          expect(config( { pfx: "apn.pfx", cert: "cert.pem", key: "key.pem" })).to.have.property("cert", "cert.pem");
+        it('does not include a value for `cert`', function () {
+          expect(config({ pfx: 'apn.pfx' }).cert).to.be.undefined;
         });
 
-        it("does not include a value for `key`", function () {
-          expect(config( { pfx: "apn.pfx", cert: "cert.pem", key: "key.pem" })).to.have.property("key", "key.pem");
-        });
-      });
-
-      context("pfxData value is supplied without cert and key", function () {
-        it("includes the value of `pfxData`", function () {
-          expect(config( { pfxData: "apnData" } )).to.have.property("pfxData", "apnData");
-        });
-
-        it("does not include a value for `cert`", function () {
-          expect(config( { pfxData: "apnData" } ).cert).to.be.undefined;
-        });
-
-        it("does not include a value for `key`", function () {
-          expect(config( { pfxData: "apnData" }).key).to.be.undefined;
+        it('does not include a value for `key`', function () {
+          expect(config({ pfx: 'apn.pfx' }).key).to.be.undefined;
         });
       });
 
-      context("pfxData value is supplied along with a cert and key", function () {
-        it("includes the value of `pfxData`", function () {
-          expect(config( { pfxData: "apnData", cert: "cert.pem", key: "key.pem" } )).to.have.property("pfxData", "apnData");
+      context('pfx value is supplied along with a cert and key', function () {
+        it('includes the value of `pfx`', function () {
+          expect(config({ pfx: 'apn.pfx', cert: 'cert.pem', key: 'key.pem' })).to.have.property(
+            'pfx',
+            'apn.pfx'
+          );
         });
 
-        it("does not include a value for `cert`", function () {
-          expect(config( { pfxData: "apnData", cert: "cert.pem", key: "key.pem" })).to.have.property("cert", "cert.pem");
+        it('does not include a value for `cert`', function () {
+          expect(config({ pfx: 'apn.pfx', cert: 'cert.pem', key: 'key.pem' })).to.have.property(
+            'cert',
+            'cert.pem'
+          );
         });
 
-        it("does not include a value for `key`", function () {
-          expect(config( { pfxData: "apnData", cert: "cert.pem", key: "key.pem" })).to.have.property("key", "key.pem");
+        it('does not include a value for `key`', function () {
+          expect(config({ pfx: 'apn.pfx', cert: 'cert.pem', key: 'key.pem' })).to.have.property(
+            'key',
+            'key.pem'
+          );
         });
       });
 
-      it("loads and validates the TLS credentials", function () {
-        fakes.prepareCertificate.returns({"cert": "certData", "key": "keyData", "pfx": "pfxData"});
+      context('pfxData value is supplied without cert and key', function () {
+        it('includes the value of `pfxData`', function () {
+          expect(config({ pfxData: 'apnData' })).to.have.property('pfxData', 'apnData');
+        });
 
-        let configuration = config({});
-        expect(configuration).to.have.property("cert", "certData");
-        expect(configuration).to.have.property("key", "keyData");
-        expect(configuration).to.have.property("pfx", "pfxData");
+        it('does not include a value for `cert`', function () {
+          expect(config({ pfxData: 'apnData' }).cert).to.be.undefined;
+        });
+
+        it('does not include a value for `key`', function () {
+          expect(config({ pfxData: 'apnData' }).key).to.be.undefined;
+        });
       });
 
-      it("prepares the CA certificates", function () {
-        fakes.prepareCA.returns({ ca: "certificate1" });
+      context('pfxData value is supplied along with a cert and key', function () {
+        it('includes the value of `pfxData`', function () {
+          expect(config({ pfxData: 'apnData', cert: 'cert.pem', key: 'key.pem' })).to.have.property(
+            'pfxData',
+            'apnData'
+          );
+        });
 
-        let configuration = config({});
-        expect(configuration).to.have.property("ca", "certificate1");
+        it('does not include a value for `cert`', function () {
+          expect(config({ pfxData: 'apnData', cert: 'cert.pem', key: 'key.pem' })).to.have.property(
+            'cert',
+            'cert.pem'
+          );
+        });
+
+        it('does not include a value for `key`', function () {
+          expect(config({ pfxData: 'apnData', cert: 'cert.pem', key: 'key.pem' })).to.have.property(
+            'key',
+            'key.pem'
+          );
+        });
+      });
+
+      it('loads and validates the TLS credentials', function () {
+        fakes.prepareCertificate.returns({ cert: 'certData', key: 'keyData', pfx: 'pfxData' });
+
+        const configuration = config({});
+        expect(configuration).to.have.property('cert', 'certData');
+        expect(configuration).to.have.property('key', 'keyData');
+        expect(configuration).to.have.property('pfx', 'pfxData');
+      });
+
+      it('prepares the CA certificates', function () {
+        fakes.prepareCA.returns({ ca: 'certificate1' });
+
+        const configuration = config({});
+        expect(configuration).to.have.property('ca', 'certificate1');
       });
     });
 
-    context("`token` supplied", function () {
-      const key = "testKey";
-      const keyId = "abckeyId";
-      const teamId = "teamId123";
+    context('`token` supplied', function () {
+      const key = 'testKey';
+      const keyId = 'abckeyId';
+      const teamId = 'teamId123';
 
       // Clear these to ensure tls.Socket doesn't attempt to do client-auth
-      it("clears the `pfx` property", function () {
-        expect(config( { token: { key, keyId, teamId } })).to.not.have.property("pfx");
+      it('clears the `pfx` property', function () {
+        expect(config({ token: { key, keyId, teamId } })).to.not.have.property('pfx');
       });
 
-      it("clears the `key` property", function () {
-        expect(config( { token: { key, keyId, teamId } })).to.not.have.property("key");
+      it('clears the `key` property', function () {
+        expect(config({ token: { key, keyId, teamId } })).to.not.have.property('key');
       });
 
-      it("clears the `cert` property", function () {
-        expect(config( { token: { key, keyId, teamId } })).to.not.have.property("cert");
+      it('clears the `cert` property', function () {
+        expect(config({ token: { key, keyId, teamId } })).to.not.have.property('cert');
       });
 
-      describe("token", function () {
-
-        it("throws an error if keyId is missing", function () {
+      describe('token', function () {
+        it('throws an error if keyId is missing', function () {
           expect(() => config({ token: { key, teamId } })).to.throw(/token\.keyId is missing/);
         });
 
-        it("throws an error if keyId is not a string", function () {
-          expect(() => config({ token: { key, teamId, keyId: 123 }})).to.throw(/token\.keyId must be a string/);
+        it('throws an error if keyId is not a string', function () {
+          expect(() => config({ token: { key, teamId, keyId: 123 } })).to.throw(
+            /token\.keyId must be a string/
+          );
         });
 
-        it("throws an error if teamId is missing", function () {
-          expect(() => config({ token: { key, keyId }})).to.throw(/token\.teamId is missing/);
+        it('throws an error if teamId is missing', function () {
+          expect(() => config({ token: { key, keyId } })).to.throw(/token\.teamId is missing/);
         });
 
-        it("throws an error if teamId is not a string", function () {
-          expect(() => config({ token: { key, keyId, teamId: 123 }})).to.throw(/token\.teamId must be a string/);
+        it('throws an error if teamId is not a string', function () {
+          expect(() => config({ token: { key, keyId, teamId: 123 } })).to.throw(
+            /token\.teamId must be a string/
+          );
         });
       });
 
-      it("does not invoke prepareCertificate", function () {
-        let configuration = config({ token: { key, keyId, teamId } });
+      it('does not invoke prepareCertificate', function () {
+        const configuration = config({ token: { key, keyId, teamId } });
 
         expect(fakes.prepareCertificate).to.have.not.been.called;
       });
 
-      it("prepares a token generator", function () {
-        let testConfig = { key, keyId, teamId };
+      it('prepares a token generator', function () {
+        const testConfig = { key, keyId, teamId };
 
-        fakes.prepareToken
-          .withArgs(sinon.match(testConfig))
-          .returns( () => "fake-token" );
+        fakes.prepareToken.withArgs(sinon.match(testConfig)).returns(() => 'fake-token');
 
-        let configuration = config({ token: testConfig });
+        const configuration = config({ token: testConfig });
         expect(fakes.prepareToken).to.have.been.called;
-        expect(configuration.token()).to.equal("fake-token");
+        expect(configuration.token()).to.equal('fake-token');
       });
 
-      it("prepares the CA certificates", function () {
-        fakes.prepareCA.returns({ ca: "certificate1" });
+      it('prepares the CA certificates', function () {
+        fakes.prepareCA.returns({ ca: 'certificate1' });
 
-        let configuration = config({});
-        expect(configuration).to.have.property("ca", "certificate1");
+        const configuration = config({});
+        expect(configuration).to.have.property('ca', 'certificate1');
       });
     });
   });
 
-  context("a null config value is passed", function () {
-    it("should log a message with `debug`", function () {
-      config( { address: null } );
+  context('a null config value is passed', function () {
+    it('should log a message with `debug`', function () {
+      config({ address: null });
 
-      expect(fakes.logger).to.be.calledWith("Option [address] is null. This may cause unexpected behaviour.");
+      expect(fakes.logger).to.be.calledWith(
+        'Option [address] is null. This may cause unexpected behaviour.'
+      );
     });
   });
 
-  context("a config value is undefined", function () {
-    it("should log a message with `debug`", function () {
-      config( { anOption: undefined } );
+  context('a config value is undefined', function () {
+    it('should log a message with `debug`', function () {
+      config({ anOption: undefined });
 
-      expect(fakes.logger).to.be.calledWith("Option [anOption] is undefined. This may cause unexpected behaviour.");
+      expect(fakes.logger).to.be.calledWith(
+        'Option [anOption] is undefined. This may cause unexpected behaviour.'
+      );
     });
   });
 });

--- a/test/config.js
+++ b/test/config.js
@@ -236,7 +236,7 @@ describe('config', function () {
       });
 
       it('does not invoke prepareCertificate', function () {
-        const configuration = config({ token: { key, keyId, teamId } });
+        config({ token: { key, keyId, teamId } });
 
         expect(fakes.prepareCertificate).to.have.not.been.called;
       });

--- a/test/credentials/ca/prepare.js
+++ b/test/credentials/ca/prepare.js
@@ -1,44 +1,39 @@
-"use strict";
+const fs = require('fs');
 
-const fs = require("fs");
-
-describe("prepareCA", function() {
+describe('prepareCA', function () {
   let cert, prepareCA;
 
   before(function () {
-    cert = fs.readFileSync("test/support/initializeTest.crt");
+    cert = fs.readFileSync('test/support/initializeTest.crt');
 
-    const resolve = require("../../../lib/credentials/resolve");
-    prepareCA = require("../../../lib/credentials/ca/prepare")({ resolve });
+    const resolve = require('../../../lib/credentials/resolve');
+    prepareCA = require('../../../lib/credentials/ca/prepare')({ resolve });
   });
 
-  it("should load a single CA certificate from disk", function () {
-    return expect(prepareCA({ca: "test/support/initializeTest.crt" })
-          .ca[0].toString()).to.equal(cert.toString());
+  it('should load a single CA certificate from disk', function () {
+    return expect(prepareCA({ ca: 'test/support/initializeTest.crt' }).ca[0].toString()).to.equal(
+      cert.toString()
+    );
   });
 
-  it("should provide a single CA certificate from a Buffer", function () {
-    return expect(prepareCA({ca: cert }).ca[0].toString())
-          .to.equal(cert.toString());
+  it('should provide a single CA certificate from a Buffer', function () {
+    return expect(prepareCA({ ca: cert }).ca[0].toString()).to.equal(cert.toString());
   });
 
-  it("should provide a single CA certificate from a String", function () {
-    return expect(prepareCA({ca: cert.toString() }).ca[0])
-          .to.equal(cert.toString());
+  it('should provide a single CA certificate from a String', function () {
+    return expect(prepareCA({ ca: cert.toString() }).ca[0]).to.equal(cert.toString());
   });
 
-  it("should load an array of CA certificates", function () {
+  it('should load an array of CA certificates', function () {
     const certString = cert.toString();
-    return expect(prepareCA({ca: [
-      "test/support/initializeTest.crt",
-      cert,
-      certString
-    ]}).ca.map( cert => cert.toString() ))
-      .to.deep.equal([certString, certString, certString]);
+    return expect(
+      prepareCA({ ca: ['test/support/initializeTest.crt', cert, certString] }).ca.map(cert =>
+        cert.toString()
+      )
+    ).to.deep.equal([certString, certString, certString]);
   });
 
-  it("returns undefined if no CA values are specified", function() {
-    return expect(prepareCA({ca: null}).ca)
-      .to.be.undefined;
+  it('returns undefined if no CA values are specified', function () {
+    return expect(prepareCA({ ca: null }).ca).to.be.undefined;
   });
 });

--- a/test/credentials/certificate/APNCertificate.js
+++ b/test/credentials/certificate/APNCertificate.js
@@ -1,107 +1,105 @@
-"use strict";
+const APNCertificate = require('../../../lib/credentials/certificate/APNCertificate');
+const APNKey = require('../../../lib/credentials/certificate/APNKey');
+const forge = require('node-forge');
+const fs = require('fs');
 
-const APNCertificate = require("../../../lib/credentials/certificate/APNCertificate");
-const APNKey = require("../../../lib/credentials/certificate/APNKey");
-const forge = require("node-forge");
-const fs = require("fs");
-
-describe("APNCertificate", function() {
+describe('APNCertificate', function () {
   let certPem;
-  before(function() {
-    certPem = fs.readFileSync("test/credentials/support/cert.pem");
+  before(function () {
+    certPem = fs.readFileSync('test/credentials/support/cert.pem');
   });
 
   let cert;
-  beforeEach(function() {
+  beforeEach(function () {
     cert = forge.pki.certificateFromPem(certPem.toString());
   });
 
-  describe("accepts a Certificate object", function() {
-    it("does not throw", function() {
-      expect(function() {
+  describe('accepts a Certificate object', function () {
+    it('does not throw', function () {
+      expect(function () {
         new APNCertificate(cert);
       }).to.not.throw(Error);
     });
   });
 
-  describe("throws", function() {
-    it("missing public key", function() {
+  describe('throws', function () {
+    it('missing public key', function () {
       delete cert.publicKey;
 
-      expect(function() {
+      expect(function () {
         new APNCertificate(cert);
-      }).to.throw("certificate object is invalid");
+      }).to.throw('certificate object is invalid');
     });
 
-    it("missing validity", function() {
+    it('missing validity', function () {
       delete cert.validity;
 
-      expect(function() {
+      expect(function () {
         new APNCertificate(cert);
-      }).to.throw("certificate object is invalid");
+      }).to.throw('certificate object is invalid');
     });
 
-    it("missing subject", function() {
+    it('missing subject', function () {
       delete cert.subject;
 
-      expect(function() {
+      expect(function () {
         new APNCertificate(cert);
-      }).to.throw("certificate object is invalid");
+      }).to.throw('certificate object is invalid');
     });
   });
 
-  describe("key", function() {
-    it("returns an APNKey", function() {
+  describe('key', function () {
+    it('returns an APNKey', function () {
       expect(new APNCertificate(cert).key()).to.be.an.instanceof(APNKey);
     });
 
-    it("returns the the certificates public key", function() {
-      expect(new APNCertificate(cert).key().fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+    it('returns the the certificates public key', function () {
+      expect(new APNCertificate(cert).key().fingerprint()).to.equal(
+        '2d594c9861227dd22ba5ae37cc9354e9117a804d'
+      );
     });
   });
 
-  describe("validity", function() {
-    it("returns an object containing notBefore", function() {
+  describe('validity', function () {
+    it('returns an object containing notBefore', function () {
       expect(new APNCertificate(cert).validity())
-        .to.have.property("notBefore")
-        .and
-        .to.eql(new Date("2015-01-01T00:00:00Z"));
+        .to.have.property('notBefore')
+        .and.to.eql(new Date('2015-01-01T00:00:00Z'));
     });
 
-    it("returns an object containing notAfter", function() {
+    it('returns an object containing notAfter', function () {
       expect(new APNCertificate(cert).validity())
-        .to.have.property("notAfter")
-        .and
-        .to.eql(new Date("2025-01-01T00:00:00Z"));
+        .to.have.property('notAfter')
+        .and.to.eql(new Date('2025-01-01T00:00:00Z'));
     });
   });
 
-  describe("environment", function() {
-    describe("development certificate", function() {
-      it("sandbox flag", function() {
+  describe('environment', function () {
+    describe('development certificate', function () {
+      it('sandbox flag', function () {
         expect(new APNCertificate(cert).environment().sandbox).to.be.true;
       });
 
-      it("production flag", function() {
+      it('production flag', function () {
         expect(new APNCertificate(cert).environment().production).to.be.false;
       });
     });
 
-    describe("production certificate", function() {
+    describe('production certificate', function () {
       let productionCertPem, productionCert;
-      before(function() {
-        productionCertPem = fs.readFileSync("test/credentials/support/certProduction.pem");
+      before(function () {
+        productionCertPem = fs.readFileSync('test/credentials/support/certProduction.pem');
       });
 
-      beforeEach(function() {
+      beforeEach(function () {
         productionCert = forge.pki.certificateFromPem(productionCertPem.toString());
       });
 
-      it("sandbox flag", function() {
+      it('sandbox flag', function () {
         expect(new APNCertificate(productionCert).environment().sandbox).to.be.false;
       });
 
-      it("production flag", function() {
+      it('production flag', function () {
         expect(new APNCertificate(productionCert).environment().production).to.be.true;
       });
     });

--- a/test/credentials/certificate/APNKey.js
+++ b/test/credentials/certificate/APNKey.js
@@ -1,39 +1,37 @@
-"use strict";
+const APNKey = require('../../../lib/credentials/certificate/APNKey');
+const forge = require('node-forge');
+const fs = require('fs');
 
-const APNKey = require("../../../lib/credentials/certificate/APNKey");
-const forge = require("node-forge");
-const fs = require("fs");
-
-describe("APNKey", function() {
-  it("initialises with a node-forge public key", function() {
-    expect(new APNKey({ n: 12345, e: 65536})).to.be.an.instanceof(APNKey);
+describe('APNKey', function () {
+  it('initialises with a node-forge public key', function () {
+    expect(new APNKey({ n: 12345, e: 65536 })).to.be.an.instanceof(APNKey);
   });
 
-  describe("throws", function() {
-    it("missing modulus", function() {
-      expect(function() {
+  describe('throws', function () {
+    it('missing modulus', function () {
+      expect(function () {
         new APNKey({ e: 65536 });
-      }).to.throw("key is not a valid public key");
+      }).to.throw('key is not a valid public key');
     });
 
-    it("missing exponent", function() {
-      expect(function() {
+    it('missing exponent', function () {
+      expect(function () {
         new APNKey({ n: 12345 });
-      }).to.throw("key is not a valid public key");
+      }).to.throw('key is not a valid public key');
     });
 
-    it("undefined", function() {
-      expect(function() {
+    it('undefined', function () {
+      expect(function () {
         new APNKey();
-      }).to.throw("key is not a valid public key");
+      }).to.throw('key is not a valid public key');
     });
   });
 
-  describe("fingerprint", function() {
-    it("returns the fingerprint of the public key", function() {
-      let keyPem = fs.readFileSync("test/credentials/support/key.pem");
-      let apnKey = new APNKey(forge.pki.decryptRsaPrivateKey(keyPem));
-      expect(apnKey.fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+  describe('fingerprint', function () {
+    it('returns the fingerprint of the public key', function () {
+      const keyPem = fs.readFileSync('test/credentials/support/key.pem');
+      const apnKey = new APNKey(forge.pki.decryptRsaPrivateKey(keyPem));
+      expect(apnKey.fingerprint()).to.equal('2d594c9861227dd22ba5ae37cc9354e9117a804d');
     });
   });
 });

--- a/test/credentials/certificate/load.js
+++ b/test/credentials/certificate/load.js
@@ -1,75 +1,79 @@
-"use strict";
+const fs = require('fs');
 
-const fs = require("fs");
-
-describe("loadCredentials", function() {
+describe('loadCredentials', function () {
   let pfx, cert, key, loadCredentials;
   before(function () {
-    pfx = fs.readFileSync("test/support/initializeTest.pfx");
-    cert = fs.readFileSync("test/support/initializeTest.crt");
-    key = fs.readFileSync("test/support/initializeTest.key");
+    pfx = fs.readFileSync('test/support/initializeTest.pfx');
+    cert = fs.readFileSync('test/support/initializeTest.crt');
+    key = fs.readFileSync('test/support/initializeTest.key');
 
-    const resolve = require("../../../lib/credentials/resolve");
-    loadCredentials = require("../../../lib/credentials/certificate/load")({ resolve });
+    const resolve = require('../../../lib/credentials/resolve');
+    loadCredentials = require('../../../lib/credentials/certificate/load')({ resolve });
   });
 
-  it("should load a pfx file from disk", function () {
-    return expect(loadCredentials({ pfx: "test/support/initializeTest.pfx" })
-          .pfx.toString()).to.equal(pfx.toString());
+  it('should load a pfx file from disk', function () {
+    return expect(
+      loadCredentials({ pfx: 'test/support/initializeTest.pfx' }).pfx.toString()
+    ).to.equal(pfx.toString());
   });
 
-  it("should provide pfx data from memory", function () {
-    return expect(loadCredentials({ pfx: pfx }).pfx.toString())
-          .to.equal(pfx.toString());
+  it('should provide pfx data from memory', function () {
+    return expect(loadCredentials({ pfx: pfx }).pfx.toString()).to.equal(pfx.toString());
   });
 
-  it("should provide pfx data explicitly passed in pfxData parameter", function () {
-    return expect(loadCredentials({ pfxData: pfx }).pfx.toString())
-          .to.equal(pfx.toString());
+  it('should provide pfx data explicitly passed in pfxData parameter', function () {
+    return expect(loadCredentials({ pfxData: pfx }).pfx.toString()).to.equal(pfx.toString());
   });
 
-  it("should load a certificate from disk", function () {
-    return expect(loadCredentials({ cert: "test/support/initializeTest.crt", key: null})
-          .cert.toString()).to.equal(cert.toString());
+  it('should load a certificate from disk', function () {
+    return expect(
+      loadCredentials({ cert: 'test/support/initializeTest.crt', key: null }).cert.toString()
+    ).to.equal(cert.toString());
   });
 
-  it("should provide a certificate from a Buffer", function () {
-    return expect(loadCredentials({ cert: cert, key: null}).cert.toString())
-          .to.equal(cert.toString());
+  it('should provide a certificate from a Buffer', function () {
+    return expect(loadCredentials({ cert: cert, key: null }).cert.toString()).to.equal(
+      cert.toString()
+    );
   });
 
-  it("should provide a certificate from a String", function () {
-    return expect(loadCredentials({ cert: cert.toString(), key: null}).cert)
-          .to.equal(cert.toString());
+  it('should provide a certificate from a String', function () {
+    return expect(loadCredentials({ cert: cert.toString(), key: null }).cert).to.equal(
+      cert.toString()
+    );
   });
 
-  it("should provide certificate data explicitly passed in the certData parameter", function () {
-    return expect(loadCredentials({ certData: cert, key: null}).cert.toString())
-          .to.equal(cert.toString());
+  it('should provide certificate data explicitly passed in the certData parameter', function () {
+    return expect(loadCredentials({ certData: cert, key: null }).cert.toString()).to.equal(
+      cert.toString()
+    );
   });
 
-  it("should load a key from disk", function () {
-    return expect(loadCredentials({ cert: null, key: "test/support/initializeTest.key"})
-          .key.toString()).to.equal(key.toString());
+  it('should load a key from disk', function () {
+    return expect(
+      loadCredentials({ cert: null, key: 'test/support/initializeTest.key' }).key.toString()
+    ).to.equal(key.toString());
   });
 
-  it("should provide a key from a Buffer", function () {
-    return expect(loadCredentials({ cert: null, key: key}).key.toString())
-          .to.equal(key.toString());
+  it('should provide a key from a Buffer', function () {
+    return expect(loadCredentials({ cert: null, key: key }).key.toString()).to.equal(
+      key.toString()
+    );
   });
 
-  it("should provide a key from a String", function () {
-    return expect(loadCredentials({ cert: null, key: key.toString()}).key)
-          .to.equal(key.toString());
+  it('should provide a key from a String', function () {
+    return expect(loadCredentials({ cert: null, key: key.toString() }).key).to.equal(
+      key.toString()
+    );
   });
 
-  it("should provide key data explicitly passed in the keyData parameter", function () {
-    return expect(loadCredentials({ cert: null, keyData: key}).key.toString())
-          .to.equal(key.toString());
+  it('should provide key data explicitly passed in the keyData parameter', function () {
+    return expect(loadCredentials({ cert: null, keyData: key }).key.toString()).to.equal(
+      key.toString()
+    );
   });
 
-  it("should inclue the passphrase in the resolved value", function() {
-    return expect(loadCredentials({ passphrase: "apntest" }).passphrase)
-      .to.equal("apntest");
+  it('should inclue the passphrase in the resolved value', function () {
+    return expect(loadCredentials({ passphrase: 'apntest' }).passphrase).to.equal('apntest');
   });
 });

--- a/test/credentials/certificate/parse.js
+++ b/test/credentials/certificate/parse.js
@@ -1,122 +1,126 @@
-"use strict";
+const sinon = require('sinon');
 
-const sinon = require("sinon");
+const APNCertificate = require('../../../lib/credentials/certificate/APNCertificate');
+const APNKey = require('../../../lib/credentials/certificate/APNKey');
 
-const APNCertificate = require("../../../lib/credentials/certificate/APNCertificate");
-const APNKey = require("../../../lib/credentials/certificate/APNKey");
-
-describe("parseCredentials", function() {
+describe('parseCredentials', function () {
   let fakes, parseCredentials;
 
-  const pfxKey = new APNKey({n: 1, e: 1 });
-  const pfxCert = new APNCertificate({publicKey: {}, validity: {}, subject: {} });
+  const pfxKey = new APNKey({ n: 1, e: 1 });
+  const pfxCert = new APNCertificate({ publicKey: {}, validity: {}, subject: {} });
 
-  const pemKey = new APNKey({n: 2, e: 1 });
-  const pemCert = new APNCertificate({publicKey: {}, validity: {}, subject: {} });
+  const pemKey = new APNKey({ n: 2, e: 1 });
+  const pemCert = new APNCertificate({ publicKey: {}, validity: {}, subject: {} });
 
-  beforeEach(function() {
+  beforeEach(function () {
     fakes = {
       parsePkcs12: sinon.stub(),
       parsePemKey: sinon.stub(),
       parsePemCert: sinon.stub(),
     };
 
-    fakes.parsePemKey.withArgs("pemkey").returns(pemKey);
+    fakes.parsePemKey.withArgs('pemkey').returns(pemKey);
 
-    fakes.parsePemKey.withArgs("pemcert").returns(pemCert);
+    fakes.parsePemKey.withArgs('pemcert').returns(pemCert);
 
-    parseCredentials = require("../../../lib/credentials/certificate/parse")(fakes);
+    parseCredentials = require('../../../lib/credentials/certificate/parse')(fakes);
   });
 
-  describe("with PFX file", function() {
-    it("returns the parsed key", function() {
-      fakes.parsePkcs12.withArgs("pfxData").returns({ key: pfxKey, certificates: [pfxCert] });
+  describe('with PFX file', function () {
+    it('returns the parsed key', function () {
+      fakes.parsePkcs12.withArgs('pfxData').returns({ key: pfxKey, certificates: [pfxCert] });
 
-      const parsed = parseCredentials({ pfx: "pfxData" });
+      const parsed = parseCredentials({ pfx: 'pfxData' });
       expect(parsed.key).to.be.an.instanceof(APNKey);
     });
 
-    it("returns the parsed certificates", function() {
-      fakes.parsePkcs12.withArgs("pfxData").returns({ key: pfxKey, certificates: [pfxCert] });
+    it('returns the parsed certificates', function () {
+      fakes.parsePkcs12.withArgs('pfxData').returns({ key: pfxKey, certificates: [pfxCert] });
 
-      const parsed = parseCredentials({ pfx: "pfxData" });
+      const parsed = parseCredentials({ pfx: 'pfxData' });
       expect(parsed.certificates[0]).to.be.an.instanceof(APNCertificate);
     });
 
-    describe("having passphrase", function() {
-      beforeEach(function() {
-        fakes.parsePkcs12.withArgs("encryptedPfxData", "apntest").returns({ key: pfxKey, certificates: [pfxCert] });
-        fakes.parsePkcs12.withArgs("encryptedPfxData", sinon.match.any).throws(new Error("unable to read credentials, incorrect passphrase"));
+    describe('having passphrase', function () {
+      beforeEach(function () {
+        fakes.parsePkcs12
+          .withArgs('encryptedPfxData', 'apntest')
+          .returns({ key: pfxKey, certificates: [pfxCert] });
+        fakes.parsePkcs12
+          .withArgs('encryptedPfxData', sinon.match.any)
+          .throws(new Error('unable to read credentials, incorrect passphrase'));
       });
 
-      it("returns the parsed key", function() {
-        const parsed = parseCredentials({ pfx: "encryptedPfxData", passphrase: "apntest" });
+      it('returns the parsed key', function () {
+        const parsed = parseCredentials({ pfx: 'encryptedPfxData', passphrase: 'apntest' });
         expect(parsed.key).to.be.an.instanceof(APNKey);
       });
 
-      it("throws when passphrase is incorrect", function() {
-        expect(function() {
-          parseCredentials({ pfx: "encryptedPfxData", passphrase: "incorrectpassphrase" });
+      it('throws when passphrase is incorrect', function () {
+        expect(function () {
+          parseCredentials({ pfx: 'encryptedPfxData', passphrase: 'incorrectpassphrase' });
         }).to.throw(/incorrect passphrase/);
       });
 
-      it("throws when passphrase is not supplied", function() {
-        expect(function() {
-          parseCredentials({ pfx: "encryptedPfxData" });
+      it('throws when passphrase is not supplied', function () {
+        expect(function () {
+          parseCredentials({ pfx: 'encryptedPfxData' });
         }).to.throw(/incorrect passphrase/);
       });
     });
   });
 
-  describe("with PEM key", function() {
-    it("returns the parsed key", function() {
-      fakes.parsePemKey.withArgs("pemKeyData").returns(pemKey);
+  describe('with PEM key', function () {
+    it('returns the parsed key', function () {
+      fakes.parsePemKey.withArgs('pemKeyData').returns(pemKey);
 
-      const parsed = parseCredentials({ key: "pemKeyData" });
+      const parsed = parseCredentials({ key: 'pemKeyData' });
       expect(parsed.key).to.be.an.instanceof(APNKey);
     });
 
-    describe("having passphrase", function() {
-      beforeEach(function() {
-        fakes.parsePemKey.withArgs("encryptedPemKeyData", "apntest").returns(pemKey);
-        fakes.parsePemKey.withArgs("encryptedPemKeyData", sinon.match.any).throws(new Error("unable to load key, incorrect passphrase"));
+    describe('having passphrase', function () {
+      beforeEach(function () {
+        fakes.parsePemKey.withArgs('encryptedPemKeyData', 'apntest').returns(pemKey);
+        fakes.parsePemKey
+          .withArgs('encryptedPemKeyData', sinon.match.any)
+          .throws(new Error('unable to load key, incorrect passphrase'));
       });
 
-      it("returns the parsed key", function() {
-        const parsed = parseCredentials({ key: "encryptedPemKeyData", passphrase: "apntest" });
+      it('returns the parsed key', function () {
+        const parsed = parseCredentials({ key: 'encryptedPemKeyData', passphrase: 'apntest' });
         expect(parsed.key).to.be.an.instanceof(APNKey);
       });
 
-      it("throws when passphrase is incorrect", function() {
-        expect(function() {
-          parseCredentials({ key: "encryptedPemKeyData", passphrase: "incorrectpassphrase" });
+      it('throws when passphrase is incorrect', function () {
+        expect(function () {
+          parseCredentials({ key: 'encryptedPemKeyData', passphrase: 'incorrectpassphrase' });
         }).to.throw(/incorrect passphrase/);
       });
 
-      it("throws when passphrase is not supplied", function() {
-        expect(function() {
-          parseCredentials({ key: "encryptedPemKeyData" });
+      it('throws when passphrase is not supplied', function () {
+        expect(function () {
+          parseCredentials({ key: 'encryptedPemKeyData' });
         }).to.throw(/incorrect passphrase/);
       });
     });
   });
 
-  describe("with PEM certificate", function() {
-    it("returns the parsed certificate", function() {
-      fakes.parsePemCert.withArgs("pemCertData").returns([pemCert]);
+  describe('with PEM certificate', function () {
+    it('returns the parsed certificate', function () {
+      fakes.parsePemCert.withArgs('pemCertData').returns([pemCert]);
 
-      const parsed = parseCredentials({ cert: "pemCertData" });
+      const parsed = parseCredentials({ cert: 'pemCertData' });
       expect(parsed.certificates[0]).to.be.an.instanceof(APNCertificate);
     });
   });
 
-  describe("both PEM and PFX data is supplied", function() {
-    it("it prefers PFX to PEM", function() {
-      fakes.parsePkcs12.withArgs("pfxData").returns({ key: pfxKey, certificates: [pfxCert] });
-      fakes.parsePemKey.withArgs("pemKeyData").returns(pemKey);
-      fakes.parsePemCert.withArgs("pemCertData").returns([pemCert]);
+  describe('both PEM and PFX data is supplied', function () {
+    it('it prefers PFX to PEM', function () {
+      fakes.parsePkcs12.withArgs('pfxData').returns({ key: pfxKey, certificates: [pfxCert] });
+      fakes.parsePemKey.withArgs('pemKeyData').returns(pemKey);
+      fakes.parsePemCert.withArgs('pemCertData').returns([pemCert]);
 
-      const parsed = parseCredentials({ pfx: "pfxData", key: "pemKeyData", cert: "pemCertData"});
+      const parsed = parseCredentials({ pfx: 'pfxData', key: 'pemKeyData', cert: 'pemCertData' });
       expect(parsed.key).to.equal(pfxKey);
       expect(parsed.certificates[0]).to.equal(pfxCert);
     });

--- a/test/credentials/certificate/parsePemCertificate.js
+++ b/test/credentials/certificate/parsePemCertificate.js
@@ -1,90 +1,94 @@
-"use strict";
+const parsePemCertificate = require('../../../lib/credentials/certificate/parsePemCertificate');
+const APNCertificate = require('../../../lib/credentials/certificate/APNCertificate');
+const fs = require('fs');
 
-const parsePemCertificate = require("../../../lib/credentials/certificate/parsePemCertificate");
-const APNCertificate = require("../../../lib/credentials/certificate/APNCertificate");
-const fs = require("fs");
-
-describe("parsePemCertificate", function() {
-  describe("with PEM certificate", function() {
+describe('parsePemCertificate', function () {
+  describe('with PEM certificate', function () {
     let cert, certProperties;
-    before(function() {
-      cert = fs.readFileSync("test/credentials/support/cert.pem");
+    before(function () {
+      cert = fs.readFileSync('test/credentials/support/cert.pem');
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
       certProperties = parsePemCertificate(cert);
     });
 
-    describe("return value", function() {
-      it("is an array", function() {
-        expect(certProperties).to.be.an("array");
+    describe('return value', function () {
+      it('is an array', function () {
+        expect(certProperties).to.be.an('array');
       });
 
-      it("contains one element", function() {
+      it('contains one element', function () {
         expect(certProperties).to.have.length(1);
       });
 
-      describe("certificate [0]", function() {
-        it("is an APNCertificate", function() {
+      describe('certificate [0]', function () {
+        it('is an APNCertificate', function () {
           expect(certProperties[0]).to.be.an.instanceof(APNCertificate);
         });
 
-        it("has the correct fingerprint", function() {
-          expect(certProperties[0].key().fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+        it('has the correct fingerprint', function () {
+          expect(certProperties[0].key().fingerprint()).to.equal(
+            '2d594c9861227dd22ba5ae37cc9354e9117a804d'
+          );
         });
       });
     });
   });
 
-  describe("with PEM containing multiple certificates", function() {
+  describe('with PEM containing multiple certificates', function () {
     let cert, certProperties;
-    before(function() {
-      cert = fs.readFileSync("test/credentials/support/certIssuerKey.pem");
+    before(function () {
+      cert = fs.readFileSync('test/credentials/support/certIssuerKey.pem');
     });
 
-    beforeEach(function() {
+    beforeEach(function () {
       certProperties = parsePemCertificate(cert);
     });
 
-    it("returns the correct number of certificates", function() {
+    it('returns the correct number of certificates', function () {
       expect(certProperties).to.have.length(2);
     });
 
-    describe("certificate [0]", function() {
-      it("has the correct fingerprint", function() {
-        expect(certProperties[0].key().fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+    describe('certificate [0]', function () {
+      it('has the correct fingerprint', function () {
+        expect(certProperties[0].key().fingerprint()).to.equal(
+          '2d594c9861227dd22ba5ae37cc9354e9117a804d'
+        );
       });
     });
 
-    describe("certificate [1]", function() {
-      it("has the correct fingerprint", function() {
-        expect(certProperties[1].key().fingerprint()).to.equal("ccff221d67cb3335649f9b4fbb311948af76f4b2");
+    describe('certificate [1]', function () {
+      it('has the correct fingerprint', function () {
+        expect(certProperties[1].key().fingerprint()).to.equal(
+          'ccff221d67cb3335649f9b4fbb311948af76f4b2'
+        );
       });
     });
   });
 
-  describe("with a PKCS#12 file", function() {
-    it("throws", function() {
-      let pfx = fs.readFileSync("test/credentials/support/certIssuerKey.p12");
-      expect(function() {
+  describe('with a PKCS#12 file', function () {
+    it('throws', function () {
+      const pfx = fs.readFileSync('test/credentials/support/certIssuerKey.p12');
+      expect(function () {
         parsePemCertificate(pfx);
-      }).to.throw("unable to parse certificate, not a valid PEM file");
+      }).to.throw('unable to parse certificate, not a valid PEM file');
     });
   });
 
-  describe("with a key", function() {
-    it("returns an empty array", function() {
-      let key = fs.readFileSync("test/credentials/support/key.pem");
+  describe('with a key', function () {
+    it('returns an empty array', function () {
+      const key = fs.readFileSync('test/credentials/support/key.pem');
       expect(parsePemCertificate(key)).to.be.empty;
     });
   });
 
-  describe("returns null", function() {
-    it("for null", function() {
+  describe('returns null', function () {
+    it('for null', function () {
       expect(parsePemCertificate(null)).to.be.null;
     });
 
-    it("for undefined", function() {
+    it('for undefined', function () {
       expect(parsePemCertificate(undefined)).to.be.null;
     });
   });

--- a/test/credentials/certificate/parsePemKey.js
+++ b/test/credentials/certificate/parsePemKey.js
@@ -1,95 +1,93 @@
-"use strict";
+const parsePemKey = require('../../../lib/credentials/certificate/parsePemKey');
+const APNKey = require('../../../lib/credentials/certificate/APNKey');
+const fs = require('fs');
 
-const parsePemKey = require("../../../lib/credentials/certificate/parsePemKey");
-const APNKey = require("../../../lib/credentials/certificate/APNKey");
-const fs = require("fs");
-
-describe("parsePemKey", function() {
-  describe("returns APNKey", function() {
-    describe("RSA key", function() {
+describe('parsePemKey', function () {
+  describe('returns APNKey', function () {
+    describe('RSA key', function () {
       let key;
-      beforeEach(function() {
-        let keyData = fs.readFileSync("test/credentials/support/key.pem");
+      beforeEach(function () {
+        const keyData = fs.readFileSync('test/credentials/support/key.pem');
         key = parsePemKey(keyData);
       });
 
-      it("correct type", function() {
+      it('correct type', function () {
         expect(key).to.be.an.instanceof(APNKey);
       });
 
-      it("with correct fingerprint", function() {
-        expect(key.fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+      it('with correct fingerprint', function () {
+        expect(key.fingerprint()).to.equal('2d594c9861227dd22ba5ae37cc9354e9117a804d');
       });
     });
 
-    it("openssl-encrypted RSA key, correct password", function() {
-      let key = fs.readFileSync("test/credentials/support/keyEncrypted.pem");
-      expect(parsePemKey(key, "apntest")).to.be.an.instanceof(APNKey);
+    it('openssl-encrypted RSA key, correct password', function () {
+      const key = fs.readFileSync('test/credentials/support/keyEncrypted.pem');
+      expect(parsePemKey(key, 'apntest')).to.be.an.instanceof(APNKey);
     });
 
-    it("PKCS#8 encrypted key, correct password", function() {
-      let key = fs.readFileSync("test/credentials/support/keyPKCS8Encrypted.pem");
-      expect(parsePemKey(key, "apntest")).to.be.an.instanceof(APNKey);
+    it('PKCS#8 encrypted key, correct password', function () {
+      const key = fs.readFileSync('test/credentials/support/keyPKCS8Encrypted.pem');
+      expect(parsePemKey(key, 'apntest')).to.be.an.instanceof(APNKey);
     });
 
-    it("PEM containing certificates and key", function() {
-      let certAndKey = fs.readFileSync("test/credentials/support/certKey.pem");
+    it('PEM containing certificates and key', function () {
+      const certAndKey = fs.readFileSync('test/credentials/support/certKey.pem');
       expect(parsePemKey(certAndKey)).to.be.an.instanceof(APNKey);
     });
   });
 
-  describe("throws with", function() {
-    it("PKCS#8 key (unsupported format)", function() {
-      let key = fs.readFileSync("test/credentials/support/keyPKCS8.pem");
-      expect(function() {
+  describe('throws with', function () {
+    it('PKCS#8 key (unsupported format)', function () {
+      const key = fs.readFileSync('test/credentials/support/keyPKCS8.pem');
+      expect(function () {
         parsePemKey(key);
-      }).to.throw("unable to parse key, unsupported format");
+      }).to.throw('unable to parse key, unsupported format');
     });
 
-    it("RSA encrypted key, incorrect passphrase", function() {
-      let key = fs.readFileSync("test/credentials/support/keyEncrypted.pem");
-      expect(function() {
-        parsePemKey(key, "not-the-passphrase");
-      }).to.throw("unable to parse key, incorrect passphrase");
+    it('RSA encrypted key, incorrect passphrase', function () {
+      const key = fs.readFileSync('test/credentials/support/keyEncrypted.pem');
+      expect(function () {
+        parsePemKey(key, 'not-the-passphrase');
+      }).to.throw('unable to parse key, incorrect passphrase');
     });
 
-    it("PKCS#8 encrypted key, incorrect passphrase", function() {
-      let key = fs.readFileSync("test/credentials/support/keyPKCS8Encrypted.pem");
-      expect(function() {
-        parsePemKey(key, "not-the-passphrase");
-      }).to.throw("unable to parse key, incorrect passphrase");
+    it('PKCS#8 encrypted key, incorrect passphrase', function () {
+      const key = fs.readFileSync('test/credentials/support/keyPKCS8Encrypted.pem');
+      expect(function () {
+        parsePemKey(key, 'not-the-passphrase');
+      }).to.throw('unable to parse key, incorrect passphrase');
     });
 
-    it("PEM certificate", function() {
-      let cert = fs.readFileSync("test/credentials/support/cert.pem");
-      expect(function() {
+    it('PEM certificate', function () {
+      const cert = fs.readFileSync('test/credentials/support/cert.pem');
+      expect(function () {
         parsePemKey(cert);
-      }).to.throw("unable to parse key, no private key found");
+      }).to.throw('unable to parse key, no private key found');
     });
 
-    it("PKCS#12 file", function() {
-      let pkcs12 = fs.readFileSync("test/credentials/support/certIssuerKey.p12");
-      expect(function() {
+    it('PKCS#12 file', function () {
+      const pkcs12 = fs.readFileSync('test/credentials/support/certIssuerKey.p12');
+      expect(function () {
         parsePemKey(pkcs12);
-      }).to.throw("unable to parse key, not a valid PEM file");
+      }).to.throw('unable to parse key, not a valid PEM file');
     });
   });
 
-  describe("multiple keys", function() {
-    it("throws", function() {
-      let keys = fs.readFileSync("test/credentials/support/multipleKeys.pem");
-      expect(function() {
+  describe('multiple keys', function () {
+    it('throws', function () {
+      const keys = fs.readFileSync('test/credentials/support/multipleKeys.pem');
+      expect(function () {
         parsePemKey(keys);
-      }).to.throw("multiple keys found in PEM file");
+      }).to.throw('multiple keys found in PEM file');
     });
   });
 
-  describe("returns null", function() {
-    it("for null", function() {
+  describe('returns null', function () {
+    it('for null', function () {
       expect(parsePemKey()).to.be.null;
     });
 
-    it("for undefined", function() {
+    it('for undefined', function () {
       expect(parsePemKey()).to.be.null;
     });
   });

--- a/test/credentials/certificate/parsePkcs12.js
+++ b/test/credentials/certificate/parsePkcs12.js
@@ -1,64 +1,67 @@
-"use strict";
+const parsePkcs12 = require('../../../lib/credentials/certificate/parsePkcs12');
 
-const parsePkcs12 = require("../../../lib/credentials/certificate/parsePkcs12");
+const APNKey = require('../../../lib/credentials/certificate/APNKey');
+const APNCertificate = require('../../../lib/credentials/certificate/APNCertificate');
 
-const APNKey = require("../../../lib/credentials/certificate/APNKey");
-const APNCertificate = require("../../../lib/credentials/certificate/APNCertificate");
+const fs = require('fs');
 
-const fs = require("fs");
-
-describe("parsePkcs12", function() {
-  describe("with PKCS#12 data", function() {
-    var p12, properties;
-    describe("return value", function() {
-      var credentials;
-      before(function() {
-        p12 = fs.readFileSync("test/credentials/support/certIssuerKey.p12");
+describe('parsePkcs12', function () {
+  describe('with PKCS#12 data', function () {
+    let p12, properties;
+    describe('return value', function () {
+      let credentials;
+      before(function () {
+        p12 = fs.readFileSync('test/credentials/support/certIssuerKey.p12');
         credentials = parsePkcs12(p12);
       });
 
-      it("is an object", function() {
-        expect(credentials).to.be.an("object");
+      it('is an object', function () {
+        expect(credentials).to.be.an('object');
       });
 
-      it("contains a private key", function() {
-        expect(credentials).to.include.keys("key");
+      it('contains a private key', function () {
+        expect(credentials).to.include.keys('key');
       });
 
-      describe("private key", function() {
-        it("is an instance of APNKey", function() {
+      describe('private key', function () {
+        it('is an instance of APNKey', function () {
           expect(credentials.key).to.be.an.instanceof(APNKey);
         });
 
-        it("has the correct fingerprint", function() {
-          expect(credentials.key.fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+        it('has the correct fingerprint', function () {
+          expect(credentials.key.fingerprint()).to.equal(
+            '2d594c9861227dd22ba5ae37cc9354e9117a804d'
+          );
         });
       });
 
-      it("contains a certificate chain", function() {
-        expect(credentials).to.include.keys("certificates");
+      it('contains a certificate chain', function () {
+        expect(credentials).to.include.keys('certificates');
       });
 
-      describe("certificate chain", function() {
-        it("is an array", function() {
-          expect(credentials.certificates).to.be.an("array");
+      describe('certificate chain', function () {
+        it('is an array', function () {
+          expect(credentials.certificates).to.be.an('array');
         });
 
-        it("contains the correct number of certificates", function() {
+        it('contains the correct number of certificates', function () {
           expect(credentials.certificates.length).to.equal(2);
         });
 
-        it("contains APNCertificate objects", function() {
-          var certificates = credentials.certificates;
-          certificates.forEach(function(certificate) {
+        it('contains APNCertificate objects', function () {
+          const certificates = credentials.certificates;
+          certificates.forEach(function (certificate) {
             expect(certificate).to.be.an.instanceof(APNCertificate);
           });
         });
 
-        it("contains certificates with the correct fingerprints", function() {
-          var fingerprints = ["2d594c9861227dd22ba5ae37cc9354e9117a804d", "ccff221d67cb3335649f9b4fbb311948af76f4b2"];
-          var certificates = credentials.certificates;
-          certificates.forEach(function(certificate, index) {
+        it('contains certificates with the correct fingerprints', function () {
+          const fingerprints = [
+            '2d594c9861227dd22ba5ae37cc9354e9117a804d',
+            'ccff221d67cb3335649f9b4fbb311948af76f4b2',
+          ];
+          const certificates = credentials.certificates;
+          certificates.forEach(function (certificate, index) {
             expect(certificate.key().fingerprint()).to.equal(fingerprints[index]);
           });
         });
@@ -66,57 +69,57 @@ describe("parsePkcs12", function() {
     });
 
     // OpenSSL exports keys having no passphrase as a C string with a \0 byte appended
-    describe("having empty passphrase (OpenSSL-CLI-generated file)", function() {
-      describe("return value", function() {
-        it("has the correct key", function() {
-          p12 = fs.readFileSync("test/credentials/support/certIssuerKeyOpenSSL.p12");
+    describe('having empty passphrase (OpenSSL-CLI-generated file)', function () {
+      describe('return value', function () {
+        it('has the correct key', function () {
+          p12 = fs.readFileSync('test/credentials/support/certIssuerKeyOpenSSL.p12');
           properties = parsePkcs12(p12);
-          expect(properties.key.fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+          expect(properties.key.fingerprint()).to.equal('2d594c9861227dd22ba5ae37cc9354e9117a804d');
         });
       });
     });
 
-    describe("with correct passphrase", function() {
-      describe("return value", function() {
-        it("has the correct key", function() {
-          p12 = fs.readFileSync("test/credentials/support/certIssuerKeyPassphrase.p12");
-          properties = parsePkcs12(p12, "apntest");
-          expect(properties.key.fingerprint()).to.equal("2d594c9861227dd22ba5ae37cc9354e9117a804d");
+    describe('with correct passphrase', function () {
+      describe('return value', function () {
+        it('has the correct key', function () {
+          p12 = fs.readFileSync('test/credentials/support/certIssuerKeyPassphrase.p12');
+          properties = parsePkcs12(p12, 'apntest');
+          expect(properties.key.fingerprint()).to.equal('2d594c9861227dd22ba5ae37cc9354e9117a804d');
         });
       });
     });
-    describe("with incorrect passphrase", function() {
-      it("throws", function() {
-        p12 = fs.readFileSync("test/credentials/support/certIssuerKeyPassphrase.p12");
-        expect(function() {
-          parsePkcs12(p12, "notthepassphrase");
-        }).to.throw("unable to parse credentials, incorrect passphrase");
+    describe('with incorrect passphrase', function () {
+      it('throws', function () {
+        p12 = fs.readFileSync('test/credentials/support/certIssuerKeyPassphrase.p12');
+        expect(function () {
+          parsePkcs12(p12, 'notthepassphrase');
+        }).to.throw('unable to parse credentials, incorrect passphrase');
       });
     });
 
     // Unclear whether multiple keys in one PKCS#12 file can be distinguished
     // at present if there's more than one just throw a warning. Should also
     // do the same thing in apnKeyFromPem
-    describe("multiple keys", function() {
-      it("throws", function() {
-        p12 = fs.readFileSync("test/credentials/support/multipleKeys.p12");
-        expect(function() {
+    describe('multiple keys', function () {
+      it('throws', function () {
+        p12 = fs.readFileSync('test/credentials/support/multipleKeys.p12');
+        expect(function () {
           parsePkcs12(p12);
-        }).to.throw("multiple keys found in PFX/P12 file");
+        }).to.throw('multiple keys found in PFX/P12 file');
       });
     });
   });
 
-  describe("PEM file", function() {
-    it("throws", function() {
-      var pem = fs.readFileSync("test/credentials/support/certKey.pem");
-      expect(function() {
+  describe('PEM file', function () {
+    it('throws', function () {
+      const pem = fs.readFileSync('test/credentials/support/certKey.pem');
+      expect(function () {
         parsePkcs12(pem);
-      }).to.throw("unable to parse credentials, not a PFX/P12 file");
+      }).to.throw('unable to parse credentials, not a PFX/P12 file');
     });
   });
 
-  it("returns undefined for undefined", function() {
+  it('returns undefined for undefined', function () {
     expect(parsePkcs12()).to.be.undefined;
   });
 });

--- a/test/credentials/certificate/prepare.js
+++ b/test/credentials/certificate/prepare.js
@@ -1,8 +1,6 @@
-"use strict";
+const sinon = require('sinon');
 
-const sinon = require("sinon");
-
-describe("perpareCertificate", function () {
+describe('perpareCertificate', function () {
   let fakes, prepareCertificate;
 
   beforeEach(function () {
@@ -13,127 +11,134 @@ describe("perpareCertificate", function () {
       logger: sinon.stub(),
     };
 
-    prepareCertificate = require("../../../lib/credentials/certificate/prepare")(fakes);
+    prepareCertificate = require('../../../lib/credentials/certificate/prepare')(fakes);
   });
 
-  describe("with valid credentials", function() {
+  describe('with valid credentials', function () {
     let credentials;
     const testOptions = {
-      pfx: "myCredentials.pfx",
-      cert: "myCert.pem",
-      key: "myKey.pem",
-      ca: "myCa.pem",
-      passphrase: "apntest",
+      pfx: 'myCredentials.pfx',
+      cert: 'myCert.pem',
+      key: 'myKey.pem',
+      ca: 'myCa.pem',
+      passphrase: 'apntest',
       production: true,
     };
 
-    beforeEach(function() {
-      fakes.load.withArgs(sinon.match(testOptions)).returns(
-        {
-          pfx: "myPfxData",
-          cert: "myCertData",
-          key: "myKeyData",
-          ca: ["myCaData"],
-          passphrase: "apntest",
-        }
-      );
+    beforeEach(function () {
+      fakes.load.withArgs(sinon.match(testOptions)).returns({
+        pfx: 'myPfxData',
+        cert: 'myCertData',
+        key: 'myKeyData',
+        ca: ['myCaData'],
+        passphrase: 'apntest',
+      });
 
       fakes.parse.returnsArg(0);
       credentials = prepareCertificate(testOptions);
     });
 
-    describe("the validation stage", function() {
-      it("is called once", function() {
+    describe('the validation stage', function () {
+      it('is called once', function () {
         expect(fakes.validate).to.be.calledOnce;
       });
 
-      it("is passed the production flag", function() {
-        expect(fakes.validate.getCall(0).args[0]).to.have.property("production", true);
+      it('is passed the production flag', function () {
+        expect(fakes.validate.getCall(0).args[0]).to.have.property('production', true);
       });
 
-      describe("passed credentials", function() {
-        it("contains the PFX data", function() {
-          expect(fakes.validate.getCall(0).args[0]).to.have.property("pfx", "myPfxData");
+      describe('passed credentials', function () {
+        it('contains the PFX data', function () {
+          expect(fakes.validate.getCall(0).args[0]).to.have.property('pfx', 'myPfxData');
         });
 
-        it("contains the key data", function() {
-          expect(fakes.validate.getCall(0).args[0]).to.have.property("key", "myKeyData");
+        it('contains the key data', function () {
+          expect(fakes.validate.getCall(0).args[0]).to.have.property('key', 'myKeyData');
         });
 
-        it("contains the certificate data", function() {
-          expect(fakes.validate.getCall(0).args[0]).to.have.property("cert", "myCertData");
+        it('contains the certificate data', function () {
+          expect(fakes.validate.getCall(0).args[0]).to.have.property('cert', 'myCertData');
         });
 
-        it("includes passphrase", function() {
-          expect(fakes.validate.getCall(0).args[0]).to.have.property("passphrase", "apntest");
+        it('includes passphrase', function () {
+          expect(fakes.validate.getCall(0).args[0]).to.have.property('passphrase', 'apntest');
         });
       });
     });
 
-    describe("resolution value", function() {
-
-      it("contains the PFX data", function() {
-        return expect(credentials).to.have.property("pfx", "myPfxData");
+    describe('resolution value', function () {
+      it('contains the PFX data', function () {
+        return expect(credentials).to.have.property('pfx', 'myPfxData');
       });
 
-      it("contains the key data", function() {
-        return expect(credentials).to.have.property("key", "myKeyData");
+      it('contains the key data', function () {
+        return expect(credentials).to.have.property('key', 'myKeyData');
       });
 
-      it("contains the certificate data", function() {
-        return expect(credentials).to.have.property("cert", "myCertData");
+      it('contains the certificate data', function () {
+        return expect(credentials).to.have.property('cert', 'myCertData');
       });
 
-      it("contains the CA data", function() {
-        return expect(credentials).to.have.deep.property("ca[0]", "myCaData");
+      it('contains the CA data', function () {
+        return expect(credentials).to.have.deep.property('ca[0]', 'myCaData');
       });
 
-      it("includes passphrase", function() {
-        return expect(credentials).to.have.property("passphrase", "apntest");
+      it('includes passphrase', function () {
+        return expect(credentials).to.have.property('passphrase', 'apntest');
       });
     });
   });
 
-  describe("credential file cannot be parsed", function() {
-    beforeEach(function() {
-      fakes.load.returns({ cert: "myCertData", key: "myKeyData" });
-      fakes.parse.throws(new Error("unable to parse key"));
+  describe('credential file cannot be parsed', function () {
+    beforeEach(function () {
+      fakes.load.returns({ cert: 'myCertData', key: 'myKeyData' });
+      fakes.parse.throws(new Error('unable to parse key'));
     });
 
-    it("should resolve with the credentials", function() {
-      let credentials = prepareCertificate({ cert: "myUnparseableCert.pem", key: "myUnparseableKey.pem", production: true });
-      return expect(credentials).to.deep.equal({ cert: "myCertData", key: "myKeyData" });
+    it('should resolve with the credentials', function () {
+      const credentials = prepareCertificate({
+        cert: 'myUnparseableCert.pem',
+        key: 'myUnparseableKey.pem',
+        production: true,
+      });
+      return expect(credentials).to.deep.equal({ cert: 'myCertData', key: 'myKeyData' });
     });
 
-    it("should log an error", function() {
-      prepareCertificate({ cert: "myUnparseableCert.pem", key: "myUnparseableKey.pem" });
+    it('should log an error', function () {
+      prepareCertificate({ cert: 'myUnparseableCert.pem', key: 'myUnparseableKey.pem' });
 
-      expect(fakes.logger).to.be.calledWith(sinon.match(function(err) {
+      expect(fakes.logger).to.be.calledWith(
+        sinon.match(function (err) {
           return err.message ? err.message.match(/unable to parse key/) : false;
-        }, "\"unable to parse key\""));
+        }, '"unable to parse key"')
+      );
     });
 
-    it("should not attempt to validate", function() {
-      prepareCertificate({ cert: "myUnparseableCert.pem", key: "myUnparseableKey.pem" });
+    it('should not attempt to validate', function () {
+      prepareCertificate({ cert: 'myUnparseableCert.pem', key: 'myUnparseableKey.pem' });
       expect(fakes.validate).to.not.be.called;
     });
   });
 
-  describe("credential validation fails", function() {
-    it("should throw", function() {
-      fakes.load.returns(Promise.resolve({ cert: "myCertData", key: "myMismatchedKeyData" }));
+  describe('credential validation fails', function () {
+    it('should throw', function () {
+      fakes.load.returns(Promise.resolve({ cert: 'myCertData', key: 'myMismatchedKeyData' }));
       fakes.parse.returnsArg(0);
-      fakes.validate.throws(new Error("certificate and key do not match"));
+      fakes.validate.throws(new Error('certificate and key do not match'));
 
-      return expect(() => prepareCertificate({ cert: "myCert.pem", key: "myMistmatchedKey.pem" })).to.throw(/certificate and key do not match/);
+      return expect(() =>
+        prepareCertificate({ cert: 'myCert.pem', key: 'myMistmatchedKey.pem' })
+      ).to.throw(/certificate and key do not match/);
     });
   });
 
-  describe("credential file cannot be loaded", function() {
-    it("should throw", function() {
-      fakes.load.throws(new Error("ENOENT, no such file or directory"));
+  describe('credential file cannot be loaded', function () {
+    it('should throw', function () {
+      fakes.load.throws(new Error('ENOENT, no such file or directory'));
 
-      return expect(() => prepareCertificate({ cert: "noSuchFile.pem", key: "myKey.pem" })).to.throw("ENOENT, no such file or directory");
+      return expect(() =>
+        prepareCertificate({ cert: 'noSuchFile.pem', key: 'myKey.pem' })
+      ).to.throw('ENOENT, no such file or directory');
     });
   });
 });

--- a/test/credentials/certificate/validate.js
+++ b/test/credentials/certificate/validate.js
@@ -1,129 +1,130 @@
-"use strict";
-
-const sinon = require("sinon");
-const validateCredentials = require("../../../lib/credentials/certificate/validate");
+const sinon = require('sinon');
+const validateCredentials = require('../../../lib/credentials/certificate/validate');
 
 let fakeCredentials;
 
-describe("validateCredentials", function() {
+describe('validateCredentials', function () {
   let credentials;
-  beforeEach(function() {
+  beforeEach(function () {
     credentials = fakeCredentials();
   });
 
-  describe("with valid credentials", function() {
-    it("returns", function() {
-      expect(function() {
+  describe('with valid credentials', function () {
+    it('returns', function () {
+      expect(function () {
         validateCredentials(credentials);
       }).to.not.throw();
     });
   });
 
-  describe("with mismatched key and certificate", function() {
-    it("throws", function() {
-      sinon.stub(credentials.certificates[0]._key, "fingerprint").returns("fingerprint2");
+  describe('with mismatched key and certificate', function () {
+    it('throws', function () {
+      sinon.stub(credentials.certificates[0]._key, 'fingerprint').returns('fingerprint2');
 
-      expect(function() {
+      expect(function () {
         validateCredentials(credentials);
       }).to.throw(/certificate and key do not match/);
     });
   });
 
-  describe("with expired certificate", function() {
-    it("throws", function() {
-      sinon.stub(credentials.certificates[0], "validity")
-        .returns({
-          notBefore: new Date(Date.now() - 100000),
-          notAfter: new Date(Date.now() - 10000)
-        });
+  describe('with expired certificate', function () {
+    it('throws', function () {
+      sinon.stub(credentials.certificates[0], 'validity').returns({
+        notBefore: new Date(Date.now() - 100000),
+        notAfter: new Date(Date.now() - 10000),
+      });
 
-      expect(function() {
+      expect(function () {
         validateCredentials(credentials);
       }).to.throw(/certificate has expired/);
     });
   });
 
-  describe("with incorrect environment", function() {
-    it("throws with sandbox cert in production", function() {
-      sinon.stub(credentials.certificates[0], "environment")
-        .returns({
-          production: false,
-          sandbox: true
-        });
+  describe('with incorrect environment', function () {
+    it('throws with sandbox cert in production', function () {
+      sinon.stub(credentials.certificates[0], 'environment').returns({
+        production: false,
+        sandbox: true,
+      });
 
-      expect(function() {
+      expect(function () {
         validateCredentials(credentials);
-      }).to.throw("certificate does not support configured environment, production: true");
+      }).to.throw('certificate does not support configured environment, production: true');
     });
 
-    it("throws with production cert in sandbox", function() {
-      sinon.stub(credentials.certificates[0], "environment")
-        .returns({
-          production: true,
-          sandbox: false
-        });
+    it('throws with production cert in sandbox', function () {
+      sinon.stub(credentials.certificates[0], 'environment').returns({
+        production: true,
+        sandbox: false,
+      });
       credentials.production = false;
 
-      expect(function() {
+      expect(function () {
         validateCredentials(credentials);
-      }).to.throw("certificate does not support configured environment, production: false");
+      }).to.throw('certificate does not support configured environment, production: false');
     });
   });
 
-  describe("with missing production flag", function() {
-    it("does not throw", function() {
-      sinon.stub(credentials.certificates[0], "environment")
-        .returns({
-          production: true,
-          sandbox: false
-        });
+  describe('with missing production flag', function () {
+    it('does not throw', function () {
+      sinon.stub(credentials.certificates[0], 'environment').returns({
+        production: true,
+        sandbox: false,
+      });
       credentials.production = undefined;
 
-      expect(function() {
+      expect(function () {
         validateCredentials(credentials);
       }).to.not.throw();
     });
   });
 
-  describe("with certificate supporting both environments", function() {
-    it("does not throw", function() {
-      sinon.stub(credentials.certificates[0], "environment")
-        .returns({
-          production: true,
-          sandbox: true
-        });
+  describe('with certificate supporting both environments', function () {
+    it('does not throw', function () {
+      sinon.stub(credentials.certificates[0], 'environment').returns({
+        production: true,
+        sandbox: true,
+      });
       credentials.production = false;
 
-      expect(function() {
+      expect(function () {
         validateCredentials(credentials);
       }).to.not.throw();
     });
   });
 });
 
-fakeCredentials = function() {
+fakeCredentials = function () {
   return {
     key: {
-      _fingerprint: "fingerprint1",
-      fingerprint: function() { return this._fingerprint; },
+      _fingerprint: 'fingerprint1',
+      fingerprint: function () {
+        return this._fingerprint;
+      },
     },
-    certificates: [{
-      _key: {
-        _fingerprint: "fingerprint1",
-        fingerprint: function() { return this._fingerprint; },
+    certificates: [
+      {
+        _key: {
+          _fingerprint: 'fingerprint1',
+          fingerprint: function () {
+            return this._fingerprint;
+          },
+        },
+        _validity: {
+          notBefore: new Date(Date.now() - 100000),
+          notAfter: new Date(Date.now() + 100000),
+        },
+        key: function () {
+          return this._key;
+        },
+        validity: function () {
+          return this._validity;
+        },
+        environment: function () {
+          return { production: true, sandbox: false };
+        },
       },
-      _validity: {
-        notBefore: new Date(Date.now() - 100000),
-        notAfter: new Date(Date.now() + 100000)
-      },
-      key: function() { return this._key; },
-      validity: function() {
-        return this._validity;
-      },
-      environment: function() {
-        return { production: true, sandbox: false };
-      }
-    }],
-    production: true
+    ],
+    production: true,
   };
 };

--- a/test/credentials/certificate/validate.js
+++ b/test/credentials/certificate/validate.js
@@ -1,7 +1,40 @@
 const sinon = require('sinon');
 const validateCredentials = require('../../../lib/credentials/certificate/validate');
 
-let fakeCredentials;
+const fakeCredentials = function () {
+  return {
+    key: {
+      _fingerprint: 'fingerprint1',
+      fingerprint: function () {
+        return this._fingerprint;
+      },
+    },
+    certificates: [
+      {
+        _key: {
+          _fingerprint: 'fingerprint1',
+          fingerprint: function () {
+            return this._fingerprint;
+          },
+        },
+        _validity: {
+          notBefore: new Date(Date.now() - 100000),
+          notAfter: new Date(Date.now() + 100000),
+        },
+        key: function () {
+          return this._key;
+        },
+        validity: function () {
+          return this._validity;
+        },
+        environment: function () {
+          return { production: true, sandbox: false };
+        },
+      },
+    ],
+    production: true,
+  };
+};
 
 describe('validateCredentials', function () {
   let credentials;
@@ -93,38 +126,3 @@ describe('validateCredentials', function () {
     });
   });
 });
-
-fakeCredentials = function () {
-  return {
-    key: {
-      _fingerprint: 'fingerprint1',
-      fingerprint: function () {
-        return this._fingerprint;
-      },
-    },
-    certificates: [
-      {
-        _key: {
-          _fingerprint: 'fingerprint1',
-          fingerprint: function () {
-            return this._fingerprint;
-          },
-        },
-        _validity: {
-          notBefore: new Date(Date.now() - 100000),
-          notAfter: new Date(Date.now() + 100000),
-        },
-        key: function () {
-          return this._key;
-        },
-        validity: function () {
-          return this._validity;
-        },
-        environment: function () {
-          return { production: true, sandbox: false };
-        },
-      },
-    ],
-    production: true,
-  };
-};

--- a/test/credentials/resolve.js
+++ b/test/credentials/resolve.js
@@ -1,46 +1,39 @@
-"use strict";
+const resolve = require('../../lib/credentials/resolve');
+const fs = require('fs');
 
-var resolve = require("../../lib/credentials/resolve");
-var fs = require("fs");
-
-describe("resolve", function() {
-  var pfx, cert, key;
+describe('resolve', function () {
+  let pfx, cert, key;
   before(function () {
-    pfx = fs.readFileSync("test/support/initializeTest.pfx");
-    cert = fs.readFileSync("test/support/initializeTest.crt");
-    key = fs.readFileSync("test/support/initializeTest.key");
+    pfx = fs.readFileSync('test/support/initializeTest.pfx');
+    cert = fs.readFileSync('test/support/initializeTest.crt');
+    key = fs.readFileSync('test/support/initializeTest.key');
   });
 
-  it("returns PEM string as supplied", function() {
-    expect(resolve(cert.toString()))
-      .to.be.a("string")
-      .and.to.equal(cert.toString());
+  it('returns PEM string as supplied', function () {
+    expect(resolve(cert.toString())).to.be.a('string').and.to.equal(cert.toString());
   });
 
-  it("returns Buffer as supplied", function() {
-    expect(resolve(pfx))
-      .to.satisfy(Buffer.isBuffer)
-      .and.to.equal(pfx);
+  it('returns Buffer as supplied', function () {
+    expect(resolve(pfx)).to.satisfy(Buffer.isBuffer).and.to.equal(pfx);
   });
 
-  describe("with file path", function() {
-    it("returns a Buffer for valid path", function() {
-      return expect(resolve("test/support/initializeTest.key"))
-             .to.satisfy(Buffer.isBuffer);
+  describe('with file path', function () {
+    it('returns a Buffer for valid path', function () {
+      return expect(resolve('test/support/initializeTest.key')).to.satisfy(Buffer.isBuffer);
     });
 
-    it("returns contents for value path", function () {
-      return expect(resolve("test/support/initializeTest.key")
-        .toString()).to.equal(key.toString());
+    it('returns contents for value path', function () {
+      return expect(resolve('test/support/initializeTest.key').toString()).to.equal(key.toString());
     });
 
-    it("throws for invalid path", function() {
-      return expect(() => { resolve("test/support/fail/initializeTest.key") })
-        .to.throw;
+    it('throws for invalid path', function () {
+      return expect(() => {
+        resolve('test/support/fail/initializeTest.key');
+      }).to.throw;
     });
   });
 
-  it("returns null/undefined as supplied", function() {
+  it('returns null/undefined as supplied', function () {
     expect(resolve(null)).to.be.null;
     expect(resolve()).to.be.undefined;
   });

--- a/test/credentials/token/prepare.js
+++ b/test/credentials/token/prepare.js
@@ -1,8 +1,6 @@
-"use strict";
+const sinon = require('sinon');
 
-const sinon = require("sinon");
-
-describe("perpareToken", function () {
+describe('perpareToken', function () {
   let fakes, prepareToken;
 
   beforeEach(function () {
@@ -12,40 +10,39 @@ describe("perpareToken", function () {
       decode: sinon.stub(),
     };
 
-    prepareToken = require("../../../lib/credentials/token/prepare")(fakes);
+    prepareToken = require('../../../lib/credentials/token/prepare')(fakes);
   });
 
   const testOptions = {
-    key: "key.pem",
-    keyId: "123KeyId",
-    teamId: "abcTeamId",
+    key: 'key.pem',
+    keyId: '123KeyId',
+    teamId: 'abcTeamId',
   };
 
-  context("with valid options", function() {
+  context('with valid options', function () {
     let token;
 
-    beforeEach(function() {
-      fakes.resolve.withArgs("key.pem").returns("keyData");
-      fakes.sign.returns("generated-token");
+    beforeEach(function () {
+      fakes.resolve.withArgs('key.pem').returns('keyData');
+      fakes.sign.returns('generated-token');
 
       token = prepareToken(testOptions);
     });
 
-    describe("return value", function (){
-
-      describe("`current` property", function () {
-        it("is initialized to a signed token", function () {
-          expect(token.current).to.have.equal("generated-token");
+    describe('return value', function () {
+      describe('`current` property', function () {
+        it('is initialized to a signed token', function () {
+          expect(token.current).to.have.equal('generated-token');
         });
       });
 
-      describe("`generation` property", function () {
-        it("is initialized to 0", function () {
+      describe('`generation` property', function () {
+        it('is initialized to 0', function () {
           expect(token.generation).to.equal(0);
         });
       });
 
-      context("`regenerate` called with the current `generation` value", function () {
+      context('`regenerate` called with the current `generation` value', function () {
         let generation;
 
         beforeEach(function () {
@@ -54,35 +51,35 @@ describe("perpareToken", function () {
           token.generation = generation;
 
           fakes.sign.reset();
-          fakes.sign.onCall(0).returns("second-token");
+          fakes.sign.onCall(0).returns('second-token');
 
           token.regenerate(generation);
         });
 
-        it("increments `generation` property", function () {
+        it('increments `generation` property', function () {
           expect(token.generation).to.equal(generation + 1);
         });
 
-        it("invokes the sign method with the correct arguments", function (){
+        it('invokes the sign method with the correct arguments', function () {
           expect(fakes.sign).to.have.been.calledWith(
             sinon.match({}), // empty payload
-            "keyData", 
+            'keyData',
             sinon.match({
-              algorithm: "ES256",
-              issuer: "abcTeamId",
+              algorithm: 'ES256',
+              issuer: 'abcTeamId',
               header: sinon.match({
-                kid: "123KeyId",
+                kid: '123KeyId',
               }),
             })
           );
         });
 
-        it("updates the `current` property to the return value of the sign method", function () {
-          expect(token.current).to.equal("second-token");
+        it('updates the `current` property to the return value of the sign method', function () {
+          expect(token.current).to.equal('second-token');
         });
       });
 
-      context("`regenerate` called with a lower `generation` value", function () {
+      context('`regenerate` called with a lower `generation` value', function () {
         let generation;
 
         beforeEach(function () {
@@ -91,67 +88,70 @@ describe("perpareToken", function () {
           token.generation = generation;
 
           fakes.sign.reset();
-          fakes.sign.onCall(0).returns("second-token");
+          fakes.sign.onCall(0).returns('second-token');
 
           token.regenerate(generation - 1);
         });
 
-        it("does not increment `generation` property", function () {
+        it('does not increment `generation` property', function () {
           expect(token.generation).to.equal(generation);
         });
 
-        it("does not invoke the sign method", function () {
+        it('does not invoke the sign method', function () {
           expect(fakes.sign).to.have.not.been.called;
         });
 
-        it("does not change the `current` property", function () {
-          expect(token.current).to.equal("generated-token");
+        it('does not change the `current` property', function () {
+          expect(token.current).to.equal('generated-token');
         });
       });
 
-      context("`isExpired` called with expired token", function () {
+      context('`isExpired` called with expired token', function () {
         let token;
         beforeEach(function () {
-          fakes.resolve.withArgs("key.pem").returns("keyData");
-          fakes.decode.onCall(0).returns({iat:Math.floor(Date.now() / 1000)-1});
+          fakes.resolve.withArgs('key.pem').returns('keyData');
+          fakes.decode.onCall(0).returns({ iat: Math.floor(Date.now() / 1000) - 1 });
           token = prepareToken(testOptions);
         });
 
-        it("token is not expired", function () {
+        it('token is not expired', function () {
           expect(token.isExpired(0)).to.equal(true);
         });
       });
 
-      context("`isExpired` called with valid token", function () {
+      context('`isExpired` called with valid token', function () {
         let token;
         beforeEach(function () {
-          fakes.resolve.withArgs("key.pem").returns("keyData");
-          fakes.decode.onCall(0).returns({iat:Math.floor(Date.now() / 1000)});
+          fakes.resolve.withArgs('key.pem').returns('keyData');
+          fakes.decode.onCall(0).returns({ iat: Math.floor(Date.now() / 1000) });
           token = prepareToken(testOptions);
         });
 
-        it("token is not expired", function () {
+        it('token is not expired', function () {
           expect(token.isExpired(5)).to.equal(false);
         });
       });
-      
     });
   });
 
-  context("with bad `key` parameter", function () {
-    context("key resolution fails", function () {
-      it("throws a wrapped error", function () {
-        fakes.resolve.withArgs("key.pem").throws(new Error("ENOENT: Unable to read file key.pem"));
+  context('with bad `key` parameter', function () {
+    context('key resolution fails', function () {
+      it('throws a wrapped error', function () {
+        fakes.resolve.withArgs('key.pem').throws(new Error('ENOENT: Unable to read file key.pem'));
 
-        expect(() => prepareToken(testOptions)).to.throw(/Failed loading token key: ENOENT: Unable to read file key.pem/);
+        expect(() => prepareToken(testOptions)).to.throw(
+          /Failed loading token key: ENOENT: Unable to read file key.pem/
+        );
       });
     });
 
-    context("key cannot be used for signing", function () {
-      it("throws a wrapped error from jwt.sign", function () {
-        fakes.sign.throws(new Error("Unable to sign token"));
+    context('key cannot be used for signing', function () {
+      it('throws a wrapped error from jwt.sign', function () {
+        fakes.sign.throws(new Error('Unable to sign token'));
 
-        expect(() => prepareToken(testOptions)).to.throw(/Failed to generate token: Unable to sign token/);
+        expect(() => prepareToken(testOptions)).to.throw(
+          /Failed to generate token: Unable to sign token/
+        );
       });
     });
   });

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -3,7 +3,6 @@
 
 const VError = require('verror');
 const http2 = require('http2');
-const util = require('util');
 
 const debug = require('debug')('apn');
 const credentials = require('../lib/credentials')({

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -1,31 +1,30 @@
-"use strict";
 // Tests of MultiClient, copied from test/client.js with modifications of
 // expected connection counts.
 
-const VError = require("verror");
-const http2 = require("http2");
-const util = require("util");
+const VError = require('verror');
+const http2 = require('http2');
+const util = require('util');
 
-const debug = require("debug")("apn");
-const credentials = require("../lib/credentials")({
-  logger: debug
+const debug = require('debug')('apn');
+const credentials = require('../lib/credentials')({
+  logger: debug,
 });
 
 const TEST_PORT = 30939;
 const LOAD_TEST_BATCH_SIZE = 2000;
 
-const config = require("../lib/config")({
+const config = require('../lib/config')({
   logger: debug,
-  prepareCertificate: () => ({}),  // credentials.certificate,
+  prepareCertificate: () => ({}), // credentials.certificate,
   prepareToken: credentials.token,
   prepareCA: credentials.ca,
 });
-const Client = require("../lib/client")({
+const Client = require('../lib/client')({
   logger: debug,
   config,
   http2,
 });
-const MultiClient = require("../lib/multiclient")({
+const MultiClient = require('../lib/multiclient')({
   Client,
 });
 debug.log = console.log.bind(console);
@@ -60,7 +59,7 @@ debug.log = console.log.bind(console);
 // and if a test case crashes, then others may get stuck.
 //
 // Try to fix this if any issues come up.
-describe("MultiClient", () => {
+describe('MultiClient', () => {
   let server;
   let client;
   const MOCK_BODY = '{"mock-key":"mock-value"}';
@@ -71,12 +70,12 @@ describe("MultiClient", () => {
   // (It's probably possible to allow accepting invalid certificates instead,
   // but that's not the most important point of these tests)
   const createClient = (port, timeout = 500) => {
-    let mc = new MultiClient({
+    const mc = new MultiClient({
       port: TEST_PORT,
       address: '127.0.0.1',
       clientCount: 2,
     });
-    mc.clients.forEach((c) => {
+    mc.clients.forEach(c => {
       c._mockOverrideUrl = `http://127.0.0.1:${port}`;
       c.config.port = port;
       c.config.address = '127.0.0.1';
@@ -87,15 +86,15 @@ describe("MultiClient", () => {
   // Create an insecure server for unit testing.
   const createAndStartMockServer = (port, cb) => {
     server = http2.createServer((req, res) => {
-      var buffers = [];
-      req.on('data', (data) => buffers.push(data));
+      const buffers = [];
+      req.on('data', data => buffers.push(data));
       req.on('end', () => {
         const requestBody = Buffer.concat(buffers).toString('utf-8');
         cb(req, res, requestBody);
       });
     });
     server.listen(port);
-    server.on('error', (err) => {
+    server.on('error', err => {
       expect.fail(`unexpected error ${err}`);
     });
     // Don't block the tests if this server doesn't shut down properly
@@ -106,7 +105,7 @@ describe("MultiClient", () => {
     server = http2.createServer();
     server.on('stream', cb);
     server.listen(port);
-    server.on('error', (err) => {
+    server.on('error', err => {
       expect.fail(`unexpected error ${err}`);
     });
     // Don't block the tests if this server doesn't shut down properly
@@ -114,8 +113,8 @@ describe("MultiClient", () => {
     return server;
   };
 
-  afterEach((done) => {
-    let closeServer = () => {
+  afterEach(done => {
+    const closeServer = () => {
       if (server) {
         server.close();
         server = null;
@@ -130,17 +129,20 @@ describe("MultiClient", () => {
     }
   });
 
-  it("rejects invalid clientCount", () => {
-    [-1, 'invalid'].forEach((clientCount) => {
-      expect(() => new MultiClient({
-        port: TEST_PORT,
-        address: '127.0.0.1',
-        clientCount,
-      })).to.throw(`Expected positive client count but got ${clientCount}`);
+  it('rejects invalid clientCount', () => {
+    [-1, 'invalid'].forEach(clientCount => {
+      expect(
+        () =>
+          new MultiClient({
+            port: TEST_PORT,
+            address: '127.0.0.1',
+            clientCount,
+          })
+      ).to.throw(`Expected positive client count but got ${clientCount}`);
     });
   });
 
-  it("Treats HTTP 200 responses as successful", async () => {
+  it('Treats HTTP 200 responses as successful', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     let requestsServed = 0;
@@ -160,22 +162,19 @@ describe("MultiClient", () => {
       requestsServed += 1;
       didRequest = true;
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
 
     const runSuccessfulRequest = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({ device: MOCK_DEVICE_TOKEN });
       expect(didRequest).to.be.true;
     };
@@ -196,7 +195,7 @@ describe("MultiClient", () => {
   });
 
   // Assert that this doesn't crash when a large batch of requests are requested simultaneously
-  it("Treats HTTP 200 responses as successful (load test for a batch of requests)", async function () {
+  it('Treats HTTP 200 responses as successful (load test for a batch of requests)', async function () {
     this.timeout(10000);
     let establishedConnections = 0;
     let requestsServed = 0;
@@ -216,22 +215,19 @@ describe("MultiClient", () => {
         requestsServed += 1;
       }, 100);
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT, 1500);
 
     const runSuccessfulRequest = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({ device: MOCK_DEVICE_TOKEN });
     };
     expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
@@ -248,7 +244,7 @@ describe("MultiClient", () => {
   });
 
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
-  it("JSON decodes HTTP 400 responses", async () => {
+  it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -259,33 +255,34 @@ describe("MultiClient", () => {
       res.end('{"reason": "BadDeviceToken"}');
       didRequest = true;
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
     const infoMessages = [];
     const errorMessages = [];
-    const mockInfoLogger = (message) => { infoMessages.push(message); };
-    const mockErrorLogger = (message) => { errorMessages.push(message); };
+    const mockInfoLogger = message => {
+      infoMessages.push(message);
+    };
+    const mockErrorLogger = message => {
+      errorMessages.push(message);
+    };
     mockInfoLogger.enabled = true;
     mockErrorLogger.enabled = true;
     client.setLogger(mockInfoLogger, mockErrorLogger);
 
     const runRequestWithBadDeviceToken = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         response: {
-          "reason": "BadDeviceToken",
+          reason: 'BadDeviceToken',
         },
         status: 400,
       });
@@ -297,16 +294,16 @@ describe("MultiClient", () => {
     expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
     expect(infoMessages).to.deep.equal([
       'Session connected',
-      "Request ended with status 400 and responseData: {\"reason\": \"BadDeviceToken\"}",
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
       'Session connected',
-      "Request ended with status 400 and responseData: {\"reason\": \"BadDeviceToken\"}",
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
 
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
-  it("Closes connections when HTTP 500 responses are received", async () => {
+  it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     let responseDelay = 50;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -317,22 +314,19 @@ describe("MultiClient", () => {
         res.end('{"reason": "InternalServerError"}');
       }, responseDelay);
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.exist;
       expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
       expect(result.error).to.be.an.instanceof(VError);
@@ -354,9 +348,9 @@ describe("MultiClient", () => {
     expect(establishedConnections).to.equal(5); // should close and establish new connections on http 500
   });
 
-  it("Handles unexpected invalid JSON responses", async () => {
+  it('Handles unexpected invalid JSON responses', async () => {
     let establishedConnections = 0;
-    let responseDelay = 0;
+    const responseDelay = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
       // Wait 50ms before sending the responses in parallel
       setTimeout(() => {
@@ -365,32 +359,31 @@ describe("MultiClient", () => {
         res.end('PC LOAD LETTER');
       }, responseDelay);
     });
-    server.on('connection', () => establishedConnections += 1);
-    await new Promise((resolve) => server.on('listening', resolve));
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
 
     client = createClient(TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
-      const mockHeaders = {'apns-someheader': 'somevalue'};
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
         headers: mockHeaders,
         body: MOCK_BODY,
       };
       const mockDevice = MOCK_DEVICE_TOKEN;
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       // Should not happen, but if it does, the promise should resolve with an error
       expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
-      expect(result.error.message).to.equal('Unexpected error processing APNs response: Unexpected token P in JSON at position 0');
+      expect(result.error.message).to.equal(
+        'Unexpected error processing APNs response: Unexpected token P in JSON at position 0'
+      );
     };
     await runRequestWithInternalServerError();
     await runRequestWithInternalServerError();
     expect(establishedConnections).to.equal(2); // Currently reuses the connections.
   });
 
-  it("Handles APNs timeouts", async () => {
+  it('Handles APNs timeouts', async () => {
     let didGetRequest = false;
     let didGetResponse = false;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -403,20 +396,17 @@ describe("MultiClient", () => {
     });
     client = createClient(TEST_PORT);
 
-    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
 
-    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
     const mockNotification = {
       headers: mockHeaders,
       body: MOCK_BODY,
     };
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingTimeout = async () => {
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         error: new VError('apn write timeout'),
@@ -436,32 +426,29 @@ describe("MultiClient", () => {
     ]);
   });
 
-  it("Handles goaway frames", async () => {
+  it('Handles goaway frames', async () => {
     let didGetRequest = false;
     let establishedConnections = 0;
-    server = createAndStartMockLowLevelServer(TEST_PORT, (stream) => {
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
       const session = stream.session;
       const errorCode = 1;
       didGetRequest = true;
       session.goaway(errorCode);
     });
-    server.on('connection', () => establishedConnections += 1);
+    server.on('connection', () => (establishedConnections += 1));
     client = createClient(TEST_PORT);
 
-    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
 
-    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
     const mockNotification = {
       headers: mockHeaders,
       body: MOCK_BODY,
     };
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingGoAway = async () => {
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         error: new VError('stream ended unexpectedly with status null and empty body'),
@@ -474,11 +461,11 @@ describe("MultiClient", () => {
     expect(establishedConnections).to.equal(2);
   });
 
-  it("Handles unexpected protocol errors (no response sent)", async () => {
+  it('Handles unexpected protocol errors (no response sent)', async () => {
     let didGetRequest = false;
     let establishedConnections = 0;
     let responseTimeout = 0;
-    server = createAndStartMockLowLevelServer(TEST_PORT, (stream) => {
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
       setTimeout(() => {
         const session = stream.session;
         didGetRequest = true;
@@ -487,23 +474,20 @@ describe("MultiClient", () => {
         }
       }, responseTimeout);
     });
-    server.on('connection', () => establishedConnections += 1);
+    server.on('connection', () => (establishedConnections += 1));
     client = createClient(TEST_PORT);
 
-    const onListeningPromise = new Promise((resolve) => server.on('listening', resolve));;
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
 
-    const mockHeaders = {'apns-someheader': 'somevalue'};
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
     const mockNotification = {
       headers: mockHeaders,
       body: MOCK_BODY,
     };
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingDisconnect = async () => {
-      const result = await client.write(
-        mockNotification,
-        mockDevice,
-      );
+      const result = await client.write(mockNotification, mockDevice);
       expect(result).to.deep.equal({
         device: MOCK_DEVICE_TOKEN,
         error: new VError('stream ended unexpectedly with status null and empty body'),
@@ -566,34 +550,27 @@ describe("MultiClient", () => {
   //   });
   // });
 
-  describe("write", () => {
+  describe('write', () => {
     // beforeEach(() => {
     //   fakes.config.returnsArg(0);
     //   fakes.endpointManager.getStream = sinon.stub();
-
     //   fakes.EndpointManager.returns(fakes.endpointManager);
     // });
-
     // context("a stream is available", () => {
     //   let client;
-
     //   context("transmission succeeds", () => {
     //     beforeEach( () => {
     //       client = new MultiClient( { address: "testapi" } );
-
     //       fakes.stream = new FakeStream("abcd1234", "200");
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //     });
-
     //     it("attempts to acquire one stream", () => {
     //       return client.write(builtNotification(), "abcd1234")
     //         .then(() => {
     //           expect(fakes.endpointManager.getStream).to.be.calledOnce;
     //         });
     //     });
-
     //     describe("headers", () => {
-
     //       it("sends the required HTTP/2 headers", () => {
     //         return client.write(builtNotification(), "abcd1234")
     //           .then(() => {
@@ -605,7 +582,6 @@ describe("MultiClient", () => {
     //             });
     //           });
     //       });
-
     //       it("does not include apns headers when not required", () => {
     //         return client.write(builtNotification(), "abcd1234")
     //           .then(() => {
@@ -614,17 +590,14 @@ describe("MultiClient", () => {
     //             });
     //           });
     //       });
-
     //       it("sends the notification-specific apns headers when specified", () => {
     //         let notification = builtNotification();
-
     //         notification.headers = {
     //           "apns-id": "123e4567-e89b-12d3-a456-42665544000",
     //           "apns-priority": 5,
     //           "apns-expiration": 123,
     //           "apns-topic": "io.apn.node",
     //         };
-
     //         return client.write(notification, "abcd1234")
     //           .then(() => {
     //             expect(fakes.stream.headers).to.be.calledWithMatch( {
@@ -635,7 +608,6 @@ describe("MultiClient", () => {
     //             });
     //           });
     //       });
-
     //       context("when token authentication is enabled", () => {
     //         beforeEach(() => {
     //           fakes.token = {
@@ -644,16 +616,12 @@ describe("MultiClient", () => {
     //             regenerate: sinon.stub(),
     //             isExpired: sinon.stub()
     //           };
-
     //           client = new MultiClient( { address: "testapi", token: fakes.token } );
-
     //           fakes.stream = new FakeStream("abcd1234", "200");
     //           fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //         });
-
     //         it("sends the bearer token", () => {
     //           let notification = builtNotification();
-
     //           return client.write(notification, "abcd1234").then(() => {
     //             expect(fakes.stream.headers).to.be.calledWithMatch({
     //               authorization: "bearer fake-token",
@@ -661,25 +629,20 @@ describe("MultiClient", () => {
     //           });
     //         });
     //       });
-
     //       context("when token authentication is disabled", () => {
     //         beforeEach(() => {
     //           client = new MultiClient( { address: "testapi" } );
-
     //           fakes.stream = new FakeStream("abcd1234", "200");
     //           fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //         });
-
     //         it("does not set an authorization header", () => {
     //           let notification = builtNotification();
-
     //           return client.write(notification, "abcd1234").then(() => {
     //             expect(fakes.stream.headers.firstCall.args[0]).to.not.have.property("authorization");
     //           })
     //         });
     //       })
     //     });
-
     //     it("writes the notification data to the pipe", () => {
     //       const notification = builtNotification();
     //       return client.write(notification, "abcd1234")
@@ -687,7 +650,6 @@ describe("MultiClient", () => {
     //           expect(fakes.stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(notification.body)));
     //         });
     //     });
-
     //     it("ends the stream", () => {
     //       sinon.spy(fakes.stream, "end");
     //       return client.write(builtNotification(), "abcd1234")
@@ -695,31 +657,24 @@ describe("MultiClient", () => {
     //           expect(fakes.stream.end).to.be.calledOnce;
     //         });
     //     });
-
     //     it("resolves with the device token", () => {
     //       return expect(client.write(builtNotification(), "abcd1234"))
     //         .to.become({ device: "abcd1234" });
     //     });
     //   });
-
     //   context("error occurs", () => {
     //     let promise;
-
     //     context("general case", () => {
     //       beforeEach(() => {
     //         const client = new MultiClient( { address: "testapi" } );
-
     //         fakes.stream = new FakeStream("abcd1234", "400", { "reason" : "BadDeviceToken" });
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //         promise = client.write(builtNotification(), "abcd1234");
     //       });
-
     //       it("resolves with the device token, status code and response", () => {
     //         return expect(promise).to.eventually.deep.equal({ status: "400", device: "abcd1234", response: { reason: "BadDeviceToken" }});
     //       });
     //     })
-
     //     context("ExpiredProviderToken", () => {
     //       beforeEach(() => {
     //         let tokenGenerator = sinon.stub().returns("fake-token");
@@ -727,28 +682,21 @@ describe("MultiClient", () => {
     //       })
     //     });
     //   });
-
     //   context("stream ends without completing request", () => {
     //     let promise;
-
     //     beforeEach(() => {
     //       const client = new MultiClient( { address: "testapi" } );
     //       fakes.stream = new stream.Transform({
     //         transform: function(chunk, encoding, callback) {}
     //       });
     //       fakes.stream.headers = sinon.stub();
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       promise = client.write(builtNotification(), "abcd1234");
-
     //       fakes.stream.push(null);
     //     });
-
     //     it("resolves with an object containing the device token", () => {
     //       return expect(promise).to.eventually.have.property("device", "abcd1234");
     //     });
-
     //     it("resolves with an object containing an error", () => {
     //       return promise.then( (response) => {
     //         expect(response).to.have.property("error");
@@ -757,65 +705,50 @@ describe("MultiClient", () => {
     //       });
     //     });
     //   });
-
     //   context("stream is unprocessed", () => {
     //     let promise;
-
     //     beforeEach(() => {
     //       const client = new MultiClient( { address: "testapi" } );
     //       fakes.stream = new stream.Transform({
     //         transform: function(chunk, encoding, callback) {}
     //       });
     //       fakes.stream.headers = sinon.stub();
-
     //       fakes.secondStream = FakeStream("abcd1234", "200");
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.secondStream);
-
     //       promise = client.write(builtNotification(), "abcd1234");
-
     //       setImmediate(() => {
     //         fakes.stream.emit("unprocessed");
     //       });
     //     });
-
     //     it("attempts to resend on a new stream", function (done) {
     //       setImmediate(() => {
     //         expect(fakes.endpointManager.getStream).to.be.calledTwice;
     //         done();
     //       });
     //     });
-
     //     it("fulfills the promise", () => {
     //       return expect(promise).to.eventually.deep.equal({ device: "abcd1234"  });
     //     });
     //   });
-
     //   context("stream error occurs", () => {
     //     let promise;
-
     //     beforeEach(() => {
     //       const client = new MultiClient( { address: "testapi" } );
     //       fakes.stream = new stream.Transform({
     //         transform: function(chunk, encoding, callback) {}
     //       });
     //       fakes.stream.headers = sinon.stub();
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       promise = client.write(builtNotification(), "abcd1234");
     //     });
-
     //     context("passing an Error", () => {
     //       beforeEach(() => {
     //         fakes.stream.emit("error", new Error("stream error"));
     //       });
-
     //       it("resolves with an object containing the device token", () => {
     //         return expect(promise).to.eventually.have.property("device", "abcd1234");
     //       });
-
     //       it("resolves with an object containing a wrapped error", () => {
     //         return promise.then( (response) => {
     //           expect(response.error).to.be.an.instanceOf(Error);
@@ -824,7 +757,6 @@ describe("MultiClient", () => {
     //         });
     //       });
     //     });
-
     //     context("passing a string", () => {
     //       it("resolves with the device token and an error", () => {
     //         fakes.stream.emit("error", "stream error");
@@ -838,27 +770,19 @@ describe("MultiClient", () => {
     //     });
     //   });
     // });
-
     // context("no new stream is returned but the endpoint later wakes up", () => {
     //   let notification, promise;
-
     //   beforeEach( () => {
     //     const client = new MultiClient( { address: "testapi" } );
-
     //     fakes.stream = new FakeStream("abcd1234", "200");
     //     fakes.endpointManager.getStream.onCall(0).returns(null);
     //     fakes.endpointManager.getStream.onCall(1).returns(fakes.stream);
-
     //     notification = builtNotification();
     //     promise = client.write(notification, "abcd1234");
-
     //     expect(fakes.stream.headers).to.not.be.called;
-
     //     fakes.endpointManager.emit("wakeup");
-
     //     return promise;
     //   });
-
     //   it("sends the required headers to the newly available stream", () => {
     //     expect(fakes.stream.headers).to.be.calledWithMatch( {
     //       ":scheme": "https",
@@ -867,14 +791,11 @@ describe("MultiClient", () => {
     //       ":path": "/3/device/abcd1234",
     //     });
     //   });
-
     //   it("writes the notification data to the pipe", () => {
     //     expect(fakes.stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(notification.body)));
     //   });
     // });
-
     // context("when 5 successive notifications are sent", () => {
-
     //   beforeEach(() => {
     //       fakes.streams = [
     //         new FakeStream("abcd1234", "200"),
@@ -884,19 +805,15 @@ describe("MultiClient", () => {
     //         new FakeStream("aabbc788", "413", { reason: "PayloadTooLarge" }),
     //       ];
     //   });
-
     //   context("streams are always returned", () => {
     //     let promises;
-
     //     beforeEach( () => {
     //       const client = new MultiClient( { address: "testapi" } );
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
     //       fakes.endpointManager.getStream.onCall(3).returns(fakes.streams[3]);
     //       fakes.endpointManager.getStream.onCall(4).returns(fakes.streams[4]);
-
     //       promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
@@ -904,10 +821,8 @@ describe("MultiClient", () => {
     //         client.write(builtNotification(), "bcfe4433"),
     //         client.write(builtNotification(), "aabbc788"),
     //       ]);
-
     //       return promises;
     //     });
-
     //     it("sends the required headers for each stream", () => {
     //       expect(fakes.streams[0].headers).to.be.calledWithMatch( { ":path": "/3/device/abcd1234" } );
     //       expect(fakes.streams[1].headers).to.be.calledWithMatch( { ":path": "/3/device/adfe5969" } );
@@ -915,13 +830,11 @@ describe("MultiClient", () => {
     //       expect(fakes.streams[3].headers).to.be.calledWithMatch( { ":path": "/3/device/bcfe4433" } );
     //       expect(fakes.streams[4].headers).to.be.calledWithMatch( { ":path": "/3/device/aabbc788" } );
     //     });
-
     //     it("writes the notification data for each stream", () => {
     //       fakes.streams.forEach( stream => {
     //         expect(stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(builtNotification().body)));
     //       });
     //     });
-
     //     it("resolves with the notification outcomes", () => {
     //       return expect(promises).to.eventually.deep.equal([
     //           { device: "abcd1234"},
@@ -932,16 +845,12 @@ describe("MultiClient", () => {
     //       ]);
     //     });
     //   });
-
     //   context("some streams return, others wake up later", () => {
     //     let promises;
-
     //     beforeEach( function() {
     //       const client = new MultiClient( { address: "testapi" } );
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
-
     //       promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
@@ -949,24 +858,20 @@ describe("MultiClient", () => {
     //         client.write(builtNotification(), "bcfe4433"),
     //         client.write(builtNotification(), "aabbc788"),
     //       ]);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[2]);
     //         fakes.endpointManager.getStream.onCall(1).returns(null);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 1);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
     //         fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 2);
-
     //       return promises;
     //     });
-
     //     it("sends the correct device ID for each stream", () => {
     //       expect(fakes.streams[0].headers).to.be.calledWithMatch({":path": "/3/device/abcd1234"});
     //       expect(fakes.streams[1].headers).to.be.calledWithMatch({":path": "/3/device/adfe5969"});
@@ -974,13 +879,11 @@ describe("MultiClient", () => {
     //       expect(fakes.streams[3].headers).to.be.calledWithMatch({":path": "/3/device/bcfe4433"});
     //       expect(fakes.streams[4].headers).to.be.calledWithMatch({":path": "/3/device/aabbc788"});
     //     });
-
     //     it("writes the notification data for each stream", () => {
     //       fakes.streams.forEach( stream => {
     //         expect(stream._transform).to.be.calledWithMatch(actual => actual.equals(Buffer.from(builtNotification().body)));
     //       });
     //     });
-
     //     it("resolves with the notification reponses", () => {
     //       return expect(promises).to.eventually.deep.equal([
     //           { device: "abcd1234"},
@@ -991,51 +894,40 @@ describe("MultiClient", () => {
     //       ]);
     //     });
     //   });
-
     //   context("connection fails", () => {
     //     let promises, client;
-
     //     beforeEach( function() {
     //       client = new MultiClient( { address: "testapi" } );
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
-
     //       promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
     //         client.write(builtNotification(), "abcd1335"),
     //       ]);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.emit("error", new Error("endpoint failed"));
     //       }, 1);
-
     //       return promises;
     //     });
-
     //     it("resolves with 1 success", () => {
     //       return promises.then( response => {
     //         expect(response[0]).to.deep.equal({ device: "abcd1234" });
     //       });
     //     });
-
     //     it("resolves with 2 errors", () => {
     //       return promises.then( response => {
     //         expect(response[1]).to.deep.equal({ device: "adfe5969", error: new Error("endpoint failed") });
     //         expect(response[2]).to.deep.equal({ device: "abcd1335", error: new Error("endpoint failed") });
     //       })
     //     });
-
     //     it("clears the queue", () => {
     //       return promises.then( () => {
     //         expect(client.queue.length).to.equal(0);
     //       });
     //     });
     //   });
-
     // });
-
     // describe("token generator behaviour", () => {
     //   beforeEach(() => {
     //     fakes.token = {
@@ -1044,26 +936,21 @@ describe("MultiClient", () => {
     //       regenerate: sinon.stub(),
     //       isExpired: sinon.stub()
     //     }
-
     //     fakes.streams = [
     //       new FakeStream("abcd1234", "200"),
     //       new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
     //       new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
     //     ];
     //   });
-
     //   it("reuses the token", () => {
     //     const client = new MultiClient( { address: "testapi", token: fakes.token } );
-
     //     fakes.token.regenerate = () => {
     //       fakes.token.generation = 1;
     //       fakes.token.current = "second-token";
     //     }
-
     //     fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //     fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //     fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
-
     //     return Promise.all([
     //       client.write(builtNotification(), "abcd1234"),
     //       client.write(builtNotification(), "adfe5969"),
@@ -1074,9 +961,7 @@ describe("MultiClient", () => {
     //       expect(fakes.streams[2].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
     //     });
     //   });
-
     //   context("token expires", () => {
-
     //     beforeEach(() => {
     //       fakes.token.regenerate = function (generation) {
     //         if (generation === fakes.token.generation) {
@@ -1085,31 +970,24 @@ describe("MultiClient", () => {
     //         }
     //       }
     //     });
-
     //     it("resends the notification with a new token", () => {
     //       fakes.streams = [
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //         new FakeStream("adfe5969", "200"),
     //       ];
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
-
     //       const client = new MultiClient( { address: "testapi", token: fakes.token } );
-
     //       const promise = client.write(builtNotification(), "adfe5969");
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[1]);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 1);
-
     //       return promise.then(() => {
     //         expect(fakes.streams[0].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
     //         expect(fakes.streams[1].headers).to.be.calledWithMatch({ authorization: "bearer token-1" });
     //       });
     //     });
-
     //     it("only regenerates the token once per-expiry", () => {
     //       fakes.streams = [
     //         new FakeStream("abcd1234", "200"),
@@ -1118,26 +996,21 @@ describe("MultiClient", () => {
     //         new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
     //         new FakeStream("abcd1335", "410", { reason: "BadDeviceToken", timestamp: 123456789 }),
     //       ];
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
-
     //       const client = new MultiClient( { address: "testapi", token: fakes.token } );
-
     //       const promises = Promise.all([
     //         client.write(builtNotification(), "abcd1234"),
     //         client.write(builtNotification(), "adfe5969"),
     //         client.write(builtNotification(), "abcd1335"),
     //       ]);
-
     //       setTimeout(() => {
     //         fakes.endpointManager.getStream.reset();
     //         fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
     //         fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
     //         fakes.endpointManager.emit("wakeup");
     //       }, 1);
-
     //       return promises.then(() => {
     //         expect(fakes.streams[0].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
     //         expect(fakes.streams[1].headers).to.be.calledWithMatch({ authorization: "bearer fake-token" });
@@ -1146,80 +1019,64 @@ describe("MultiClient", () => {
     //         expect(fakes.streams[4].headers).to.be.calledWithMatch({ authorization: "bearer token-1" });
     //       });
     //     });
-
     //     it("abandons sending after 3 ExpiredProviderToken failures", () => {
     //       fakes.streams = [
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //         new FakeStream("adfe5969", "403", { reason: "ExpiredProviderToken" }),
     //       ];
-
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
     //       fakes.endpointManager.getStream.onCall(2).returns(fakes.streams[2]);
-
     //       const client = new MultiClient( { address: "testapi", token: fakes.token } );
-
     //       return expect(client.write(builtNotification(), "adfe5969")).to.eventually.have.property("status", "403");
     //     });
-
     //     it("regenerate token", () => {
     //       fakes.stream = new FakeStream("abcd1234", "200");
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       fakes.token.isExpired = function (current, validSeconds) {
     //         return true;
     //       }
-
     //       let client = new MultiClient({
     //         address: "testapi",
     //         token: fakes.token
     //       });
-
     //       return client.write(builtNotification(), "abcd1234")
     //         .then(() => {
     //           expect(fakes.token.generation).to.equal(1);
     //         });
     //     });
-
     //     it("internal server error", () => {
     //       fakes.stream = new FakeStream("abcd1234", "500", { reason: "InternalServerError" });
     //       fakes.stream.connection = sinon.stub();
     //       fakes.stream.connection.close = sinon.stub();
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.stream);
-
     //       let client = new MultiClient({
     //         address: "testapi",
     //         token: fakes.token
     //       });
-
     //       return expect(client.write(builtNotification(), "abcd1234")).to.eventually.have.deep.property("error.jse_shortmsg","Error 500, stream ended unexpectedly");
     //     });
     //   });
     // });
   });
 
-  describe("shutdown", () => {
+  describe('shutdown', () => {
     // beforeEach(() => {
     //   fakes.config.returnsArg(0);
     //   fakes.endpointManager.getStream = sinon.stub();
-
     //   fakes.EndpointManager.returns(fakes.endpointManager);
     // });
-
     // context("with no pending notifications", () => {
     //   it("invokes shutdown on endpoint manager", () => {
     //     let client = new MultiClient();
     //     client.shutdown();
-
     //     expect(fakes.endpointManager.shutdown).to.be.calledOnce;
     //   });
     // });
-
     // context("with pending notifications", () => {
     //   it("invokes shutdown on endpoint manager after queue drains", () => {
     //     let client = new MultiClient({ address: "none" });
-
     //     fakes.streams = [
     //       new FakeStream("abcd1234", "200"),
     //       new FakeStream("adfe5969", "400", { reason: "MissingTopic" }),
@@ -1227,10 +1084,8 @@ describe("MultiClient", () => {
     //       new FakeStream("bcfe4433", "200"),
     //       new FakeStream("aabbc788", "413", { reason: "PayloadTooLarge" }),
     //     ];
-
     //     fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[0]);
     //     fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[1]);
-
     //     let promises = Promise.all([
     //       client.write(builtNotification(), "abcd1234"),
     //       client.write(builtNotification(), "adfe5969"),
@@ -1238,25 +1093,20 @@ describe("MultiClient", () => {
     //       client.write(builtNotification(), "bcfe4433"),
     //       client.write(builtNotification(), "aabbc788"),
     //     ]);
-
     //     client.shutdown();
-
     //     expect(fakes.endpointManager.shutdown).to.not.be.called;
-
     //     setTimeout(() => {
     //       fakes.endpointManager.getStream.reset();
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[2]);
     //       fakes.endpointManager.getStream.onCall(1).returns(null);
     //       fakes.endpointManager.emit("wakeup");
     //     }, 1);
-
     //     setTimeout(() => {
     //       fakes.endpointManager.getStream.reset();
     //       fakes.endpointManager.getStream.onCall(0).returns(fakes.streams[3]);
     //       fakes.endpointManager.getStream.onCall(1).returns(fakes.streams[4]);
     //       fakes.endpointManager.emit("wakeup");
     //     }, 2);
-
     //     return promises.then( () => {
     //       expect(fakes.endpointManager.shutdown).to.have.been.called;
     //     });

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -1,773 +1,824 @@
-"use strict";
+const Notification = require('../../lib/notification');
 
-const Notification = require("../../lib/notification");
-
-describe("Notification", function() {
-
+describe('Notification', function () {
   let note;
-  beforeEach(function() {
+  beforeEach(function () {
     note = new Notification();
   });
 
-  describe("aps convenience properties", function() {
-    describe("alert", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.alert");
+  describe('aps convenience properties', function () {
+    describe('alert', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.alert');
       });
 
-      it("can be set to a string", function() {
-        note.alert = "hello";
-        expect(compiledOutput()).to.have.deep.property("aps.alert", "hello");
+      it('can be set to a string', function () {
+        note.alert = 'hello';
+        expect(compiledOutput()).to.have.deep.property('aps.alert', 'hello');
       });
 
-      it("can be set to an object", function() {
-        note.alert = {"body": "hello"};
-        expect(compiledOutput()).to.have.deep.property("aps.alert")
-          .that.deep.equals({"body": "hello"});
+      it('can be set to an object', function () {
+        note.alert = { body: 'hello' };
+        expect(compiledOutput())
+          .to.have.deep.property('aps.alert')
+          .that.deep.equals({ body: 'hello' });
       });
 
-      it("can be set to undefined", function() {
-        note.alert = {"body": "hello"};
+      it('can be set to undefined', function () {
+        note.alert = { body: 'hello' };
         note.alert = undefined;
-        expect(compiledOutput()).to.not.have.deep.property("aps.alert");
+        expect(compiledOutput()).to.not.have.deep.property('aps.alert');
       });
 
-      describe("setAlert", function () {
-        it("is chainable", function () {
-          expect(note.setAlert("hello")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert", "hello");
+      describe('setAlert', function () {
+        it('is chainable', function () {
+          expect(note.setAlert('hello')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.alert', 'hello');
         });
       });
     });
 
-    describe("body", function() {
-      it("defaults to undefined", function() {
+    describe('body', function () {
+      it('defaults to undefined', function () {
         expect(note.body).to.be.undefined;
       });
 
-      it("can be set to a string", function() {
-        note.body = "Hello, world";
-        expect(typeof compiledOutput().aps.alert).to.equal("string");
+      it('can be set to a string', function () {
+        note.body = 'Hello, world';
+        expect(typeof compiledOutput().aps.alert).to.equal('string');
       });
 
-      it("sets alert as a string by default", function () {
-        note.body = "Hello, world";
-        expect(compiledOutput()).to.have.deep.property("aps.alert", "Hello, world");
+      it('sets alert as a string by default', function () {
+        note.body = 'Hello, world';
+        expect(compiledOutput()).to.have.deep.property('aps.alert', 'Hello, world');
       });
 
-      context("alert is already an Object", function () {
+      context('alert is already an Object', function () {
         beforeEach(function () {
-          note.alert = {"body": "Existing Body"};
+          note.alert = { body: 'Existing Body' };
         });
 
-        it("reads the value from alert body", function () {
-          expect(note.body).to.equal("Existing Body");
+        it('reads the value from alert body', function () {
+          expect(note.body).to.equal('Existing Body');
         });
 
-        it("sets the value correctly", function () {
-          note.body = "Hello, world";
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
+        it('sets the value correctly', function () {
+          note.body = 'Hello, world';
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
         });
       });
 
-      describe("setBody", function () {
-        it("is chainable", function () {
-          expect(note.setBody("hello")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert", "hello");
+      describe('setBody', function () {
+        it('is chainable', function () {
+          expect(note.setBody('hello')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.alert', 'hello');
         });
       });
     });
 
-    describe("locKey", function () {
-      it("sets the aps.alert.loc-key property", function () {
-        note.locKey = "hello_world";
-        expect(compiledOutput()).to.have.deep.property("aps.alert.loc\-key", "hello_world");
+    describe('locKey', function () {
+      it('sets the aps.alert.loc-key property', function () {
+        note.locKey = 'hello_world';
+        expect(compiledOutput()).to.have.deep.property('aps.alert.loc-key', 'hello_world');
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.locKey = "hello_world";
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.locKey = 'hello_world';
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "loc-key": "hello_world"});
+        it('contains all expected properties', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+            body: 'Test',
+            'launch-image': 'test.png',
+            'loc-key': 'hello_world',
+          });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Good Morning";
-          note.locKey = "good_morning";
+          note.alert = 'Good Morning';
+          note.locKey = 'good_morning';
         });
 
-        it("retains the alert body correctly", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Good Morning");
+        it('retains the alert body correctly', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Good Morning');
         });
 
-        it("sets the aps.alert.loc-key property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.loc\-key", "good_morning");
+        it('sets the aps.alert.loc-key property', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.loc-key', 'good_morning');
         });
       });
 
-      describe("setLocKey", function () {
-        it("is chainable", function () {
-          expect(note.setLocKey("good_morning")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.loc\-key", "good_morning");
+      describe('setLocKey', function () {
+        it('is chainable', function () {
+          expect(note.setLocKey('good_morning')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.alert.loc-key', 'good_morning');
         });
       });
     });
 
-    describe("locArgs", function () {
-      it("sets the aps.alert.loc-args property", function () {
-        note.locArgs = ["arg1", "arg2"];
-        expect(compiledOutput()).to.have.deep.property("aps.alert.loc\-args")
-          .that.deep.equals(["arg1", "arg2"]);
+    describe('locArgs', function () {
+      it('sets the aps.alert.loc-args property', function () {
+        note.locArgs = ['arg1', 'arg2'];
+        expect(compiledOutput())
+          .to.have.deep.property('aps.alert.loc-args')
+          .that.deep.equals(['arg1', 'arg2']);
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.locArgs = ["Hi there"];
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.locArgs = ['Hi there'];
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "loc-args": ["Hi there"]});
+        it('contains all expected properties', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert')
+            .that.deep.equals({
+              body: 'Test',
+              'launch-image': 'test.png',
+              'loc-args': ['Hi there'],
+            });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Hello, world";
-          note.locArgs = ["Hi there"];
+          note.alert = 'Hello, world';
+          note.locArgs = ['Hi there'];
         });
 
-        it("retains the alert body", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
+        it('retains the alert body', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
         });
 
-        it("sets the aps.alert.loc-args property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.loc\-args")
-            .that.deep.equals(["Hi there"]);
+        it('sets the aps.alert.loc-args property', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert.loc-args')
+            .that.deep.equals(['Hi there']);
         });
       });
 
-      describe("setLocArgs", function () {
-        it("is chainable", function () {
-          expect(note.setLocArgs(["Robert"])).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.loc\-args")
-            .that.deep.equals(["Robert"]);
+      describe('setLocArgs', function () {
+        it('is chainable', function () {
+          expect(note.setLocArgs(['Robert'])).to.equal(note);
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert.loc-args')
+            .that.deep.equals(['Robert']);
         });
       });
     });
 
-    describe("title", function () {
-      it("sets the aps.alert.title property", function () {
-        note.title = "node-apn";
-        expect(compiledOutput()).to.have.deep.property("aps.alert.title", "node-apn");
+    describe('title', function () {
+      it('sets the aps.alert.title property', function () {
+        note.title = 'node-apn';
+        expect(compiledOutput()).to.have.deep.property('aps.alert.title', 'node-apn');
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.title = "node-apn";
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.title = 'node-apn';
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "title": "node-apn"});
+        it('contains all expected properties', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert')
+            .that.deep.equals({ body: 'Test', 'launch-image': 'test.png', title: 'node-apn' });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Hello, world";
-          note.title = "Welcome";
+          note.alert = 'Hello, world';
+          note.title = 'Welcome';
         });
 
-        it("retains the alert body", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
+        it('retains the alert body', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
         });
 
-        it("sets the aps.alert.title property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.title", "Welcome");
+        it('sets the aps.alert.title property', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.title', 'Welcome');
         });
       });
 
-      describe("setTitle", function () {
-        it("is chainable", function () {
-          expect(note.setTitle("Bienvenue")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.title", "Bienvenue");
+      describe('setTitle', function () {
+        it('is chainable', function () {
+          expect(note.setTitle('Bienvenue')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.alert.title', 'Bienvenue');
         });
       });
     });
 
-    describe("subtitle", function () {
-      it("sets the aps.alert.subtitle property", function () {
-        note.subtitle = "node-apn";
-        expect(compiledOutput()).to.have.deep.property("aps.alert.subtitle", "node-apn");
+    describe('subtitle', function () {
+      it('sets the aps.alert.subtitle property', function () {
+        note.subtitle = 'node-apn';
+        expect(compiledOutput()).to.have.deep.property('aps.alert.subtitle', 'node-apn');
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.subtitle = "node-apn";
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.subtitle = 'node-apn';
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "subtitle": "node-apn"});
+        it('contains all expected properties', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert')
+            .that.deep.equals({ body: 'Test', 'launch-image': 'test.png', subtitle: 'node-apn' });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Hello, world";
-          note.subtitle = "Welcome";
+          note.alert = 'Hello, world';
+          note.subtitle = 'Welcome';
         });
 
-        it("retains the alert body", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
+        it('retains the alert body', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
         });
 
-        it("sets the aps.alert.subtitle property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.subtitle", "Welcome");
+        it('sets the aps.alert.subtitle property', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.subtitle', 'Welcome');
         });
       });
 
-      describe("setSubtitle", function () {
-        it("is chainable", function () {
-          expect(note.setSubtitle("Bienvenue")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.subtitle", "Bienvenue");
+      describe('setSubtitle', function () {
+        it('is chainable', function () {
+          expect(note.setSubtitle('Bienvenue')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.alert.subtitle', 'Bienvenue');
         });
       });
     });
-    describe("titleLocKey", function () {
-      it("sets the aps.alert.title-loc-key property", function () {
-        note.titleLocKey = "Warning";
-        expect(compiledOutput()).to.have.deep.property("aps.alert.title\-loc\-key", "Warning");
+    describe('titleLocKey', function () {
+      it('sets the aps.alert.title-loc-key property', function () {
+        note.titleLocKey = 'Warning';
+        expect(compiledOutput()).to.have.deep.property('aps.alert.title-loc-key', 'Warning');
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.titleLocKey = "Warning";
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.titleLocKey = 'Warning';
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "title-loc-key": "Warning"});
+        it('contains all expected properties', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+            body: 'Test',
+            'launch-image': 'test.png',
+            'title-loc-key': 'Warning',
+          });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Hello, world";
-          note.titleLocKey = "Warning";
+          note.alert = 'Hello, world';
+          note.titleLocKey = 'Warning';
         });
 
-        it("retains the alert body correctly", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
+        it('retains the alert body correctly', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
         });
 
-        it("sets the aps.alert.title-loc-key property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.title\-loc\-key", "Warning");
-        });
-      });
-
-      describe("setAlert", function () {
-        it("is chainable", function () {
-          expect(note.setTitleLocKey("greeting")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.title\-loc\-key", "greeting");
-        });
-      });
-    });
-
-    describe("titleLocArgs", function () {
-      it("sets the aps.alert.title-loc-args property", function () {
-        note.titleLocArgs = ["arg1", "arg2"];
-        expect(compiledOutput()).to.have.deep.property("aps.alert.title\-loc\-args")
-          .that.deep.equals(["arg1", "arg2"]);
-      });
-
-      context("alert is already an object", function () {
-        beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.titleLocArgs = ["Hi there"];
-        });
-
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "title-loc-args": ["Hi there"]});
+        it('sets the aps.alert.title-loc-key property', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.title-loc-key', 'Warning');
         });
       });
 
-      context("alert is already a string", function () {
-        beforeEach(function () {
-          note.alert = "Hello, world";
-          note.titleLocArgs = ["Hi there"];
-        });
-
-        it("retains the alert body", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
-        });
-
-        it("sets the aps.alert.title-loc-args property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.title\-loc\-args")
-            .that.deep.equals(["Hi there"]);
-        });
-      });
-
-      describe("setTitleLocArgs", function () {
-        it("is chainable", function () {
-          expect(note.setTitleLocArgs(["iPhone 6s"])).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.title\-loc\-args")
-            .that.deep.equals(["iPhone 6s"]);
+      describe('setAlert', function () {
+        it('is chainable', function () {
+          expect(note.setTitleLocKey('greeting')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.alert.title-loc-key', 'greeting');
         });
       });
     });
 
-    describe("action", function () {
-      it("sets the aps.alert.action property", function () {
-        note.action = "View";
-        expect(compiledOutput()).to.have.deep.property("aps.alert.action", "View");
+    describe('titleLocArgs', function () {
+      it('sets the aps.alert.title-loc-args property', function () {
+        note.titleLocArgs = ['arg1', 'arg2'];
+        expect(compiledOutput())
+          .to.have.deep.property('aps.alert.title-loc-args')
+          .that.deep.equals(['arg1', 'arg2']);
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.action = "View";
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.titleLocArgs = ['Hi there'];
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "action": "View"});
+        it('contains all expected properties', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert')
+            .that.deep.equals({
+              body: 'Test',
+              'launch-image': 'test.png',
+              'title-loc-args': ['Hi there'],
+            });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Alert";
-          note.action = "Investigate";
+          note.alert = 'Hello, world';
+          note.titleLocArgs = ['Hi there'];
         });
 
-        it("retains the alert body", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Alert");
+        it('retains the alert body', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
         });
 
-        it("sets the aps.alert.action property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.action", "Investigate");
+        it('sets the aps.alert.title-loc-args property', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert.title-loc-args')
+            .that.deep.equals(['Hi there']);
         });
       });
 
-      describe("setAction", function () {
-        it("is chainable", function () {
-          expect(note.setAction("Reply")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.action", "Reply");
+      describe('setTitleLocArgs', function () {
+        it('is chainable', function () {
+          expect(note.setTitleLocArgs(['iPhone 6s'])).to.equal(note);
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert.title-loc-args')
+            .that.deep.equals(['iPhone 6s']);
         });
       });
     });
 
-    describe("actionLocKey", function () {
-      it("sets the aps.alert.action-loc-key property", function () {
-        note.actionLocKey = "reply_title";
-        expect(compiledOutput()).to.have.deep.property("aps.alert.action\-loc\-key", "reply_title");
+    describe('action', function () {
+      it('sets the aps.alert.action property', function () {
+        note.action = 'View';
+        expect(compiledOutput()).to.have.deep.property('aps.alert.action', 'View');
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "launch-image": "test.png"};
-          note.actionLocKey = "reply_title";
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.action = 'View';
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "launch-image": "test.png", "action-loc-key": "reply_title"});
+        it('contains all expected properties', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert')
+            .that.deep.equals({ body: 'Test', 'launch-image': 'test.png', action: 'View' });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Hello, world";
-          note.actionLocKey = "ignore_title";
+          note.alert = 'Alert';
+          note.action = 'Investigate';
         });
 
-        it("retains the alert body correctly", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
+        it('retains the alert body', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Alert');
         });
 
-        it("sets the aps.alert.action-loc-key property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.action\-loc\-key", "ignore_title");
+        it('sets the aps.alert.action property', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.action', 'Investigate');
         });
       });
 
-      describe("setActionLocKey", function () {
-        it("is chainable", function () {
-          expect(note.setActionLocKey("ignore_title")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.action\-loc\-key", "ignore_title");
+      describe('setAction', function () {
+        it('is chainable', function () {
+          expect(note.setAction('Reply')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.alert.action', 'Reply');
         });
       });
     });
 
-    describe("launchImage", function () {
-      it("sets the aps.alert.launch-image property", function () {
-        note.launchImage = "testLaunch.png";
-        expect(compiledOutput()).to.have.deep.property("aps.alert.launch\-image")
-          .that.deep.equals("testLaunch.png");
+    describe('actionLocKey', function () {
+      it('sets the aps.alert.action-loc-key property', function () {
+        note.actionLocKey = 'reply_title';
+        expect(compiledOutput()).to.have.deep.property('aps.alert.action-loc-key', 'reply_title');
       });
 
-      context("alert is already an object", function () {
+      context('alert is already an object', function () {
         beforeEach(function () {
-          note.alert = {body: "Test", "title-loc-key": "node-apn"};
-          note.launchImage = "apnLaunch.png";
+          note.alert = { body: 'Test', 'launch-image': 'test.png' };
+          note.actionLocKey = 'reply_title';
         });
 
-        it("contains all expected properties", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert")
-            .that.deep.equals({body: "Test", "title-loc-key": "node-apn", "launch-image": "apnLaunch.png"});
+        it('contains all expected properties', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+            body: 'Test',
+            'launch-image': 'test.png',
+            'action-loc-key': 'reply_title',
+          });
         });
       });
 
-      context("alert is already a string", function () {
+      context('alert is already a string', function () {
         beforeEach(function () {
-          note.alert = "Hello, world";
-          note.launchImage = "apnLaunch.png";
+          note.alert = 'Hello, world';
+          note.actionLocKey = 'ignore_title';
         });
 
-        it("retains the alert body", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.body", "Hello, world");
+        it('retains the alert body correctly', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
         });
 
-        it("sets the aps.alert.launch-image property", function () {
-          expect(compiledOutput()).to.have.deep.property("aps.alert.launch\-image")
-            .that.deep.equals("apnLaunch.png");
-        })
+        it('sets the aps.alert.action-loc-key property', function () {
+          expect(compiledOutput()).to.have.deep.property(
+            'aps.alert.action-loc-key',
+            'ignore_title'
+          );
+        });
       });
 
-      describe("setLaunchImage", function () {
-        it("is chainable", function () {
-          expect(note.setLaunchImage("remoteLaunch.png")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.alert.launch\-image", "remoteLaunch.png");
+      describe('setActionLocKey', function () {
+        it('is chainable', function () {
+          expect(note.setActionLocKey('ignore_title')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property(
+            'aps.alert.action-loc-key',
+            'ignore_title'
+          );
         });
       });
     });
 
-    describe("badge", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.badge");
+    describe('launchImage', function () {
+      it('sets the aps.alert.launch-image property', function () {
+        note.launchImage = 'testLaunch.png';
+        expect(compiledOutput())
+          .to.have.deep.property('aps.alert.launch-image')
+          .that.deep.equals('testLaunch.png');
       });
 
-      it("can be set to a number", function() {
+      context('alert is already an object', function () {
+        beforeEach(function () {
+          note.alert = { body: 'Test', 'title-loc-key': 'node-apn' };
+          note.launchImage = 'apnLaunch.png';
+        });
+
+        it('contains all expected properties', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+            body: 'Test',
+            'title-loc-key': 'node-apn',
+            'launch-image': 'apnLaunch.png',
+          });
+        });
+      });
+
+      context('alert is already a string', function () {
+        beforeEach(function () {
+          note.alert = 'Hello, world';
+          note.launchImage = 'apnLaunch.png';
+        });
+
+        it('retains the alert body', function () {
+          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+        });
+
+        it('sets the aps.alert.launch-image property', function () {
+          expect(compiledOutput())
+            .to.have.deep.property('aps.alert.launch-image')
+            .that.deep.equals('apnLaunch.png');
+        });
+      });
+
+      describe('setLaunchImage', function () {
+        it('is chainable', function () {
+          expect(note.setLaunchImage('remoteLaunch.png')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property(
+            'aps.alert.launch-image',
+            'remoteLaunch.png'
+          );
+        });
+      });
+    });
+
+    describe('badge', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.badge');
+      });
+
+      it('can be set to a number', function () {
         note.badge = 5;
 
-        expect(compiledOutput()).to.have.deep.property("aps.badge", 5);
+        expect(compiledOutput()).to.have.deep.property('aps.badge', 5);
       });
 
-      it("can be set to undefined", function() {
+      it('can be set to undefined', function () {
         note.badge = 5;
         note.badge = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.badge");
+        expect(compiledOutput()).to.not.have.deep.property('aps.badge');
       });
 
-      it("can be set to zero", function() {
+      it('can be set to zero', function () {
         note.badge = 0;
 
-        expect(compiledOutput()).to.have.deep.property("aps.badge", 0);
+        expect(compiledOutput()).to.have.deep.property('aps.badge', 0);
       });
 
-      it("cannot be set to a string", function() {
-        note.badge = "hello";
+      it('cannot be set to a string', function () {
+        note.badge = 'hello';
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.badge");
+        expect(compiledOutput()).to.not.have.deep.property('aps.badge');
       });
 
-      describe("setBadge", function () {
-        it("is chainable", function () {
+      describe('setBadge', function () {
+        it('is chainable', function () {
           expect(note.setBadge(7)).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.badge", 7);
+          expect(compiledOutput()).to.have.deep.property('aps.badge', 7);
         });
       });
     });
 
-    describe("sound", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.sound");
+    describe('sound', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.sound');
       });
 
-      it("can be set to a string", function() {
-        note.sound = "sound.caf";
+      it('can be set to a string', function () {
+        note.sound = 'sound.caf';
 
-        expect(compiledOutput()).to.have.deep.property("aps.sound", "sound.caf");
+        expect(compiledOutput()).to.have.deep.property('aps.sound', 'sound.caf');
       });
 
-      it("can be set to undefined", function() {
-        note.sound = "sound.caf";
+      it('can be set to undefined', function () {
+        note.sound = 'sound.caf';
         note.sound = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.sound");
+        expect(compiledOutput()).to.not.have.deep.property('aps.sound');
       });
 
-      it("cannot be set to a number", function() {
+      it('cannot be set to a number', function () {
         note.sound = 5;
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.sound");
+        expect(compiledOutput()).to.not.have.deep.property('aps.sound');
       });
 
-      it("can be set to object", function() {
+      it('can be set to object', function () {
         note.sound = {
-          name: "sound.caf",
+          name: 'sound.caf',
           critical: 1,
-          volume: 0.75
+          volume: 0.75,
         };
 
-        expect(compiledOutput()).to.have.deep.property("aps.sound.name", "sound.caf");
-        expect(compiledOutput()).to.have.deep.property("aps.sound.critical", 1);
-        expect(compiledOutput()).to.have.deep.property("aps.sound.volume", 0.75);
+        expect(compiledOutput()).to.have.deep.property('aps.sound.name', 'sound.caf');
+        expect(compiledOutput()).to.have.deep.property('aps.sound.critical', 1);
+        expect(compiledOutput()).to.have.deep.property('aps.sound.volume', 0.75);
       });
 
-      describe("setSound", function() {
-        it("is chainable", function() {
-          expect(note.setSound("bee.caf")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.sound", "bee.caf");
+      describe('setSound', function () {
+        it('is chainable', function () {
+          expect(note.setSound('bee.caf')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.sound', 'bee.caf');
         });
       });
     });
 
-    describe("content-available", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.content\-available");
+    describe('content-available', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.content-available');
       });
 
-      it("can be set to a boolean value", function() {
+      it('can be set to a boolean value', function () {
         note.contentAvailable = true;
 
-        expect(compiledOutput()).to.have.deep.property("aps.content\-available", 1);
+        expect(compiledOutput()).to.have.deep.property('aps.content-available', 1);
       });
 
-      it("can be set to `1`", function () {
+      it('can be set to `1`', function () {
         note.contentAvailable = 1;
 
-        expect(compiledOutput()).to.have.deep.property("aps.content\-available", 1);
+        expect(compiledOutput()).to.have.deep.property('aps.content-available', 1);
       });
 
-      it("can be set to undefined", function() {
+      it('can be set to undefined', function () {
         note.contentAvailable = true;
         note.contentAvailable = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.content\-available");
+        expect(compiledOutput()).to.not.have.deep.property('aps.content-available');
       });
 
-      describe("setContentAvailable", function () {
-        it("is chainable", function () {
+      describe('setContentAvailable', function () {
+        it('is chainable', function () {
           expect(note.setContentAvailable(true)).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.content\-available", 1);
+          expect(compiledOutput()).to.have.deep.property('aps.content-available', 1);
         });
       });
     });
 
-    describe("mutable-content", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.mutable\-content");
+    describe('mutable-content', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.mutable-content');
       });
 
-      it("can be set to a boolean value", function() {
+      it('can be set to a boolean value', function () {
         note.mutableContent = true;
 
-        expect(compiledOutput()).to.have.deep.property("aps.mutable\-content", 1);
+        expect(compiledOutput()).to.have.deep.property('aps.mutable-content', 1);
       });
 
-      it("can be set to `1`", function () {
+      it('can be set to `1`', function () {
         note.mutableContent = 1;
 
-        expect(compiledOutput()).to.have.deep.property("aps.mutable\-content", 1);
+        expect(compiledOutput()).to.have.deep.property('aps.mutable-content', 1);
       });
 
-      it("can be set to undefined", function() {
+      it('can be set to undefined', function () {
         note.mutableContent = true;
         note.mutableContent = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.mutable\-content");
+        expect(compiledOutput()).to.not.have.deep.property('aps.mutable-content');
       });
 
-      describe("setMutableContent", function () {
-        it("is chainable", function () {
+      describe('setMutableContent', function () {
+        it('is chainable', function () {
           expect(note.setMutableContent(true)).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.mutable\-content", 1);
+          expect(compiledOutput()).to.have.deep.property('aps.mutable-content', 1);
         });
       });
     });
 
-    describe("mdm", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("mdm");
+    describe('mdm', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('mdm');
       });
 
-      it("can be set to a string", function() {
-        note.mdm = "mdm payload";
+      it('can be set to a string', function () {
+        note.mdm = 'mdm payload';
 
-        expect(compiledOutput()).to.deep.equal({"mdm": "mdm payload"});
+        expect(compiledOutput()).to.deep.equal({ mdm: 'mdm payload' });
       });
 
-      it("can be set to undefined", function() {
-        note.mdm = "mdm payload";
+      it('can be set to undefined', function () {
+        note.mdm = 'mdm payload';
         note.mdm = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property("mdm");
+        expect(compiledOutput()).to.not.have.deep.property('mdm');
       });
 
-      it("does not include the aps payload", function() {
-        note.mdm = "mdm payload";
+      it('does not include the aps payload', function () {
+        note.mdm = 'mdm payload';
         note.badge = 5;
 
-        expect(compiledOutput()).to.not.have.any.keys("aps");
+        expect(compiledOutput()).to.not.have.any.keys('aps');
       });
 
-      describe("setMdm", function () {
-        it("is chainable", function () {
-          expect(note.setMdm("hello")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("mdm", "hello");
+      describe('setMdm', function () {
+        it('is chainable', function () {
+          expect(note.setMdm('hello')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('mdm', 'hello');
         });
       });
     });
 
-    describe("urlArgs", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.url\-args");
+    describe('urlArgs', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.url-args');
       });
 
-      it("can be set to an array", function() {
-        note.urlArgs = ["arg1", "arg2"];
+      it('can be set to an array', function () {
+        note.urlArgs = ['arg1', 'arg2'];
 
-        expect(compiledOutput()).to.have.deep.property("aps.url\-args")
-          .that.deep.equals(["arg1", "arg2"]);
+        expect(compiledOutput())
+          .to.have.deep.property('aps.url-args')
+          .that.deep.equals(['arg1', 'arg2']);
       });
 
-      it("can be set to undefined", function() {
-        note.urlArgs = ["arg1", "arg2"];
+      it('can be set to undefined', function () {
+        note.urlArgs = ['arg1', 'arg2'];
         note.urlArgs = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.url\-args");
+        expect(compiledOutput()).to.not.have.deep.property('aps.url-args');
       });
 
-      describe("setUrlArgs", function () {
-        it("is chainable", function () {
-          expect(note.setUrlArgs(["A318", "BA001"])).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.url\-args")
-            .that.deep.equals(["A318", "BA001"]);
+      describe('setUrlArgs', function () {
+        it('is chainable', function () {
+          expect(note.setUrlArgs(['A318', 'BA001'])).to.equal(note);
+          expect(compiledOutput())
+            .to.have.deep.property('aps.url-args')
+            .that.deep.equals(['A318', 'BA001']);
         });
       });
     });
 
-    describe("category", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.category");
+    describe('category', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.category');
       });
 
-      it("can be set to a string", function() {
-        note.category = "the-category";
-        expect(compiledOutput()).to.have.deep.property("aps.category", "the-category");
+      it('can be set to a string', function () {
+        note.category = 'the-category';
+        expect(compiledOutput()).to.have.deep.property('aps.category', 'the-category');
       });
 
-      it("can be set to undefined", function() {
-        note.category = "the-category";
+      it('can be set to undefined', function () {
+        note.category = 'the-category';
         note.category = undefined;
-        expect(compiledOutput()).to.not.have.deep.property("aps.category");
+        expect(compiledOutput()).to.not.have.deep.property('aps.category');
       });
 
-      describe("setCategory", function () {
-        it("is chainable", function () {
-          expect(note.setCategory("reminder")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.category", "reminder");
+      describe('setCategory', function () {
+        it('is chainable', function () {
+          expect(note.setCategory('reminder')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.category', 'reminder');
         });
       });
     });
 
-    describe("target-content-id", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput())
-          .to.not.have.nested.property("aps.target\-content\-id");
+    describe('target-content-id', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.target-content-id');
       });
 
-      it("can be set to a string", function() {
-        note.targetContentIdentifier = "the-target-content-id";
+      it('can be set to a string', function () {
+        note.targetContentIdentifier = 'the-target-content-id';
 
-        expect(compiledOutput()).to.have.nested.property("aps.target\-content\-id",
-          "the-target-content-id");
+        expect(compiledOutput()).to.have.nested.property(
+          'aps.target-content-id',
+          'the-target-content-id'
+        );
       });
 
-      it("can be set to undefined", function() {
-        note.targetContentIdentifier = "the-target-content-identifier";
+      it('can be set to undefined', function () {
+        note.targetContentIdentifier = 'the-target-content-identifier';
         note.targetContentIdentifier = undefined;
 
-        expect(compiledOutput()).to.not.have.nested.property("aps.target\-content\-id");
+        expect(compiledOutput()).to.not.have.nested.property('aps.target-content-id');
       });
 
-      describe("setTargetContentIdentifier", function () {
-        it("is chainable", function () {
-          expect(note.setTargetContentIdentifier("the-target-content-id")).to.equal(note);
-          expect(compiledOutput()).to.have.nested.property("aps.target\-content\-id",
-            "the-target-content-id");
+      describe('setTargetContentIdentifier', function () {
+        it('is chainable', function () {
+          expect(note.setTargetContentIdentifier('the-target-content-id')).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property(
+            'aps.target-content-id',
+            'the-target-content-id'
+          );
         });
       });
     });
 
-    describe("thread-id", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.deep.property("aps.thread\-id");
+    describe('thread-id', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.deep.property('aps.thread-id');
       });
 
-      it("can be set to a string", function() {
-        note.threadId = "the-thread-id";
+      it('can be set to a string', function () {
+        note.threadId = 'the-thread-id';
 
-        expect(compiledOutput()).to.have.deep.property("aps.thread\-id", "the-thread-id");
+        expect(compiledOutput()).to.have.deep.property('aps.thread-id', 'the-thread-id');
       });
 
-      it("can be set to undefined", function() {
-        note.threadId = "the-thread-id";
+      it('can be set to undefined', function () {
+        note.threadId = 'the-thread-id';
         note.threadId = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property("aps.thread\-id");
+        expect(compiledOutput()).to.not.have.deep.property('aps.thread-id');
       });
 
-      describe("setThreadId", function () {
-        it("is chainable", function () {
-          expect(note.setThreadId("the-thread-id")).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property("aps.thread\-id", "the-thread-id");
+      describe('setThreadId', function () {
+        it('is chainable', function () {
+          expect(note.setThreadId('the-thread-id')).to.equal(note);
+          expect(compiledOutput()).to.have.deep.property('aps.thread-id', 'the-thread-id');
         });
       });
     });
 
-    describe("interruption-level", function() {
-      it("defaults to undefined", function() {
-        expect(compiledOutput()).to.not.have.nested.property("aps.interruption\-level");
+    describe('interruption-level', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.interruption-level');
       });
 
-      it("can be set to a string", function() {
-        note.interruptionLevel = "the-interruption-level";
+      it('can be set to a string', function () {
+        note.interruptionLevel = 'the-interruption-level';
 
-        expect(compiledOutput()).to.have.nested.property("aps.interruption\-level", "the-interruption-level");
+        expect(compiledOutput()).to.have.nested.property(
+          'aps.interruption-level',
+          'the-interruption-level'
+        );
       });
 
-      it("can be set to undefined", function() {
-        note.interruptionLevel = "the-interruption-level";
+      it('can be set to undefined', function () {
+        note.interruptionLevel = 'the-interruption-level';
         note.interruptionLevel = undefined;
 
-        expect(compiledOutput()).to.not.have.nested.property("aps.interruption\-level");
+        expect(compiledOutput()).to.not.have.nested.property('aps.interruption-level');
       });
 
-      describe("setInterruptionLevel", function () {
-        it("is chainable", function () {
-          expect(note.setInterruptionLevel("the-interruption-level")).to.equal(note);
-          expect(compiledOutput()).to.have.nested.property("aps.interruption\-level", "the-interruption-level");
+      describe('setInterruptionLevel', function () {
+        it('is chainable', function () {
+          expect(note.setInterruptionLevel('the-interruption-level')).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property(
+            'aps.interruption-level',
+            'the-interruption-level'
+          );
         });
       });
     });
 
-    context("when no aps properties are set", function() {
-      it("is not present", function() {
+    context('when no aps properties are set', function () {
+      it('is not present', function () {
         expect(compiledOutput().aps).to.be.undefined;
       });
     });

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -1,224 +1,222 @@
-"use strict";
+const Notification = require('../../lib/notification');
+const sinon = require('sinon');
 
-var Notification = require("../../lib/notification");
-var sinon = require("sinon");
+describe('Notification', function () {
+  let note;
+  beforeEach(function () {
+    note = new Notification();
+  });
 
-describe("Notification", function() {
+  describe('constructor', function () {
+    it('accepts initialization values', function () {
+      const properties = { priority: 5, topic: 'io.apn.node', payload: { foo: 'bar' }, badge: 5 };
+      note = new Notification(properties);
 
-	var note;
-	beforeEach(function() {
-		note = new Notification();
-	});
+      expect(note.payload).to.deep.equal({ foo: 'bar' });
+      expect(note.priority).to.equal(5);
+      expect(note.topic).to.equal('io.apn.node');
+      expect(compiledOutput()).to.have.deep.property('aps.badge', 5);
+    });
+  });
 
-	describe("constructor", function () {
-		it("accepts initialization values", function () {
-			let properties = { "priority": 5, "topic": "io.apn.node", "payload": { "foo": "bar" }, "badge": 5};
-			note = new Notification(properties);
+  describe('rawPayload', function () {
+    it('is used as the JSON output', function () {
+      const payload = { some: 'payload' };
+      note = new Notification({ rawPayload: payload });
 
-			expect(note.payload).to.deep.equal({"foo": "bar"});
-			expect(note.priority).to.equal(5);
-			expect(note.topic).to.equal("io.apn.node");
-			expect(compiledOutput()).to.have.deep.property("aps.badge", 5);
-		});
-	});
+      expect(note.rawPayload).to.deep.equal({ some: 'payload' });
+      expect(compiledOutput()).to.deep.equal({ some: 'payload' });
+    });
 
-	describe("rawPayload", function () {
+    it('does not get clobbered by aps accessors', function () {
+      const payload = { some: 'payload', aps: { alert: 'Foo' } };
 
-		it("is used as the JSON output", function () {
-			let payload = { "some": "payload" };
-			note = new Notification({ "rawPayload": payload });
+      note = new Notification({ rawPayload: payload });
+      note.alertBody = 'Bar';
 
-			expect(note.rawPayload).to.deep.equal({ "some": "payload" });
-			expect(compiledOutput()).to.deep.equal({ "some": "payload" });
-		});
+      expect(note.rawPayload).to.deep.equal({ some: 'payload', aps: { alert: 'Foo' } });
+      expect(compiledOutput()).to.deep.equal({ some: 'payload', aps: { alert: 'Foo' } });
+    });
 
-		it("does not get clobbered by aps accessors", function () {
-			let payload = { "some": "payload", "aps": {"alert": "Foo"}};
+    it('takes precedence over the `mdm` property', function () {
+      const payload = { some: 'payload' };
 
-			note = new Notification({ "rawPayload": payload });
-			note.alertBody = "Bar";
+      note = new Notification({ rawPayload: payload });
+      note.mdm = 'abcd';
 
-			expect(note.rawPayload).to.deep.equal({ "some": "payload", "aps": {"alert": "Foo"}});
-			expect(compiledOutput()).to.deep.equal({ "some": "payload", "aps": {"alert": "Foo"}});
-		});
+      expect(note.rawPayload).to.deep.equal({ some: 'payload' });
+      expect(compiledOutput()).to.deep.equal({ some: 'payload' });
+    });
 
-		it("takes precedence over the `mdm` property", function () {
-			let payload = { "some": "payload" };
+    context('when passed in the notification constructor', function () {
+      beforeEach(function () {
+        note = new Notification({
+          rawPayload: { foo: 'bar', baz: 1, aps: { badge: 1, alert: 'Hi there!' } },
+        });
+      });
 
-			note = new Notification({ "rawPayload": payload });
-			note.mdm = "abcd";
+      it('contains all original payload properties', function () {
+        expect(compiledOutput()).to.have.property('foo', 'bar');
+        expect(compiledOutput()).to.have.property('baz', 1);
+      });
 
-			expect(note.rawPayload).to.deep.equal({ "some": "payload" });
-			expect(compiledOutput()).to.deep.equal({ "some": "payload" });
-		});
+      it('contains the correct aps properties', function () {
+        expect(compiledOutput()).to.have.deep.property('aps.badge', 1);
+        expect(compiledOutput()).to.have.deep.property('aps.alert', 'Hi there!');
+      });
+    });
+  });
 
-		context("when passed in the notification constructor", function() {
-			beforeEach(function() {
-				note = new Notification({"rawPayload": {"foo": "bar", "baz": 1, "aps": { "badge": 1, "alert": "Hi there!" }}});
-			});
+  describe('payload', function () {
+    describe('when no aps properties are set', function () {
+      it('contains all original payload properties', function () {
+        note.payload = { foo: 'bar', baz: 1 };
+        expect(compiledOutput()).to.eql({ foo: 'bar', baz: 1 });
+      });
+    });
 
-			it("contains all original payload properties", function() {
-				expect(compiledOutput()).to.have.property("foo", "bar");
-				expect(compiledOutput()).to.have.property("baz", 1);
-			});
+    describe('when aps properties are given by setters', function () {
+      it('should not mutate the originally given paylaod object', function () {
+        const payload = { foo: 'bar', baz: 1 };
+        note.payload = payload;
+        note.badge = 1;
+        note.sound = 'ping.aiff';
+        note.toJSON();
+        expect(payload).to.deep.equal({ foo: 'bar', baz: 1 });
+      });
+    });
 
-			it("contains the correct aps properties", function() {
-				expect(compiledOutput()).to.have.deep.property("aps.badge", 1);
-				expect(compiledOutput()).to.have.deep.property("aps.alert", "Hi there!");
-			});
-		});
-	});
+    describe('when aps payload is present', function () {
+      beforeEach(function () {
+        note.payload = { foo: 'bar', baz: 1, aps: { badge: 1, alert: 'Hi there!' } };
+      });
 
-	describe("payload", function() {
-		describe("when no aps properties are set", function() {
-			it("contains all original payload properties", function() {
-				note.payload = {"foo": "bar", "baz": 1};
-				expect(compiledOutput()).to.eql({"foo": "bar", "baz": 1});
-			});
-		});
+      it('contains all original payload properties', function () {
+        expect(compiledOutput()).to.have.property('foo', 'bar');
+        expect(compiledOutput()).to.have.property('baz', 1);
+      });
 
-		describe("when aps properties are given by setters", function() {
-			it("should not mutate the originally given paylaod object", function() {
-				let payload = {"foo": "bar", "baz": 1};
-				note.payload = payload;
-				note.badge = 1;
-				note.sound = "ping.aiff";
-				note.toJSON();
-				expect(payload).to.deep.equal({"foo": "bar", "baz": 1});
-			});
-		});
+      it('does not contain the aps properties', function () {
+        expect(compiledOutput()).to.not.have.property('aps');
+      });
+    });
+  });
 
-		describe("when aps payload is present", function() {
-			beforeEach(function() {
-				note.payload = {"foo": "bar", "baz": 1, "aps": { "badge": 1, "alert": "Hi there!" }};
-			});
+  describe('length', function () {
+    it('returns the correct payload length', function () {
+      note.alert = 'length';
+      expect(note.length()).to.equal(26);
+    });
+  });
 
-			it("contains all original payload properties", function() {
-				expect(compiledOutput()).to.have.property("foo", "bar");
-				expect(compiledOutput()).to.have.property("baz", 1);
-			});
+  describe('headers', function () {
+    it('contains no properties by default', function () {
+      expect(note.headers()).to.deep.equal({});
+    });
 
-			it("does not contain the aps properties", function() {
-				expect(compiledOutput()).to.not.have.property("aps");
-			});
-		});
-	});
+    context('priority is non-default', function () {
+      it('contains the apns-priority header', function () {
+        note.priority = 5;
+        expect(note.headers()).to.have.property('apns-priority', 5);
+      });
+    });
 
-	describe("length", function() {
-		it("returns the correct payload length", function() {
-			note.alert = "length";
-			expect(note.length()).to.equal(26);
-		});
-	});
+    context('id is set', function () {
+      it('contains the apns-id header', function () {
+        note.id = '123e4567-e89b-12d3-a456-42665544000';
 
-	describe("headers", function() {
-		it("contains no properties by default", function() {
-			expect(note.headers()).to.deep.equal({});
-		});
+        expect(note.headers()).to.have.property('apns-id', '123e4567-e89b-12d3-a456-42665544000');
+      });
+    });
 
-		context("priority is non-default", function() {
-			it("contains the apns-priority header", function() {
-				note.priority = 5;
-				expect(note.headers()).to.have.property("apns-priority", 5);
-			});
-		});
+    context('expiry is greater than zero', function () {
+      it('contains the apns-expiration header', function () {
+        note.expiry = 1000;
 
-		context("id is set", function() {
-			it("contains the apns-id header", function() {
-				note.id = "123e4567-e89b-12d3-a456-42665544000";
+        expect(note.headers()).to.have.property('apns-expiration', 1000);
+      });
+    });
 
-				expect(note.headers()).to.have.property("apns-id", "123e4567-e89b-12d3-a456-42665544000");
-			});
-		});
+    context('expiry is zero', function () {
+      it('contains the apns-expiration header', function () {
+        note.expiry = 0;
 
-		context("expiry is greater than zero", function() {
-			it("contains the apns-expiration header", function() {
-				note.expiry = 1000;
+        expect(note.headers()).to.have.property('apns-expiration', 0);
+      });
+    });
 
-				expect(note.headers()).to.have.property("apns-expiration", 1000);
-			});
-		});
+    context('expiry is negative', function () {
+      it('not contains the apns-expiration header', function () {
+        note.expiry = -1;
 
-        context("expiry is zero", function() {
-			it("contains the apns-expiration header", function() {
-				note.expiry = 0;
+        expect(note.headers()).to.not.have.property('apns-expiration');
+      });
+    });
 
-				expect(note.headers()).to.have.property("apns-expiration", 0);
-			});
-		});
+    context('topic is set', function () {
+      it('contains the apns-topic header', function () {
+        note.topic = 'io.apn.node';
 
-        context("expiry is negative", function() {
-			it("not contains the apns-expiration header", function() {
-				note.expiry = -1;
+        expect(note.headers()).to.have.property('apns-topic', 'io.apn.node');
+      });
+    });
 
-				expect(note.headers()).to.not.have.property("apns-expiration");
-			});
-		});
+    context('collapseId is set', function () {
+      it('contains the apns-collapse-id header', function () {
+        note.collapseId = 'io.apn.collapse';
 
-		context("topic is set", function() {
-			it("contains the apns-topic header", function() {
-				note.topic = "io.apn.node";
+        expect(note.headers()).to.have.property('apns-collapse-id', 'io.apn.collapse');
+      });
+    });
 
-				expect(note.headers()).to.have.property("apns-topic", "io.apn.node");
-			});
-		});
+    context('pushType is set', function () {
+      it('contains the apns-push-type header', function () {
+        note.pushType = 'alert';
 
-		context("collapseId is set", function () {
-			it("contains the apns-collapse-id header", function () {
-				note.collapseId = "io.apn.collapse";
+        expect(note.headers()).to.have.property('apns-push-type', 'alert');
+      });
+    });
+  });
 
-				expect(note.headers()).to.have.property("apns-collapse-id", "io.apn.collapse");
-			});
-		});
+  describe('compile', function () {
+    let stub;
+    beforeEach(function () {
+      stub = sinon.stub(note, 'toJSON');
+    });
 
-		context("pushType is set", function () {
-			it("contains the apns-push-type header", function () {
-				note.pushType = "alert";
+    it('compiles the JSON payload', function () {
+      stub.returns('payload');
 
-				expect(note.headers()).to.have.property("apns-push-type", "alert");
-			});
-		});
-	});
+      expect(note.compile()).to.equal('"payload"');
+    });
 
-	describe("compile", function() {
-		var stub;
-		beforeEach(function() {
-			stub = sinon.stub(note, "toJSON");
-		});
+    it('returns the JSON payload', function () {
+      stub.returns({});
 
-		it("compiles the JSON payload", function() {
-			stub.returns("payload");
+      expect(note.compile()).to.equal('{}');
+    });
 
-			expect(note.compile()).to.equal("\"payload\"");
-		});
+    it('memoizes the JSON payload', function () {
+      stub.returns('payload1');
+      note.compile();
 
-		it("returns the JSON payload", function() {
-			stub.returns({});
+      stub.returns('payload2');
 
-			expect(note.compile()).to.equal("{}");
-		});
+      expect(note.compile()).to.equal('"payload1"');
+    });
 
-		it("memoizes the JSON payload", function() {
-			stub.returns("payload1");
-			note.compile();
+    it('re-compiles the JSON payload when `note.compiled` = false', function () {
+      stub.returns('payload1');
+      note.compile();
 
-			stub.returns("payload2");
+      stub.returns('payload2');
+      note.compiled = false;
 
-			expect(note.compile()).to.equal("\"payload1\"");
-		});
+      expect(note.compile()).to.equal('"payload2"');
+    });
+  });
 
-		it("re-compiles the JSON payload when `note.compiled` = false", function() {
-			stub.returns("payload1");
-			note.compile();
-
-			stub.returns("payload2");
-			note.compiled = false;
-
-			expect(note.compile()).to.equal("\"payload2\"");
-		});
-	});
-
-	function compiledOutput() {
-		return JSON.parse(note.compile());
-	}
+  function compiledOutput() {
+    return JSON.parse(note.compile());
+  }
 });

--- a/test/provider.js
+++ b/test/provider.js
@@ -1,9 +1,7 @@
-"use strict";
+const sinon = require('sinon');
+const EventEmitter = require('events');
 
-const sinon = require("sinon");
-const EventEmitter = require("events");
-
-describe("Provider", function() {
+describe('Provider', function () {
   let fakes, Provider;
 
   beforeEach(function () {
@@ -16,27 +14,26 @@ describe("Provider", function() {
     fakes.client.write = sinon.stub();
     fakes.client.shutdown = sinon.stub();
 
-    Provider = require("../lib/provider")(fakes);
+    Provider = require('../lib/provider')(fakes);
   });
 
-  describe("constructor", function () {
-
-    context("called without `new`", function () {
-      it("returns a new instance", function () {
+  describe('constructor', function () {
+    context('called without `new`', function () {
+      it('returns a new instance', function () {
         expect(Provider()).to.be.an.instanceof(Provider);
       });
     });
 
-    describe("Client instance", function() {
-      it("is created", function () {
+    describe('Client instance', function () {
+      it('is created', function () {
         Provider();
 
         expect(fakes.Client).to.be.calledOnce;
         expect(fakes.Client).to.be.calledWithNew;
       });
 
-      it("is passed the options", function () {
-        const options = { "configKey": "configValue"};
+      it('is passed the options', function () {
+        const options = { configKey: 'configValue' };
 
         Provider(options);
         expect(fakes.Client).to.be.calledWith(options);
@@ -44,120 +41,140 @@ describe("Provider", function() {
     });
   });
 
-  describe("send", function () {
-
-    describe("single notification behaviour", function () {
+  describe('send', function () {
+    describe('single notification behaviour', function () {
       let provider;
 
-      context("transmission succeeds", function () {
-        beforeEach( function () {
-          provider = new Provider( { address: "testapi" } );
+      context('transmission succeeds', function () {
+        beforeEach(function () {
+          provider = new Provider({ address: 'testapi' });
 
-          fakes.client.write.onCall(0).returns(Promise.resolve({ device: "abcd1234" }));
+          fakes.client.write.onCall(0).returns(Promise.resolve({ device: 'abcd1234' }));
         });
 
-        it("invokes the writer with correct `this`", function () {
-          return provider.send(notificationDouble(), "abcd1234")
-            .then(function () {
-              expect(fakes.client.write).to.be.calledOn(fakes.client);
-            });
+        it('invokes the writer with correct `this`', function () {
+          return provider.send(notificationDouble(), 'abcd1234').then(function () {
+            expect(fakes.client.write).to.be.calledOn(fakes.client);
+          });
         });
 
-        it("writes the notification to the client once", function () {
-          return provider.send(notificationDouble(), "abcd1234")
-            .then(function () {
-              const notification = notificationDouble();
-              const builtNotification = {
-                headers: notification.headers(),
-                body: notification.compile(),
-              };
-              expect(fakes.client.write).to.be.calledOnce;
-              expect(fakes.client.write).to.be.calledWith(builtNotification, "abcd1234");
-            });
+        it('writes the notification to the client once', function () {
+          return provider.send(notificationDouble(), 'abcd1234').then(function () {
+            const notification = notificationDouble();
+            const builtNotification = {
+              headers: notification.headers(),
+              body: notification.compile(),
+            };
+            expect(fakes.client.write).to.be.calledOnce;
+            expect(fakes.client.write).to.be.calledWith(builtNotification, 'abcd1234');
+          });
         });
 
-        it("does not pass the array index to writer", function () {
-          return provider.send(notificationDouble(), "abcd1234")
-            .then(function () {
-              expect(fakes.client.write.firstCall.args[2]).to.be.undefined;
-            });
+        it('does not pass the array index to writer', function () {
+          return provider.send(notificationDouble(), 'abcd1234').then(function () {
+            expect(fakes.client.write.firstCall.args[2]).to.be.undefined;
+          });
         });
 
-        it("resolves with the device token in the sent array", function () {
-          return expect(provider.send(notificationDouble(), "abcd1234"))
-            .to.become({ sent: [{"device": "abcd1234"}], failed: []});
+        it('resolves with the device token in the sent array', function () {
+          return expect(provider.send(notificationDouble(), 'abcd1234')).to.become({
+            sent: [{ device: 'abcd1234' }],
+            failed: [],
+          });
         });
       });
 
-      context("error occurs", function () {
+      context('error occurs', function () {
         let promise;
 
         beforeEach(function () {
-          const provider = new Provider( { address: "testapi" } );
+          const provider = new Provider({ address: 'testapi' });
 
-          fakes.client.write.onCall(0).returns(Promise.resolve({ device: "abcd1234", status: "400", response: { reason: "BadDeviceToken" }}));
-          promise = provider.send(notificationDouble(), "abcd1234");
+          fakes.client.write.onCall(0).returns(
+            Promise.resolve({
+              device: 'abcd1234',
+              status: '400',
+              response: { reason: 'BadDeviceToken' },
+            })
+          );
+          promise = provider.send(notificationDouble(), 'abcd1234');
         });
 
-        it("resolves with the device token, status code and response in the failed array", function () {
-          return expect(promise).to.eventually.deep.equal({ sent: [], failed: [{"device": "abcd1234", "status": "400", "response": { "reason" : "BadDeviceToken" }}]});
+        it('resolves with the device token, status code and response in the failed array', function () {
+          return expect(promise).to.eventually.deep.equal({
+            sent: [],
+            failed: [{ device: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } }],
+          });
         });
       });
     });
 
-    context("when multiple tokens are passed", function () {
-
+    context('when multiple tokens are passed', function () {
       beforeEach(function () {
-          fakes.resolutions = [
-            { device: "abcd1234" },
-            { device: "adfe5969", status: "400", response: { reason: "MissingTopic" }},
-            { device: "abcd1335", status: "410", response: { reason: "BadDeviceToken", timestamp: 123456789 }},
-            { device: "bcfe4433" },
-            { device: "aabbc788", status: "413", response: { reason: "PayloadTooLarge" }},
-            { device: "fbcde238", error: new Error("connection failed") },
-          ];
+        fakes.resolutions = [
+          { device: 'abcd1234' },
+          { device: 'adfe5969', status: '400', response: { reason: 'MissingTopic' } },
+          {
+            device: 'abcd1335',
+            status: '410',
+            response: { reason: 'BadDeviceToken', timestamp: 123456789 },
+          },
+          { device: 'bcfe4433' },
+          { device: 'aabbc788', status: '413', response: { reason: 'PayloadTooLarge' } },
+          { device: 'fbcde238', error: new Error('connection failed') },
+        ];
       });
 
-      context("streams are always returned", function () {
+      context('streams are always returned', function () {
         let promise;
 
-        beforeEach( function () {
-          const provider = new Provider( { address: "testapi" } );
+        beforeEach(function () {
+          const provider = new Provider({ address: 'testapi' });
 
-          for(let i=0; i < fakes.resolutions.length; i++) {
+          for (let i = 0; i < fakes.resolutions.length; i++) {
             fakes.client.write.onCall(i).returns(Promise.resolve(fakes.resolutions[i]));
           }
 
-          promise = provider.send(notificationDouble(), fakes.resolutions.map( res => res.device ));
+          promise = provider.send(
+            notificationDouble(),
+            fakes.resolutions.map(res => res.device)
+          );
 
           return promise;
         });
 
-        it("resolves with the sent notifications", function () {
-          return promise.then( (response) => {
-            expect(response.sent).to.deep.equal([{device: "abcd1234"}, {device: "bcfe4433"}]);
+        it('resolves with the sent notifications', function () {
+          return promise.then(response => {
+            expect(response.sent).to.deep.equal([{ device: 'abcd1234' }, { device: 'bcfe4433' }]);
           });
         });
 
-        it("resolves with the device token, status code and response or error of the unsent notifications", function () {
-          return promise.then( (response) => {
+        it('resolves with the device token, status code and response or error of the unsent notifications', function () {
+          return promise.then(response => {
             expect(response.failed[3].error).to.be.an.instanceof(Error);
             response.failed[3].error = { message: response.failed[3].error.message };
-            expect(response.failed).to.deep.equal([
-              { device: "adfe5969", status: "400", response: { reason: "MissingTopic" }},
-              { device: "abcd1335", status: "410", response: { reason: "BadDeviceToken", timestamp: 123456789 }},
-              { device: "aabbc788", status: "413", response: { reason: "PayloadTooLarge" }},
-              { device: "fbcde238", error: { message: "connection failed" }},
-            ], `Unexpected result: ${JSON.stringify(response.failed)}`);
+            expect(response.failed).to.deep.equal(
+              [
+                { device: 'adfe5969', status: '400', response: { reason: 'MissingTopic' } },
+                {
+                  device: 'abcd1335',
+                  status: '410',
+                  response: { reason: 'BadDeviceToken', timestamp: 123456789 },
+                },
+                { device: 'aabbc788', status: '413', response: { reason: 'PayloadTooLarge' } },
+                { device: 'fbcde238', error: { message: 'connection failed' } },
+              ],
+              `Unexpected result: ${JSON.stringify(response.failed)}`
+            );
           });
         });
       });
     });
   });
 
-  describe("shutdown", function () {
-    it("invokes shutdown on the client", function () {
-      let provider = new Provider({});
+  describe('shutdown', function () {
+    it('invokes shutdown on the client', function () {
+      const provider = new Provider({});
       provider.shutdown();
 
       expect(fakes.client.shutdown).to.be.calledOnce;
@@ -169,6 +186,8 @@ function notificationDouble() {
   return {
     headers: sinon.stub().returns({}),
     payload: { aps: { badge: 1 } },
-    compile: function() { return JSON.stringify(this.payload); }
+    compile: function () {
+      return JSON.stringify(this.payload);
+    },
   };
 }

--- a/test/support.js
+++ b/test/support.js
@@ -1,8 +1,6 @@
-"use strict";
-
-var chai = require("chai");
-var chaiAsPromised = require("chai-as-promised");
-var sinonChai = require("sinon-chai");
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const sinonChai = require('sinon-chai');
 
 chai.config.includeStack = true;
 chai.use(chaiAsPromised);

--- a/test/token.js
+++ b/test/token.js
@@ -1,40 +1,49 @@
-const token = require("../lib/token");
+const token = require('../lib/token');
 
-describe("token", function () {
-
-  context("string input", function () {
-    context("contains valid token", function () {
-      it("returns token as string", function () {
-        expect(token("a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7"))
-          .to.equal("a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7");
+describe('token', function () {
+  context('string input', function () {
+    context('contains valid token', function () {
+      it('returns token as string', function () {
+        expect(token('a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7')).to.equal(
+          'a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7'
+        );
       });
 
-      it("strips invalid characters", function () {
-        expect(token("<a9d0ed1 0e9cfd 022a61 cb0875 3f49c5 a0b0d fb784697bf9f9d750a1003da19c7>"))
-          .to.equal("a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7");
+      it('strips invalid characters', function () {
+        expect(
+          token('<a9d0ed1 0e9cfd 022a61 cb0875 3f49c5 a0b0d fb784697bf9f9d750a1003da19c7>')
+        ).to.equal('a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7');
       });
 
-      it("supports uppercase input", function () {
-        expect(token("A9D0ED10E9CFD022A61CB08753F49C5A0B0DFB784697BF9F9D750A1003DA19C7"))
-          .to.equal("A9D0ED10E9CFD022A61CB08753F49C5A0B0DFB784697BF9F9D750A1003DA19C7");
+      it('supports uppercase input', function () {
+        expect(token('A9D0ED10E9CFD022A61CB08753F49C5A0B0DFB784697BF9F9D750A1003DA19C7')).to.equal(
+          'A9D0ED10E9CFD022A61CB08753F49C5A0B0DFB784697BF9F9D750A1003DA19C7'
+        );
       });
     });
 
-    it("throws when input is empty", function () {
-      expect(function () { token(""); }).to.throw(/invalid length/);
+    it('throws when input is empty', function () {
+      expect(function () {
+        token('');
+      }).to.throw(/invalid length/);
     });
   });
 
-  context("Buffer input", function() {
-    context("contains valid token", function () {
-      it("returns token as string", function () {
-        expect(token(Buffer.from("a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7", "hex")))
-          .to.equal("a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7");
+  context('Buffer input', function () {
+    context('contains valid token', function () {
+      it('returns token as string', function () {
+        expect(
+          token(
+            Buffer.from('a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7', 'hex')
+          )
+        ).to.equal('a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb784697bf9f9d750a1003da19c7');
       });
     });
 
-    it("throws when input is empty", function () {
-      expect(function () { token(Buffer.from([])); }).to.throw(/invalid length/);
+    it('throws when input is empty', function () {
+      expect(function () {
+        token(Buffer.from([]));
+      }).to.throw(/invalid length/);
     });
   });
 });


### PR DESCRIPTION
This is done for the following reasons:

- Remove unused imports and detect unused variables (skip warning about unused parameters).
- Start standardizing the existing code style
- Make code style guidelines less subjective for existing/new contributors to save time and avoid distractions reviewing spacing/indentation in the future, and focus on semantics of changes
- Remove `use strict`, it's redundant in JS modules. https://stackoverflow.com/questions/49386015/javascript-use-strict-is-unnecessary-inside-of-modules

~~The choice of airbnb is arbitrary, it's just a common one.~~ (switched to prettier for formatting, but picked up some of the suggestions)

~~Many pre-existing issues are suppressed just to keep the volume of changes in this PR manageable to read. Many suppressions should be removed in the future.~~

This PR tries to avoid changes that may affect runtime behavior, and suppresses those lint warnings instead (e.g. potentially replacing `for in` loops are left for subsequent releases or commits to make bisecting behavior changes easier)