### PR TITLE
fix: Incorrect field name `event` instead of `events` in Live Activity push notification payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ note.pushType = "liveactivity",
 note.relevanceScore = 75,
 note.timestamp = Math.floor(Date.now() / 1000); // Current time
 note.staleDate = Math.floor(Date.now() / 1000) + (8 * 3600); // Expires 8 hour from now.
-note.event = "update"
+note.events = "update"
 note.contentState = {}
 ```
 
@@ -179,7 +179,7 @@ This will result in the the following notification payload being sent to the dev
 
 
 ```json
-{"messageFrom":"John Appleseed","aps":{"badge":3,"sound":"ping.aiff","alert":"\uD83D\uDCE7 \u2709 You have a new message", "relevance-score":75,"timestamp":1683129662,"stale-date":1683216062,"event":"update","content-state":{}}}
+{"messageFrom":"John Appleseed","aps":{"badge":3,"sound":"ping.aiff","alert":"\uD83D\uDCE7 \u2709 You have a new message", "relevance-score":75,"timestamp":1683129662,"stale-date":1683216062,"events":"update","content-state":{}}}
 ```
 
 You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`.

--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -110,7 +110,7 @@ This table shows the name of the setter, with the key-path of the underlying pro
 | `relevanceScore`           | `aps.relevance-score`       | `Number`            |
 | `timestamp`                | `aps.timestamp`             | `Number`            |
 | `staleDate`                | `aps.staleDate`             | `Number`            |
-| `event`                    | `aps.event`                 | `String`            |
+| `events`                   | `aps.events`                | `String`            |
 | `contentState`             | `aps.content-state`         | `Object`            |
 | `mdm`                      | `mdm`                       | `String`            |
 

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -101,9 +101,9 @@ module.exports = {
     }
   },
 
-  set event(value) {
+  set events(value) {
     if (typeof value === 'string' || value === undefined) {
-      this.aps.event = value;
+      this.aps.events = value;
     }
   },
 

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -52,7 +52,7 @@ Notification.prototype = require('./apsProperties');
   'relevanceScore',
   'timestamp',
   'staleDate',
-  'event',
+  'events',
   'contentState',
 ].forEach(propName => {
   const methodName = 'set' + propName[0].toUpperCase() + propName.slice(1);

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -832,28 +832,28 @@ describe('Notification', function () {
       });
     });
 
-    describe('event', function () {
+    describe('events', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.nested.property('aps.event');
+        expect(compiledOutput()).to.not.have.nested.property('aps.events');
       });
 
       it('can be set to a string', function () {
-        note.event = 'the-event';
+        note.events = 'the-event';
 
-        expect(compiledOutput()).to.have.nested.property('aps.event', 'the-event');
+        expect(compiledOutput()).to.have.nested.property('aps.events', 'the-event');
       });
 
       it('can be set to undefined', function () {
-        note.event = 'the-event';
-        note.event = undefined;
+        note.events = 'the-event';
+        note.events = undefined;
 
-        expect(compiledOutput()).to.not.have.nested.property('aps.event');
+        expect(compiledOutput()).to.not.have.nested.property('aps.events');
       });
 
-      describe('setEvent', function () {
+      describe('setEvents', function () {
         it('is chainable', function () {
-          expect(note.setEvent('the-event')).to.equal(note);
-          expect(compiledOutput()).to.have.nested.property('aps.event', 'the-event');
+          expect(note.setEvents('the-event')).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property('aps.events', 'the-event');
         });
       });
     });


### PR DESCRIPTION
Per the documentation https://developer.apple.com/documentation/activitykit/updating-and-ending-your-live-activity-with-activitykit-push-notifications

`event` should be `events`