### PR TITLE
Updated test scripts to run tests in sub folders and updated failing tests

### DIFF
--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -48,6 +48,7 @@ Notification.prototype = require('./apsProperties');
   'category',
   'threadId',
   'interruptionLevel',
+  'targetContentIdentifier',
 ].forEach(propName => {
   const methodName = 'set' + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {

--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
     "access": "public"
   },
   "scripts": {
-    "coverage": "node_modules/.bin/nyc --reporter=lcov node_modules/.bin/mocha",
+    "coverage": "node_modules/.bin/nyc --reporter=lcov node_modules/.bin/mocha 'test/**/*.js'",
     "lint": "npm run eslint && npm run prettier",
     "eslint": "eslint .",
     "prettier": "prettier --write {lib,test,examples,mock}/{**/*,*}.js index.js",
-    "test": "node_modules/.bin/mocha"
+    "test": "node_modules/.bin/mocha 'test/**/*.js'"
   },
   "jshintConfig": {
     "node": true

--- a/test/credentials/certificate/parse.js
+++ b/test/credentials/certificate/parse.js
@@ -47,7 +47,6 @@ describe('parseCredentials', function () {
           .withArgs('encryptedPfxData', 'apntest')
           .returns({ key: pfxKey, certificates: [pfxCert] });
         fakes.parsePkcs12
-          .withArgs('encryptedPfxData', sinon.match.any)
           .throws(new Error('unable to read credentials, incorrect passphrase'));
       });
 
@@ -81,9 +80,7 @@ describe('parseCredentials', function () {
     describe('having passphrase', function () {
       beforeEach(function () {
         fakes.parsePemKey.withArgs('encryptedPemKeyData', 'apntest').returns(pemKey);
-        fakes.parsePemKey
-          .withArgs('encryptedPemKeyData', sinon.match.any)
-          .throws(new Error('unable to load key, incorrect passphrase'));
+        fakes.parsePemKey.throws(new Error('unable to load key, incorrect passphrase'));
       });
 
       it('returns the parsed key', function () {

--- a/test/credentials/certificate/prepare.js
+++ b/test/credentials/certificate/prepare.js
@@ -80,7 +80,7 @@ describe('perpareCertificate', function () {
       });
 
       it('contains the CA data', function () {
-        return expect(credentials).to.have.deep.property('ca[0]', 'myCaData');
+        return expect(credentials).to.have.nested.deep.property('ca[0]', 'myCaData');
       });
 
       it('includes passphrase', function () {

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -104,19 +104,24 @@ describe('Notification', function () {
         });
 
         it('retains the alert body correctly', function () {
-          const payload = compiledOutput();
           expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Good Morning');
         });
 
         it('sets the aps.alert.loc-key property', function () {
-          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.loc-key', 'good_morning');
+          expect(compiledOutput()).to.have.nested.deep.property(
+            'aps.alert.loc-key',
+            'good_morning'
+          );
         });
       });
 
       describe('setLocKey', function () {
         it('is chainable', function () {
           expect(note.setLocKey('good_morning')).to.equal(note);
-          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.loc-key', 'good_morning');
+          expect(compiledOutput()).to.have.nested.deep.property(
+            'aps.alert.loc-key',
+            'good_morning'
+          );
         });
       });
     });
@@ -288,14 +293,20 @@ describe('Notification', function () {
         });
 
         it('sets the aps.alert.title-loc-key property', function () {
-          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title-loc-key', 'Warning');
+          expect(compiledOutput()).to.have.nested.deep.property(
+            'aps.alert.title-loc-key',
+            'Warning'
+          );
         });
       });
 
       describe('setAlert', function () {
         it('is chainable', function () {
           expect(note.setTitleLocKey('greeting')).to.equal(note);
-          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title-loc-key', 'greeting');
+          expect(compiledOutput()).to.have.nested.deep.property(
+            'aps.alert.title-loc-key',
+            'greeting'
+          );
         });
       });
     });
@@ -397,7 +408,10 @@ describe('Notification', function () {
     describe('actionLocKey', function () {
       it('sets the aps.alert.action-loc-key property', function () {
         note.actionLocKey = 'reply_title';
-        expect(compiledOutput()).to.have.nested.deep.property('aps.alert.action-loc-key', 'reply_title');
+        expect(compiledOutput()).to.have.nested.deep.property(
+          'aps.alert.action-loc-key',
+          'reply_title'
+        );
       });
 
       context('alert is already an object', function () {

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -9,31 +9,31 @@ describe('Notification', function () {
   describe('aps convenience properties', function () {
     describe('alert', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.alert');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.alert');
       });
 
       it('can be set to a string', function () {
         note.alert = 'hello';
-        expect(compiledOutput()).to.have.deep.property('aps.alert', 'hello');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert', 'hello');
       });
 
       it('can be set to an object', function () {
         note.alert = { body: 'hello' };
         expect(compiledOutput())
-          .to.have.deep.property('aps.alert')
+          .to.have.nested.deep.property('aps.alert')
           .that.deep.equals({ body: 'hello' });
       });
 
       it('can be set to undefined', function () {
         note.alert = { body: 'hello' };
         note.alert = undefined;
-        expect(compiledOutput()).to.not.have.deep.property('aps.alert');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.alert');
       });
 
       describe('setAlert', function () {
         it('is chainable', function () {
           expect(note.setAlert('hello')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.alert', 'hello');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert', 'hello');
         });
       });
     });
@@ -50,7 +50,7 @@ describe('Notification', function () {
 
       it('sets alert as a string by default', function () {
         note.body = 'Hello, world';
-        expect(compiledOutput()).to.have.deep.property('aps.alert', 'Hello, world');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert', 'Hello, world');
       });
 
       context('alert is already an Object', function () {
@@ -64,14 +64,14 @@ describe('Notification', function () {
 
         it('sets the value correctly', function () {
           note.body = 'Hello, world';
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
       });
 
       describe('setBody', function () {
         it('is chainable', function () {
           expect(note.setBody('hello')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.alert', 'hello');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert', 'hello');
         });
       });
     });
@@ -79,7 +79,7 @@ describe('Notification', function () {
     describe('locKey', function () {
       it('sets the aps.alert.loc-key property', function () {
         note.locKey = 'hello_world';
-        expect(compiledOutput()).to.have.deep.property('aps.alert.loc-key', 'hello_world');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert.loc-key', 'hello_world');
       });
 
       context('alert is already an object', function () {
@@ -89,7 +89,7 @@ describe('Notification', function () {
         });
 
         it('contains all expected properties', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert').that.deep.equals({
             body: 'Test',
             'launch-image': 'test.png',
             'loc-key': 'hello_world',
@@ -104,18 +104,19 @@ describe('Notification', function () {
         });
 
         it('retains the alert body correctly', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Good Morning');
+          const payload = compiledOutput();
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Good Morning');
         });
 
         it('sets the aps.alert.loc-key property', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.loc-key', 'good_morning');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.loc-key', 'good_morning');
         });
       });
 
       describe('setLocKey', function () {
         it('is chainable', function () {
           expect(note.setLocKey('good_morning')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.alert.loc-key', 'good_morning');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.loc-key', 'good_morning');
         });
       });
     });
@@ -124,7 +125,7 @@ describe('Notification', function () {
       it('sets the aps.alert.loc-args property', function () {
         note.locArgs = ['arg1', 'arg2'];
         expect(compiledOutput())
-          .to.have.deep.property('aps.alert.loc-args')
+          .to.have.nested.deep.property('aps.alert.loc-args')
           .that.deep.equals(['arg1', 'arg2']);
       });
 
@@ -136,7 +137,7 @@ describe('Notification', function () {
 
         it('contains all expected properties', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert')
+            .to.have.nested.deep.property('aps.alert')
             .that.deep.equals({
               body: 'Test',
               'launch-image': 'test.png',
@@ -152,12 +153,12 @@ describe('Notification', function () {
         });
 
         it('retains the alert body', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
 
         it('sets the aps.alert.loc-args property', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert.loc-args')
+            .to.have.nested.deep.property('aps.alert.loc-args')
             .that.deep.equals(['Hi there']);
         });
       });
@@ -166,7 +167,7 @@ describe('Notification', function () {
         it('is chainable', function () {
           expect(note.setLocArgs(['Robert'])).to.equal(note);
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert.loc-args')
+            .to.have.nested.deep.property('aps.alert.loc-args')
             .that.deep.equals(['Robert']);
         });
       });
@@ -175,7 +176,7 @@ describe('Notification', function () {
     describe('title', function () {
       it('sets the aps.alert.title property', function () {
         note.title = 'node-apn';
-        expect(compiledOutput()).to.have.deep.property('aps.alert.title', 'node-apn');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title', 'node-apn');
       });
 
       context('alert is already an object', function () {
@@ -186,7 +187,7 @@ describe('Notification', function () {
 
         it('contains all expected properties', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert')
+            .to.have.nested.deep.property('aps.alert')
             .that.deep.equals({ body: 'Test', 'launch-image': 'test.png', title: 'node-apn' });
         });
       });
@@ -198,18 +199,18 @@ describe('Notification', function () {
         });
 
         it('retains the alert body', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
 
         it('sets the aps.alert.title property', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.title', 'Welcome');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title', 'Welcome');
         });
       });
 
       describe('setTitle', function () {
         it('is chainable', function () {
           expect(note.setTitle('Bienvenue')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.alert.title', 'Bienvenue');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title', 'Bienvenue');
         });
       });
     });
@@ -217,7 +218,7 @@ describe('Notification', function () {
     describe('subtitle', function () {
       it('sets the aps.alert.subtitle property', function () {
         note.subtitle = 'node-apn';
-        expect(compiledOutput()).to.have.deep.property('aps.alert.subtitle', 'node-apn');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert.subtitle', 'node-apn');
       });
 
       context('alert is already an object', function () {
@@ -228,7 +229,7 @@ describe('Notification', function () {
 
         it('contains all expected properties', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert')
+            .to.have.nested.deep.property('aps.alert')
             .that.deep.equals({ body: 'Test', 'launch-image': 'test.png', subtitle: 'node-apn' });
         });
       });
@@ -240,25 +241,25 @@ describe('Notification', function () {
         });
 
         it('retains the alert body', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
 
         it('sets the aps.alert.subtitle property', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.subtitle', 'Welcome');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.subtitle', 'Welcome');
         });
       });
 
       describe('setSubtitle', function () {
         it('is chainable', function () {
           expect(note.setSubtitle('Bienvenue')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.alert.subtitle', 'Bienvenue');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.subtitle', 'Bienvenue');
         });
       });
     });
     describe('titleLocKey', function () {
       it('sets the aps.alert.title-loc-key property', function () {
         note.titleLocKey = 'Warning';
-        expect(compiledOutput()).to.have.deep.property('aps.alert.title-loc-key', 'Warning');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title-loc-key', 'Warning');
       });
 
       context('alert is already an object', function () {
@@ -268,7 +269,7 @@ describe('Notification', function () {
         });
 
         it('contains all expected properties', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert').that.deep.equals({
             body: 'Test',
             'launch-image': 'test.png',
             'title-loc-key': 'Warning',
@@ -283,18 +284,18 @@ describe('Notification', function () {
         });
 
         it('retains the alert body correctly', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
 
         it('sets the aps.alert.title-loc-key property', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.title-loc-key', 'Warning');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title-loc-key', 'Warning');
         });
       });
 
       describe('setAlert', function () {
         it('is chainable', function () {
           expect(note.setTitleLocKey('greeting')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.alert.title-loc-key', 'greeting');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.title-loc-key', 'greeting');
         });
       });
     });
@@ -303,7 +304,7 @@ describe('Notification', function () {
       it('sets the aps.alert.title-loc-args property', function () {
         note.titleLocArgs = ['arg1', 'arg2'];
         expect(compiledOutput())
-          .to.have.deep.property('aps.alert.title-loc-args')
+          .to.have.nested.deep.property('aps.alert.title-loc-args')
           .that.deep.equals(['arg1', 'arg2']);
       });
 
@@ -315,7 +316,7 @@ describe('Notification', function () {
 
         it('contains all expected properties', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert')
+            .to.have.nested.deep.property('aps.alert')
             .that.deep.equals({
               body: 'Test',
               'launch-image': 'test.png',
@@ -331,12 +332,12 @@ describe('Notification', function () {
         });
 
         it('retains the alert body', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
 
         it('sets the aps.alert.title-loc-args property', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert.title-loc-args')
+            .to.have.nested.deep.property('aps.alert.title-loc-args')
             .that.deep.equals(['Hi there']);
         });
       });
@@ -345,7 +346,7 @@ describe('Notification', function () {
         it('is chainable', function () {
           expect(note.setTitleLocArgs(['iPhone 6s'])).to.equal(note);
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert.title-loc-args')
+            .to.have.nested.deep.property('aps.alert.title-loc-args')
             .that.deep.equals(['iPhone 6s']);
         });
       });
@@ -354,7 +355,7 @@ describe('Notification', function () {
     describe('action', function () {
       it('sets the aps.alert.action property', function () {
         note.action = 'View';
-        expect(compiledOutput()).to.have.deep.property('aps.alert.action', 'View');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert.action', 'View');
       });
 
       context('alert is already an object', function () {
@@ -365,7 +366,7 @@ describe('Notification', function () {
 
         it('contains all expected properties', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert')
+            .to.have.nested.deep.property('aps.alert')
             .that.deep.equals({ body: 'Test', 'launch-image': 'test.png', action: 'View' });
         });
       });
@@ -377,18 +378,18 @@ describe('Notification', function () {
         });
 
         it('retains the alert body', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Alert');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Alert');
         });
 
         it('sets the aps.alert.action property', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.action', 'Investigate');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.action', 'Investigate');
         });
       });
 
       describe('setAction', function () {
         it('is chainable', function () {
           expect(note.setAction('Reply')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.alert.action', 'Reply');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.action', 'Reply');
         });
       });
     });
@@ -396,7 +397,7 @@ describe('Notification', function () {
     describe('actionLocKey', function () {
       it('sets the aps.alert.action-loc-key property', function () {
         note.actionLocKey = 'reply_title';
-        expect(compiledOutput()).to.have.deep.property('aps.alert.action-loc-key', 'reply_title');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert.action-loc-key', 'reply_title');
       });
 
       context('alert is already an object', function () {
@@ -406,7 +407,7 @@ describe('Notification', function () {
         });
 
         it('contains all expected properties', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert').that.deep.equals({
             body: 'Test',
             'launch-image': 'test.png',
             'action-loc-key': 'reply_title',
@@ -421,11 +422,11 @@ describe('Notification', function () {
         });
 
         it('retains the alert body correctly', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
 
         it('sets the aps.alert.action-loc-key property', function () {
-          expect(compiledOutput()).to.have.deep.property(
+          expect(compiledOutput()).to.have.nested.deep.property(
             'aps.alert.action-loc-key',
             'ignore_title'
           );
@@ -435,7 +436,7 @@ describe('Notification', function () {
       describe('setActionLocKey', function () {
         it('is chainable', function () {
           expect(note.setActionLocKey('ignore_title')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property(
+          expect(compiledOutput()).to.have.nested.deep.property(
             'aps.alert.action-loc-key',
             'ignore_title'
           );
@@ -447,7 +448,7 @@ describe('Notification', function () {
       it('sets the aps.alert.launch-image property', function () {
         note.launchImage = 'testLaunch.png';
         expect(compiledOutput())
-          .to.have.deep.property('aps.alert.launch-image')
+          .to.have.nested.deep.property('aps.alert.launch-image')
           .that.deep.equals('testLaunch.png');
       });
 
@@ -458,7 +459,7 @@ describe('Notification', function () {
         });
 
         it('contains all expected properties', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert').that.deep.equals({
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert').that.deep.equals({
             body: 'Test',
             'title-loc-key': 'node-apn',
             'launch-image': 'apnLaunch.png',
@@ -473,12 +474,12 @@ describe('Notification', function () {
         });
 
         it('retains the alert body', function () {
-          expect(compiledOutput()).to.have.deep.property('aps.alert.body', 'Hello, world');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.alert.body', 'Hello, world');
         });
 
         it('sets the aps.alert.launch-image property', function () {
           expect(compiledOutput())
-            .to.have.deep.property('aps.alert.launch-image')
+            .to.have.nested.deep.property('aps.alert.launch-image')
             .that.deep.equals('apnLaunch.png');
         });
       });
@@ -486,7 +487,7 @@ describe('Notification', function () {
       describe('setLaunchImage', function () {
         it('is chainable', function () {
           expect(note.setLaunchImage('remoteLaunch.png')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property(
+          expect(compiledOutput()).to.have.nested.deep.property(
             'aps.alert.launch-image',
             'remoteLaunch.png'
           );
@@ -496,64 +497,64 @@ describe('Notification', function () {
 
     describe('badge', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.badge');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.badge');
       });
 
       it('can be set to a number', function () {
         note.badge = 5;
 
-        expect(compiledOutput()).to.have.deep.property('aps.badge', 5);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.badge', 5);
       });
 
       it('can be set to undefined', function () {
         note.badge = 5;
         note.badge = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.badge');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.badge');
       });
 
       it('can be set to zero', function () {
         note.badge = 0;
 
-        expect(compiledOutput()).to.have.deep.property('aps.badge', 0);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.badge', 0);
       });
 
       it('cannot be set to a string', function () {
         note.badge = 'hello';
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.badge');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.badge');
       });
 
       describe('setBadge', function () {
         it('is chainable', function () {
           expect(note.setBadge(7)).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.badge', 7);
+          expect(compiledOutput()).to.have.nested.deep.property('aps.badge', 7);
         });
       });
     });
 
     describe('sound', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.sound');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.sound');
       });
 
       it('can be set to a string', function () {
         note.sound = 'sound.caf';
 
-        expect(compiledOutput()).to.have.deep.property('aps.sound', 'sound.caf');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.sound', 'sound.caf');
       });
 
       it('can be set to undefined', function () {
         note.sound = 'sound.caf';
         note.sound = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.sound');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.sound');
       });
 
       it('cannot be set to a number', function () {
         note.sound = 5;
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.sound');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.sound');
       });
 
       it('can be set to object', function () {
@@ -563,86 +564,86 @@ describe('Notification', function () {
           volume: 0.75,
         };
 
-        expect(compiledOutput()).to.have.deep.property('aps.sound.name', 'sound.caf');
-        expect(compiledOutput()).to.have.deep.property('aps.sound.critical', 1);
-        expect(compiledOutput()).to.have.deep.property('aps.sound.volume', 0.75);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.sound.name', 'sound.caf');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.sound.critical', 1);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.sound.volume', 0.75);
       });
 
       describe('setSound', function () {
         it('is chainable', function () {
           expect(note.setSound('bee.caf')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.sound', 'bee.caf');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.sound', 'bee.caf');
         });
       });
     });
 
     describe('content-available', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.content-available');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.content-available');
       });
 
       it('can be set to a boolean value', function () {
         note.contentAvailable = true;
 
-        expect(compiledOutput()).to.have.deep.property('aps.content-available', 1);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.content-available', 1);
       });
 
       it('can be set to `1`', function () {
         note.contentAvailable = 1;
 
-        expect(compiledOutput()).to.have.deep.property('aps.content-available', 1);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.content-available', 1);
       });
 
       it('can be set to undefined', function () {
         note.contentAvailable = true;
         note.contentAvailable = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.content-available');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.content-available');
       });
 
       describe('setContentAvailable', function () {
         it('is chainable', function () {
           expect(note.setContentAvailable(true)).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.content-available', 1);
+          expect(compiledOutput()).to.have.nested.deep.property('aps.content-available', 1);
         });
       });
     });
 
     describe('mutable-content', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.mutable-content');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.mutable-content');
       });
 
       it('can be set to a boolean value', function () {
         note.mutableContent = true;
 
-        expect(compiledOutput()).to.have.deep.property('aps.mutable-content', 1);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.mutable-content', 1);
       });
 
       it('can be set to `1`', function () {
         note.mutableContent = 1;
 
-        expect(compiledOutput()).to.have.deep.property('aps.mutable-content', 1);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.mutable-content', 1);
       });
 
       it('can be set to undefined', function () {
         note.mutableContent = true;
         note.mutableContent = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.mutable-content');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.mutable-content');
       });
 
       describe('setMutableContent', function () {
         it('is chainable', function () {
           expect(note.setMutableContent(true)).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.mutable-content', 1);
+          expect(compiledOutput()).to.have.nested.deep.property('aps.mutable-content', 1);
         });
       });
     });
 
     describe('mdm', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('mdm');
+        expect(compiledOutput()).to.not.have.nested.deep.property('mdm');
       });
 
       it('can be set to a string', function () {
@@ -655,7 +656,7 @@ describe('Notification', function () {
         note.mdm = 'mdm payload';
         note.mdm = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property('mdm');
+        expect(compiledOutput()).to.not.have.nested.deep.property('mdm');
       });
 
       it('does not include the aps payload', function () {
@@ -668,21 +669,21 @@ describe('Notification', function () {
       describe('setMdm', function () {
         it('is chainable', function () {
           expect(note.setMdm('hello')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('mdm', 'hello');
+          expect(compiledOutput()).to.have.nested.deep.property('mdm', 'hello');
         });
       });
     });
 
     describe('urlArgs', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.url-args');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.url-args');
       });
 
       it('can be set to an array', function () {
         note.urlArgs = ['arg1', 'arg2'];
 
         expect(compiledOutput())
-          .to.have.deep.property('aps.url-args')
+          .to.have.nested.deep.property('aps.url-args')
           .that.deep.equals(['arg1', 'arg2']);
       });
 
@@ -690,14 +691,14 @@ describe('Notification', function () {
         note.urlArgs = ['arg1', 'arg2'];
         note.urlArgs = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.url-args');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.url-args');
       });
 
       describe('setUrlArgs', function () {
         it('is chainable', function () {
           expect(note.setUrlArgs(['A318', 'BA001'])).to.equal(note);
           expect(compiledOutput())
-            .to.have.deep.property('aps.url-args')
+            .to.have.nested.deep.property('aps.url-args')
             .that.deep.equals(['A318', 'BA001']);
         });
       });
@@ -705,24 +706,24 @@ describe('Notification', function () {
 
     describe('category', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.category');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.category');
       });
 
       it('can be set to a string', function () {
         note.category = 'the-category';
-        expect(compiledOutput()).to.have.deep.property('aps.category', 'the-category');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.category', 'the-category');
       });
 
       it('can be set to undefined', function () {
         note.category = 'the-category';
         note.category = undefined;
-        expect(compiledOutput()).to.not.have.deep.property('aps.category');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.category');
       });
 
       describe('setCategory', function () {
         it('is chainable', function () {
           expect(note.setCategory('reminder')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.category', 'reminder');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.category', 'reminder');
         });
       });
     });
@@ -761,26 +762,26 @@ describe('Notification', function () {
 
     describe('thread-id', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.deep.property('aps.thread-id');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.thread-id');
       });
 
       it('can be set to a string', function () {
         note.threadId = 'the-thread-id';
 
-        expect(compiledOutput()).to.have.deep.property('aps.thread-id', 'the-thread-id');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.thread-id', 'the-thread-id');
       });
 
       it('can be set to undefined', function () {
         note.threadId = 'the-thread-id';
         note.threadId = undefined;
 
-        expect(compiledOutput()).to.not.have.deep.property('aps.thread-id');
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.thread-id');
       });
 
       describe('setThreadId', function () {
         it('is chainable', function () {
           expect(note.setThreadId('the-thread-id')).to.equal(note);
-          expect(compiledOutput()).to.have.deep.property('aps.thread-id', 'the-thread-id');
+          expect(compiledOutput()).to.have.nested.deep.property('aps.thread-id', 'the-thread-id');
         });
       });
     });

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -15,7 +15,7 @@ describe('Notification', function () {
       expect(note.payload).to.deep.equal({ foo: 'bar' });
       expect(note.priority).to.equal(5);
       expect(note.topic).to.equal('io.apn.node');
-      expect(compiledOutput()).to.have.deep.property('aps.badge', 5);
+      expect(compiledOutput()).to.have.nested.deep.property('aps.badge', 5);
     });
   });
 
@@ -61,8 +61,8 @@ describe('Notification', function () {
       });
 
       it('contains the correct aps properties', function () {
-        expect(compiledOutput()).to.have.deep.property('aps.badge', 1);
-        expect(compiledOutput()).to.have.deep.property('aps.alert', 'Hi there!');
+        expect(compiledOutput()).to.have.nested.deep.property('aps.badge', 1);
+        expect(compiledOutput()).to.have.nested.deep.property('aps.alert', 'Hi there!');
       });
     });
   });


### PR DESCRIPTION
Summary of changes:
- updated the `test` and `coverage` scripts to run all test files in the test folder: `'test/**/*.js'`
- added missing setter method for `targetContentIdentifier` property
- updated multiple tests so that they are now passing (fresh clone of repo had 76 failing tests)