### PR TITLE
fix: Minimum required Node version in `engines.node` has not been upgraded to Node 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     }
   },
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Follow up after #137