### PR TITLE
fix: Shutdown callback is not passed from provider to client

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -42,8 +42,8 @@ module.exports = function (dependencies) {
     );
   };
 
-  Provider.prototype.shutdown = function shutdown() {
-    this.client.shutdown();
+  Provider.prototype.shutdown = function shutdown(callback) {
+    this.client.shutdown(callback);
   };
 
   return Provider;

--- a/test/provider.js
+++ b/test/provider.js
@@ -174,10 +174,11 @@ describe('Provider', function () {
 
   describe('shutdown', function () {
     it('invokes shutdown on the client', function () {
+      const callback = sinon.spy();
       const provider = new Provider({});
-      provider.shutdown();
+      provider.shutdown(callback);
 
-      expect(fakes.client.shutdown).to.be.calledOnce;
+      expect(fakes.client.shutdown).to.be.calledOnceWithExactly(callback);
     });
   });
 });


### PR DESCRIPTION
Pass the optional shutdown callback from the Provider through to the Client.

fix #117