### PR TITLE
fix: Incorrect key `events` instead of `event` for Live Activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ note.pushType = "liveactivity",
 note.relevanceScore = 75,
 note.timestamp = Math.floor(Date.now() / 1000); // Current time
 note.staleDate = Math.floor(Date.now() / 1000) + (8 * 3600); // Expires 8 hour from now.
-note.events = "update"
+note.event = "update"
 note.contentState = {}
 ```
 
@@ -179,7 +179,7 @@ This will result in the the following notification payload being sent to the dev
 
 
 ```json
-{"messageFrom":"John Appleseed","aps":{"badge":3,"sound":"ping.aiff","alert":"\uD83D\uDCE7 \u2709 You have a new message", "relevance-score":75,"timestamp":1683129662,"stale-date":1683216062,"events":"update","content-state":{}}}
+{"messageFrom":"John Appleseed","aps":{"badge":3,"sound":"ping.aiff","alert":"\uD83D\uDCE7 \u2709 You have a new message", "relevance-score":75,"timestamp":1683129662,"stale-date":1683216062,"event":"update","content-state":{}}}
 ```
 
 You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`.

--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -112,6 +112,7 @@ This table shows the name of the setter, with the key-path of the underlying pro
 | `staleDate`                | `aps.staleDate`             | `Number`            |
 | `event`                    | `aps.event`                 | `String`            |
 | `contentState`             | `aps.content-state`         | `Object`            |
+| `dismissalDate`            | `aps.dismissal-date`        | `Number`            |
 | `mdm`                      | `mdm`                       | `String`            |
 
 When the notification is transmitted these properties will be added to the output before encoding.

--- a/doc/notification.markdown
+++ b/doc/notification.markdown
@@ -110,7 +110,7 @@ This table shows the name of the setter, with the key-path of the underlying pro
 | `relevanceScore`           | `aps.relevance-score`       | `Number`            |
 | `timestamp`                | `aps.timestamp`             | `Number`            |
 | `staleDate`                | `aps.staleDate`             | `Number`            |
-| `events`                   | `aps.events`                | `String`            |
+| `event`                    | `aps.event`                 | `String`            |
 | `contentState`             | `aps.content-state`         | `Object`            |
 | `mdm`                      | `mdm`                       | `String`            |
 

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -113,6 +113,12 @@ module.exports = {
     }
   },
 
+  set dismissalDate(value) {
+    if (typeof value === 'number' || value === undefined) {
+      this.aps['dismissal-date'] = value;
+    }
+  },
+
   set contentAvailable(value) {
     if (value === true || value === 1) {
       this.aps['content-available'] = 1;

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -101,9 +101,9 @@ module.exports = {
     }
   },
 
-  set events(value) {
+  set event(value) {
     if (typeof value === 'string' || value === undefined) {
-      this.aps.events = value;
+      this.aps.event = value;
     }
   },
 

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -52,7 +52,7 @@ Notification.prototype = require('./apsProperties');
   'relevanceScore',
   'timestamp',
   'staleDate',
-  'events',
+  'event',
   'contentState',
 ].forEach(propName => {
   const methodName = 'set' + propName[0].toUpperCase() + propName.slice(1);

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -54,6 +54,7 @@ Notification.prototype = require('./apsProperties');
   'staleDate',
   'event',
   'contentState',
+  'dismissalDate'
 ].forEach(propName => {
   const methodName = 'set' + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -832,28 +832,28 @@ describe('Notification', function () {
       });
     });
 
-    describe('events', function () {
+    describe('event', function () {
       it('defaults to undefined', function () {
-        expect(compiledOutput()).to.not.have.nested.property('aps.events');
+        expect(compiledOutput()).to.not.have.nested.property('aps.event');
       });
 
       it('can be set to a string', function () {
-        note.events = 'the-event';
+        note.event = 'the-event';
 
-        expect(compiledOutput()).to.have.nested.property('aps.events', 'the-event');
+        expect(compiledOutput()).to.have.nested.property('aps.event', 'the-event');
       });
 
       it('can be set to undefined', function () {
-        note.events = 'the-event';
-        note.events = undefined;
+        note.event = 'the-event';
+        note.event = undefined;
 
-        expect(compiledOutput()).to.not.have.nested.property('aps.events');
+        expect(compiledOutput()).to.not.have.nested.property('aps.event');
       });
 
-      describe('setEvents', function () {
+      describe('setEvent', function () {
         it('is chainable', function () {
-          expect(note.setEvents('the-event')).to.equal(note);
-          expect(compiledOutput()).to.have.nested.property('aps.events', 'the-event');
+          expect(note.setEvent('the-event')).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property('aps.event', 'the-event');
         });
       });
     });

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -858,6 +858,32 @@ describe('Notification', function () {
       });
     });
 
+    describe('dismissalDate', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.dismissal-date');
+      });
+
+      it('can be set to a number', function () {
+        note.dismissalDate = '123456';
+
+        expect(compiledOutput()).to.have.nested.property('aps.dismissal-date', 123456);
+      });
+
+      it('can be set to undefined', function () {
+        note.dismissalDate = '123456';
+        note.dismissalDate = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property('aps.dismissal-date');
+      });
+
+      describe('setDismissalDate', function () {
+        it('is chainable', function () {
+          expect(note.setDismissalDate(123456)).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property('aps.dismissal-date', 123456);
+        });
+      });
+    });
+
     describe('timestamp', function () {
       it('defaults to undefined', function () {
         expect(compiledOutput()).to.not.have.nested.property('aps.timestamp');


### PR DESCRIPTION
Continuing from [here](https://github.com/parse-community/node-apn/pull/133#issuecomment-1747747998).

This reverts this PR from @dplewis.
Additionally it adds `dismissal-date` as a field to APS + tests. 