### PR TITLE
feat: Add support for Node 18, 20 drop support for Node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Node.js 12
-            NODE_VERSION: 12
           - name: Node.js 14
             NODE_VERSION: 14
           - name: Node.js 16
             NODE_VERSION: 16
+          - name: Node.js 18
+            NODE_VERSION: 18
+          - name: Node.js 20
+            NODE_VERSION: 20
+      fail-fast: false
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/test/client.js
+++ b/test/client.js
@@ -427,10 +427,8 @@ describe('Client', () => {
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingGoAway = async () => {
       const result = await client.write(mockNotification, mockDevice);
-      expect(result).to.deep.equal({
-        device: MOCK_DEVICE_TOKEN,
-        error: new VError('stream ended unexpectedly with status null and empty body'),
-      });
+      expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
+      expect(result.error).to.be.an.instanceof(VError);
       expect(didGetRequest).to.be.true;
       didGetRequest = false;
     };

--- a/test/client.js
+++ b/test/client.js
@@ -352,9 +352,7 @@ describe('Client', () => {
       const result = await client.write(mockNotification, mockDevice);
       // Should not happen, but if it does, the promise should resolve with an error
       expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
-      expect(result.error.message).to.equal(
-        'Unexpected error processing APNs response: Unexpected token P in JSON at position 0'
-      );
+      expect(result.error.message.startsWith('Unexpected error processing APNs response: Unexpected token')).to.equal(true);
     };
     await runRequestWithInternalServerError();
     await runRequestWithInternalServerError();

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -373,9 +373,7 @@ describe('MultiClient', () => {
       const result = await client.write(mockNotification, mockDevice);
       // Should not happen, but if it does, the promise should resolve with an error
       expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
-      expect(result.error.message).to.equal(
-        'Unexpected error processing APNs response: Unexpected token P in JSON at position 0'
-      );
+      expect(result.error.message.startsWith('Unexpected error processing APNs response: Unexpected token')).to.equal(true);
     };
     await runRequestWithInternalServerError();
     await runRequestWithInternalServerError();

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -448,10 +448,8 @@ describe('MultiClient', () => {
     const mockDevice = MOCK_DEVICE_TOKEN;
     const performRequestExpectingGoAway = async () => {
       const result = await client.write(mockNotification, mockDevice);
-      expect(result).to.deep.equal({
-        device: MOCK_DEVICE_TOKEN,
-        error: new VError('stream ended unexpectedly with status null and empty body'),
-      });
+      expect(result.device).to.equal(MOCK_DEVICE_TOKEN);
+      expect(result.error).to.be.an.instanceof(VError);
       expect(didGetRequest).to.be.true;
       didGetRequest = false;
     };

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -960,7 +960,6 @@ describe('Notification', function () {
       describe('setContentState', function () {
         it('is chainable', function () {
           expect(note.setContentState(payload)).to.equal(note);
-          console.log(compiledOutput());
           expect(compiledOutput())
             .to.have.nested.property('aps.content-state')
             .that.deep.equals(payload);


### PR DESCRIPTION
https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#nodejs

There was a fix in the http2 module to correctly handle errors. Before we had to parse the error in the `end` event now its handled on `error` emitter on client requests.

Closes: #132

This PR is referencing #131, which has now been closed.