### PR TITLE
feat: Add the ability to manage channels and send broadcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A Node.js module for interfacing with the Apple Push Notification service.
     - [Connecting through an HTTP proxy](#connecting-through-an-http-proxy)
     - [Using a pool of http/2 connections](#using-a-pool-of-http2-connections)
   - [Sending a notification](#sending-a-notification)
+  - [Managing channels](#manage-channels)
+  - [Sending a broadcast notification](#sending-a-broadcast-notification)
 
 # Features
 
@@ -178,7 +180,7 @@ Send the notification to the API with `send`, which returns a promise.
 
 ```javascript
 try {
-  const result = await apnProvider.send(note, deviceToken)
+  const result = await apnProvider.send(note, deviceToken);
   // see documentation for an explanation of result
 } catch (error) {
   // Handle error...
@@ -193,5 +195,92 @@ This will result in the the following notification payload being sent to the dev
 ```
 
 ## Manage Channels
+Live Activities can be used to broadcast push notifications over channels. To do so, you will need your apps `bundleId`. 
 
-## Sending Broadcast Notifications
+```javascript
+let bundleId = "com.node.apn";
+```
+
+Create a notification object, configuring it with the relevant parameters (See the [notification documentation](doc/notification.markdown) for more details.)
+
+```javascript
+let note = new apn.Notification();
+
+note.requestId = "0309F412-AA57-46A8-9AC6-B5AECA8C4594"; // Optional
+note.payload = {'message-storage-policy': '1', 'push-type': 'liveactivity'}; // Required
+```
+
+Create a channel with `manageChannels` and the `create` action, which returns a promise.
+
+```javascript
+try {
+  const result = await apnProvider.manageChannels(note, bundleId, 'create');
+  // see documentation for an explanation of result
+} catch (error) {
+  // Handle error...
+}
+```
+
+If the channel is created succesffuly, the result will look like the folowing:
+```javascript
+{ 
+  apns-request-id: '0309F412-AA57-46A8-9AC6-B5AECA8C4594', 
+  apns-channel-id: 'dHN0LXNyY2gtY2hubA==' // The new channel
+}
+```
+
+Similarly, `manageChannels` has additional `actions` that allow you to `read`, `readAll`, and `delete` channels. The `read` and `delete` action require similar information to the `create` example above with the exception that they require `note.channelId` to be populated. To request all active channel id's, you can use the `readAll` action:
+
+```javascript
+try {
+  const result = await apnProvider.manageChannels(note, bundleId, 'readAll');
+  // see documentation for an explanation of result
+} catch (error) {
+  // Handle error...
+}
+```
+
+After the promise is fulfilled, `result` will look like the following:
+
+```javascript
+{ 
+  apns-request-id: 'some id value', 
+  channels: ['dHN0LXNyY2gtY2hubA==', 'eCN0LXNyY2gtY2hubA==' ...] // A list of active channels
+}
+```
+
+Further information about managing channels can be found in [Apple's documentation](https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns).
+
+## Sending A Broadcast Notification
+After a channel is created using `manageChannels`, broadcast push notifications can be sent to any device subscribed to the respective `channelId` created for a `bundleId`. A broadcast notification looks very similar to a standard Live Activity notification mentioned above, but also requires `note.channelId` to be populated. An example is below:
+
+```javascript
+let note = new apn.Notification();
+
+note.channelId = "dHN0LXNyY2gtY2hubA=="; // Required
+note.expiry = Math.floor(Date.now() / 1000) + 3600; // Expires 1 hour from now.
+note.badge = 3;
+note.sound = "ping.aiff";
+note.alert = "\uD83D\uDCE7 \u2709 You have a new message";
+note.payload = {'messageFrom': 'John Appleseed'};
+note.topic = "<your-app-bundle-id>";
+note.pushType = "liveactivity",
+note.relevanceScore = 75,
+note.timestamp = Math.floor(Date.now() / 1000); // Current time
+note.staleDate = Math.floor(Date.now() / 1000) + (8 * 3600); // Expires 8 hour from now.
+note.event = "update"
+note.contentState = {}
+```
+
+Send the broadcast notification to the API with `broadcast`, which returns a promise.
+
+```javascript
+try {
+  const result = await apnProvider.broadcast(note, bundleId);
+  // see documentation for an explanation of result
+} catch (error) {
+  // Handle error...
+}
+```
+
+Further information about broadcast notifications can be found in [Apple's documentation](https://developer.apple.com/documentation/usernotifications/sending-broadcast-push-notification-requests-to-apns).

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ This will result in the following notification payload being sent to the device.
 ```
 
 ## Manage Channels
-Live Activities can be used to broadcast push notifications over channels. To do so, you will need your apps' `bundleId`. 
+Starting in iOS 18 and iPadOS 18 Live Activities can be used to broadcast push notifications over channels. To do so, you will need your apps' `bundleId`. 
 
 ```javascript
 let bundleId = "com.node.apn";
@@ -252,7 +252,7 @@ After the promise is fulfilled, `result` will look like the following:
 Further information about managing channels can be found in [Apple's documentation](https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns).
 
 ## Sending A Broadcast Notification
-After a channel is created using `manageChannels`, broadcast push notifications can be sent to any device subscribed to the respective `channelId` created for a `bundleId`. A broadcast notification looks similar to a standard Live Activity notification mentioned above but requires `note.channelId` to be populated. An example is below:
+Starting in iOS 18 and iPadOS 18, after a channel is created using `manageChannels`, broadcast push notifications can be sent to any device subscribed to the respective `channelId` created for a `bundleId`. A broadcast notification looks similar to a standard Live Activity notification mentioned above but requires `note.channelId` to be populated. An example is below:
 
 ```javascript
 let note = new apn.Notification();

--- a/README.md
+++ b/README.md
@@ -70,9 +70,10 @@ For more information about configuration options, consult the [provider document
 
 Help with preparing the key and certificate files for connection can be found in the [wiki][certificateWiki]
 
-⚠️ You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app, there is no need for more than one `Provider`.
-
-If you are constantly creating `Provider` instances in your app, make sure to call `Provider.shutdown()` when you are done with each provider to release its resources and memory.
+> [!WARNING] 
+> You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app, there is no need for more than one `Provider`.
+>
+> If you are constantly creating `Provider` instances in your app, make sure to call `Provider.shutdown()` when you are done with each provider to release its resources and memory.
 
 ### Connecting through an HTTP proxy
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var options = {
   production: false
 };
 
-var apnProvider = new apn.Provider(options);
+const apnProvider = new apn.Provider(options);
 ```
 
 By default, the provider will connect to the sandbox unless the environment variable `NODE_ENV=production` is set.
@@ -67,6 +67,10 @@ By default, the provider will connect to the sandbox unless the environment vari
 For more information about configuration options consult the [provider documentation](doc/provider.markdown).
 
 Help with preparing the key and certificate files for connection can be found in the [wiki][certificateWiki]
+
+⚠️ You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`.
+
+If you are constantly creating `Provider` instances in your app, make sure to call `Provider.shutdown()` when you are done with each provider to release its resources and memory.
 
 ### Connecting through an HTTP proxy
 
@@ -86,7 +90,7 @@ var options = {
   production: false
 };
 
-var apnProvider = new apn.Provider(options);
+const apnProvider = new apn.Provider(options);
 ```
 
 The provider will first send an HTTP CONNECT request to the specified proxy in order to establish an HTTP tunnel. Once established, it will create a new secure connection to the Apple Push Notification provider API through the tunnel.
@@ -111,7 +115,7 @@ var options = {
   production: false
 };
 
-var apnProvider = new apn.MultiProvider(options);
+const apnProvider = new apn.MultiProvider(options);
 ```
 
 ## Sending a notification
@@ -124,7 +128,7 @@ let deviceToken = "a9d0ed10e9cfd022a61cb08753f49c5a0b0dfb383697bf9f9d750a1003da1
 Create a notification object, configuring it with the relevant parameters (See the [notification documentation](doc/notification.markdown) for more details.)
 
 ```javascript
-var note = new apn.Notification();
+let note = new apn.Notification();
 
 note.expiry = Math.floor(Date.now() / 1000) + 3600; // Expires 1 hour from now.
 note.badge = 3;
@@ -137,9 +141,12 @@ note.topic = "<your-app-bundle-id>";
 Send the notification to the API with `send`, which returns a promise.
 
 ```javascript
-apnProvider.send(note, deviceToken).then( (result) => {
+try {
+  const result = apnProvider.send(note, deviceToken);
   // see documentation for an explanation of result
-});
+} catch(error) {
+  // Handle error...
+}
 ```
 
 This will result in the the following notification payload being sent to the device
@@ -151,7 +158,7 @@ This will result in the the following notification payload being sent to the dev
 Create a Live Activity notification object, configuring it with the relevant parameters (See the [notification documentation](doc/notification.markdown) for more details.)
 
 ```javascript
-var note = new apn.Notification();
+let note = new apn.Notification();
 
 note.expiry = Math.floor(Date.now() / 1000) + 3600; // Expires 1 hour from now.
 note.badge = 3;
@@ -170,9 +177,12 @@ note.contentState = {}
 Send the notification to the API with `send`, which returns a promise.
 
 ```javascript
-apnProvider.send(note, deviceToken).then( (result) => {
+try {
+  const result = await apnProvider.send(note, deviceToken)
   // see documentation for an explanation of result
-});
+} catch (error) {
+  // Handle error...
+}
 ```
 
 This will result in the the following notification payload being sent to the device
@@ -182,6 +192,6 @@ This will result in the the following notification payload being sent to the dev
 {"messageFrom":"John Appleseed","aps":{"badge":3,"sound":"ping.aiff","alert":"\uD83D\uDCE7 \u2709 You have a new message", "relevance-score":75,"timestamp":1683129662,"stale-date":1683216062,"event":"update","content-state":{}}}
 ```
 
-You should only create one `Provider` per-process for each certificate/key pair you have. You do not need to create a new `Provider` for each notification. If you are only sending notifications to one app then there is no need for more than one `Provider`.
+## Manage Channels
 
-If you are constantly creating `Provider` instances in your app, make sure to call `Provider.shutdown()` when you are done with each provider to release its resources and memory.
+## Sending Broadcast Notifications

--- a/doc/provider.markdown
+++ b/doc/provider.markdown
@@ -103,7 +103,7 @@ If you wish to send notifications containing emoji or other multi-byte character
 
 Indicate to node-apn that it should close all open connections when the queue of pending notifications is fully drained. This will allow your application to terminate.
 
-**Note:** If notifications are pushed after the connection has started, an error will be thrown.
+**Note:** If notifications are pushed after the shutdown has started, an error will be thrown.
 
 [provider-api]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html
 [provider-auth-tokens]: https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW1

--- a/doc/provider.markdown
+++ b/doc/provider.markdown
@@ -63,13 +63,36 @@ The `Provider` can continue to be used for sending notifications and the counter
 
 ## Class: apn.Provider
 
+`apn.Provider` provides a number of methods for sending notifications, broadcasting notifications, and managing channels. Calling any of the methods will return a `Promise` for each notification and is discussed more in [Results from APN Provider Methods](#results-from-apnprovider-methods).
+
 ### connection.send(notification, recipients)
 
-This is main interface for sending notifications. Create a `Notification` object and pass it in, along with a single recipient or an array of them and node-apn will take care of the rest, delivering a copy of the notification to each recipient.
+This is the main interface for sending notifications. Create a `Notification` object and pass it in, along with a single recipient or an array of them and node-apn will take care of the rest, delivering a copy of the notification to each recipient.
 
 > A "recipient" is a `String` containing the hex-encoded device token.
 
-Calling `send` will return a `Promise`. The Promise will resolve after each notification (per token) has reached a final state. Each notification can end in one of three possible states:
+Calling `send` will return a `Promise`. The Promise will resolve after each notification (per token) has reached a final state.
+
+### connection.manageChannels(notification, bundleId, action)
+This is the interface for managing broadcast channels. Create a single `Notification` object or an aray of them and pass the notification(s) in, along with a bundleId, and an action (`create`, `read`, `readAll`, `delete`) and node-apn will take care of the rest, asking the APNs to perform the action using the criteria specified in each notification.
+
+> A "bundleId" is a `String` containing bundle identifier for the application.
+
+> An "action" is a `String` containing: `create`, `read`, `readAll`, or `delete` and represents what action to perform with a channel (See more in [Apple Documentation](https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns)).
+
+Calling `manageChannels` will return a `Promise`. The Promise will resolve after each notification has reached a final state.
+
+### connection.broadcast(notification, bundleId)
+
+This is the interface for broadcasting Live Activity notifications. Create a single `Notification` object or an aray of them and pass the notification(s) in, along with a bundleId and node-apn will take care of the rest, asking the APNs to broadcast using the criteria specified in each notification.
+
+> A "bundleId" is a `String` containing bundle identifier for the application.
+
+Calling `broadcast` will return a `Promise`. The Promise will resolve after each notification has reached a final state.
+
+### Results from apn.Provider methods
+
+ Each notification can end in one of three possible states:
 
   - `sent` - the notification was accepted by Apple for delivery to the given recipient
   - `failed` (rejected) - the notification was rejected by Apple. A rejection has an associated `status` and `reason` which is included.
@@ -79,15 +102,15 @@ When the returned `Promise` resolves, its value will be an Object containing two
 
 #### sent
 
-An array of device tokens to which the notification was successfully sent and accepted by Apple.
+An array of device tokens or bundle identifiers to which the notification was successfully sent and accepted by Apple.
 
 Being `sent` does **not** guarantee the notification will be _delivered_, other unpredictable factors - including whether the device is reachable - can ultimately prevent delivery.
 
 #### failed
 
-An array of objects for each failed token. Each object will contain the device token which failed and details of the failure which will differ between rejected and errored notifications.
+An array of objects for each failed token or bundle identifier. Each object will contain the device token or bundle identifier which failed and details of the failure which will differ between rejected and errored notifications.
 
-For **rejected** notifications the object will take the following form
+For **rejected** notifications using `send()`, the object will take the following form
 
 ```javascript
 {
@@ -101,7 +124,7 @@ For **rejected** notifications the object will take the following form
 
 More details about the response and associated status codes can be found in the [HTTP/2 Response from APN documentation][http2-response].
 
-If a failed notification was instead caused by an **error** then it will have an `error` property instead of `response` and `status`:
+If a failed notification using `send()` was instead caused by an **error** then it will have an `error` property instead of `response` and `status`:
 
 ```javascript
 {

--- a/doc/provider.markdown
+++ b/doc/provider.markdown
@@ -63,20 +63,20 @@ The `Provider` can continue to be used for sending notifications and the counter
 
 ## Class: apn.Provider
 
-`apn.Provider` provides a number of methods for sending notifications, broadcasting notifications, and managing channels. Calling any of the methods will return a `Promise` for each notification and is discussed more in [Results from APN Provider Methods](#results-from-apnprovider-methods).
+`apn.Provider` provides a number of methods for sending notifications, broadcasting notifications, and managing channels. Calling any of the methods will return a `Promise` for each notification, which is discussed more in [Results from APN Provider Methods](#results-from-apnprovider-methods).
 
 ### connection.send(notification, recipients)
 
-This is the main interface for sending notifications. Create a `Notification` object and pass it in, along with a single recipient or an array of them and node-apn will take care of the rest, delivering a copy of the notification to each recipient.
+This is the main interface for sending notifications. Create a `Notification` object and pass it in, along with a single recipient or an array of them, and node-apn will take care of the rest, delivering a copy of the notification to each recipient.
 
 > A "recipient" is a `String` containing the hex-encoded device token.
 
 Calling `send` will return a `Promise`. The Promise will resolve after each notification (per token) has reached a final state.
 
 ### connection.manageChannels(notification, bundleId, action)
-This is the interface for managing broadcast channels. Create a single `Notification` object or an aray of them and pass the notification(s) in, along with a bundleId, and an action (`create`, `read`, `readAll`, `delete`) and node-apn will take care of the rest, asking the APNs to perform the action using the criteria specified in each notification.
+This is the interface for managing broadcast channels. Create a single `Notification` object or an array of them and pass the notification(s) in, along with a bundleId, and an action (`create`, `read`, `readAll`, `delete`) and node-apn will take care of the rest, asking the APNs to perform the action using the criteria specified in each notification.
 
-> A "bundleId" is a `String` containing bundle identifier for the application.
+> A "bundleId" is a `String` containing the bundle identifier for the application.
 
 > An "action" is a `String` containing: `create`, `read`, `readAll`, or `delete` and represents what action to perform with a channel (See more in [Apple Documentation](https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns)).
 
@@ -84,9 +84,9 @@ Calling `manageChannels` will return a `Promise`. The Promise will resolve after
 
 ### connection.broadcast(notification, bundleId)
 
-This is the interface for broadcasting Live Activity notifications. Create a single `Notification` object or an aray of them and pass the notification(s) in, along with a bundleId and node-apn will take care of the rest, asking the APNs to broadcast using the criteria specified in each notification.
+This is the interface for broadcasting Live Activity notifications. Create a single `Notification` object or an array of them and pass the notification(s) in, along with a bundleId and node-apn will take care of the rest, asking the APNs to broadcast using the criteria specified in each notification.
 
-> A "bundleId" is a `String` containing bundle identifier for the application.
+> A "bundleId" is a `String` containing the bundle identifier for the application.
 
 Calling `broadcast` will return a `Promise`. The Promise will resolve after each notification has reached a final state.
 
@@ -95,8 +95,8 @@ Calling `broadcast` will return a `Promise`. The Promise will resolve after each
  Each notification can end in one of three possible states:
 
   - `sent` - the notification was accepted by Apple for delivery to the given recipient
-  - `failed` (rejected) - the notification was rejected by Apple. A rejection has an associated `status` and `reason` which is included.
-  - `failed` (error) - a connection-level error occurred which prevented successful communication with Apple. In very rare cases it's possible that the notification was still delivered. However, this state usually results from a network problem.
+  - `failed` (rejected) - the notification was rejected by Apple. A rejection has an associated `status` and `reason` which are included.
+  - `failed` (error) - a connection-level error occurred, which prevented successful communication with Apple. In very rare cases, it's possible that the notification was still delivered. However, this state usually results from a network problem.
 
 When the returned `Promise` resolves, its value will be an Object containing two properties
 
@@ -108,7 +108,7 @@ Being `sent` does **not** guarantee the notification will be _delivered_, other 
 
 #### failed
 
-An array of objects for each failed token or bundle identifier. Each object will contain the device token or bundle identifier which failed and details of the failure which will differ between rejected and errored notifications.
+An array of objects for each failed token or bundle identifier. Each object will contain the device token or bundle identifier that failed and details of the failure, which will differ between rejected and errored notifications.
 
 For **rejected** notifications using `send()`, the object will take the following form
 

--- a/doc/provider.markdown
+++ b/doc/provider.markdown
@@ -13,9 +13,9 @@ Options:
 
  - `key` {Buffer|String} The filename of the connection key to load from disk, or a Buffer/String containing the key data. (Defaults to: `key.pem`)
 
- - `ca` An array of trusted certificates. Each element should contain either a filename to load, or a Buffer/String (in PEM format) to be used directly. If this is omitted several well known "root" CAs will be used. - You may need to use this as some environments don't include the CA used by Apple (entrust_2048).
+ - `ca` An array of trusted certificates. Each element should contain either a filename to load, or a Buffer/String (in PEM format) to be used directly. If this is omitted several well known "root" CAs will be used. - You may need to use this as some environments don't include the CA used by Apple (entrust_2048)
 
- - `pfx` {Buffer|String} File path for private key, certificate and CA certs in PFX or PKCS12 format, or a Buffer containing the PFX data. If supplied will always be used instead of certificate and key above.
+ - `pfx` {Buffer|String} File path for private key, certificate and CA certs in PFX or PKCS12 format, or a Buffer containing the PFX data. If supplied will always be used instead of certificate and key above
 
  - `passphrase` {String} The passphrase for the connection key, if required
 
@@ -23,7 +23,23 @@ Options:
 
  - `rejectUnauthorized` {Boolean} Reject Unauthorized property to be passed through to tls.connect() (Defaults to `true`)
 
+ - `address` {String} The address of the APNs server to send notifications to. If not provided, will connect to standard APNs server
+
+- `port` {Number} The port of the APNs server to send notifications to. (Defaults to 443)
+
+ - `manageChannelsAddress` {String} The address of the APNs channel management server to send notifications to. If not provided, will connect to standard APNs channel management server
+
+ - `manageChannelsPort` {Number} The port of the APNs channel management server to send notifications to. If not provided, will connect to standard APNs channel management port
+
+ - `proxy` {host: String, port: Number|String} Connect through an HTTP proxy when sending notifications
+
+ - `manageChannelsProxy` {host: String, port: Number|String} Connect through an HTTP proxy when managing channels
+
+ - `rejectUnauthorized` {Boolean} Reject Unauthorized property to be passed through to tls.connect() (Defaults to `true`)
+
  - `connectionRetryLimit` {Number} The maximum number of connection failures that will be tolerated before `apn.Provider` will "give up". [See below.](#connection-retry-limit) (Defaults to: 3)
+
+ - `heartBeat` {Number} The delay interval in ms that apn will ping APNs servers. (Defaults to: 60000)
 
 - `requestTimeout` {Number} The maximum time in ms that apn will wait for a response to a request. (Defaults to: 5000)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -140,6 +140,20 @@ export class Provider extends EventEmitter {
   send(notification: Notification, recipients: string|string[]): Promise<Responses>;
 
   /**
+   * Manage channels using a specific action.
+   *
+   * An "action" specifies what to do with the channel.
+   */
+  manageChannels(notification: Notification, bundleId: string, action: ChannelAction): Promise<Responses>;
+
+  /**
+   * Broadcast to a channel.
+   *
+   * An "action" specifies what to do with the channel.
+   */
+  broadcast(notification: Notification, bundleId: string): Promise<Responses>;
+
+  /**
    * Set an info logger, and optionally an errorLogger to separately log errors.
    *
    * In order to log, these functions must have a property '.enabled' that is true.
@@ -177,6 +191,8 @@ export class MultiProvider extends EventEmitter {
    */
   shutdown(callback?: () => void): void;
 }
+
+export type ChannelAction = 'create' | 'read' | 'readAll' | 'delete';
 
 export type NotificationPushType = 'background' | 'alert' | 'voip' | 'pushtotalk' | 'liveactivity' | 'location' | 'complication' | 'fileprovider' | 'mdm';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -223,9 +223,9 @@ export class MultiProvider extends EventEmitter {
   shutdown(callback?: () => void): void;
 }
 
-export type ChannelAction = 'create' | 'read' | 'readAll' | 'delete';
-
 export type NotificationPushType = 'background' | 'alert' | 'voip' | 'pushtotalk' | 'liveactivity' | 'location' | 'complication' | 'fileprovider' | 'mdm';
+
+export type ChannelAction = 'create' | 'read' | 'readAll' | 'delete';
 
 export interface NotificationAlertOptions {
   title?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -59,9 +59,13 @@ export interface ProviderOptions {
    */
   requestTimeout?: number;
   /**
-   * Connect through an HTTP proxy
+   * Connect through an HTTP proxy when sending notifications
    */
   proxy?: { host: string, port: number|string }
+  /**
+   * Connect through an HTTP proxy when managing channels
+   */
+  manageChannelsProxy?: { host: string, port: number|string }
 }
 
 export interface MultiProviderOptions extends ProviderOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,11 +31,11 @@ export interface ProviderOptions {
    */
   key?: string|Buffer;
   /**
-   * An array of trusted certificates. Each element should contain either a filename to load, or a Buffer/String (in PEM format) to be used directly. If this is omitted several well known "root" CAs will be used. - You may need to use this as some environments don't include the CA used by Apple (entrust_2048).
+   * An array of trusted certificates. Each element should contain either a filename to load, or a Buffer/String (in PEM format) to be used directly. If this is omitted several well known "root" CAs will be used. - You may need to use this as some environments don't include the CA used by Apple (entrust_2048)
    */
   ca?: (string|Buffer)[];
   /**
-   * File path for private key, certificate and CA certs in PFX or PKCS12 format, or a Buffer containing the PFX data. If supplied will always be used instead of certificate and key above.
+   * File path for private key, certificate and CA certs in PFX or PKCS12 format, or a Buffer containing the PFX data. If supplied will always be used instead of certificate and key above
    */
   pfx?: string|Buffer;
   /**
@@ -47,17 +47,21 @@ export interface ProviderOptions {
    */
   production?: boolean;
   /**
-   * Reject Unauthorized property to be passed through to tls.connect() (Defaults to `true`)
+   * The address of the APNs server to send notifications to. If not provided, will connect to standard APNs server
    */
-  rejectUnauthorized?: boolean;
+  address?: string;
   /**
-   * The maximum number of connection failures that will be tolerated before `apn` will "terminate". (Defaults to: 3)
+   * The port of the APNs server to send notifications to. (Defaults to 443)
    */
-  connectionRetryLimit?: number;
+  port?: number;
   /**
-   * The maximum time in ms that apn will wait for a response to a request. (Defaults to: 5000)
+   * The address of the APNs channel management server to send notifications to. If not provided, will connect to standard APNs channel management server
    */
-  requestTimeout?: number;
+  manageChannelsAddress?: string;
+  /**
+   * The port of the APNs channel management server to send notifications to. If not provided, will connect to standard APNs channel management port
+   */
+  manageChannelsPort?: number;
   /**
    * Connect through an HTTP proxy when sending notifications
    */
@@ -66,6 +70,22 @@ export interface ProviderOptions {
    * Connect through an HTTP proxy when managing channels
    */
   manageChannelsProxy?: { host: string, port: number|string }
+  /**
+   * Reject Unauthorized property to be passed through to tls.connect() (Defaults to `true`)
+   */
+  rejectUnauthorized?: boolean;
+  /**
+   * The maximum number of connection failures that will be tolerated before `apn` will "terminate". (Defaults to: 3)
+   */
+  connectionRetryLimit?: number;
+  /**
+   * The delay interval in ms that apn will ping APNs servers. (Defaults to: 60000)
+   */
+  heartBeat?: number;
+  /**
+   * The maximum time in ms that apn will wait for a response to a request. (Defaults to: 5000)
+   */
+  requestTimeout?: number;
 }
 
 export interface MultiProviderOptions extends ProviderOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -192,7 +192,7 @@ export class Provider extends EventEmitter {
   /**
    * Indicate to node-apn that it should close all open connections when the queue of pending notifications is fully drained. This will allow your application to terminate.
    */
-  shutdown(callback?: () => void): void;
+  shutdown(callback?: () => void): Promise<void>;
 }
 
 export class MultiProvider extends EventEmitter {
@@ -238,7 +238,7 @@ export class MultiProvider extends EventEmitter {
   /**
    * Indicate to node-apn that it should close all open connections when the queue of pending notifications is fully drained. This will allow your application to terminate.
    */
-  shutdown(callback?: () => void): void;
+  shutdown(callback?: () => void): Promise<void>;
 }
 
 export type NotificationPushType = 'background' | 'alert' | 'voip' | 'pushtotalk' | 'liveactivity' | 'location' | 'complication' | 'fileprovider' | 'mdm';

--- a/index.d.ts
+++ b/index.d.ts
@@ -209,6 +209,23 @@ export class MultiProvider extends EventEmitter {
   send(notification: Notification, recipients: string|string[]): Promise<Responses<ResponseSent,ResponseFailure>>;
 
   /**
+   * Manage channels using a specific action.
+   *
+   * @param notifications - A Notification or an Array of Notifications to send. Each notification should specify the respective channelId it's directed to.
+   * @param bundleId - The bundleId for your application.
+   * @param action - Specifies the action to perform on the channel(s).
+   */
+  manageChannels(notifications: Notification|Notification[], bundleId: string, action: ChannelAction): Promise<Responses<BroadcastResponse,BroadcastResponseFailure>>;
+
+  /**
+   * Broadcast notificaitons to channel(s).
+   *
+   * @param notifications - A Notification or an Array of Notifications to send. Each notification should specify the respective channelId it's directed to.
+   * @param bundleId: The bundleId for your application.
+   */
+  broadcast(notifications: Notification|Notification[], bundleId: string): Promise<Responses<BroadcastResponse,BroadcastResponseFailure>>;
+
+  /**
    * Set an info logger, and optionally an errorLogger to separately log errors.
    *
    * @remarks

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,7 +100,8 @@ interface Aps {
   "url-args"?: string[]
   category?: string
   "thread-id"?: string
-  "interruption-level"?: string
+  "target-content-id"?: string 
+  "interruption-level"?: string | ApsNotificationInterruptionLevel
   "relevance-score"?: number
   "filter-criteria"?: string
   "stale-date"?: number
@@ -226,6 +227,8 @@ export class MultiProvider extends EventEmitter {
 export type NotificationPushType = 'background' | 'alert' | 'voip' | 'pushtotalk' | 'liveactivity' | 'location' | 'complication' | 'fileprovider' | 'mdm';
 
 export type ChannelAction = 'create' | 'read' | 'readAll' | 'delete';
+
+export type ApsNotificationInterruptionLevel = 'passive' | 'active' | 'time-sensitive' | 'critical';
 
 export interface NotificationAlertOptions {
   title?: string;

--- a/lib/client.js
+++ b/lib/client.js
@@ -192,7 +192,7 @@ module.exports = function (dependencies) {
       const subDirectoryInformation = this.makeSubDirectoryTypeObject(type, subDirectory);
       const error = {
         ...subDirectoryInformation,
-        error: new VError(`the type "${type}" is invalid`),
+        error: new VError(`the type "${type}" is not supported`),
       };
       return Promise.resolve(error);
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -147,7 +147,7 @@ module.exports = function (dependencies) {
   };
 
   Client.prototype.write = async function write(notification, subDirectory, type, method, count) {
-    const retryStatusCodes = [408, 429, 502, 503, 504];
+    const retryStatusCodes = [408, 429, 500, 502, 503, 504];
     const retryCount = count || 0;
     const subDirectoryLabel = this.subDirectoryLabel(type) ?? type;
     const subDirectoryInformation = this.makeSubDirectoryTypeObject(
@@ -225,6 +225,9 @@ module.exports = function (dependencies) {
             );
             return { ...subDirectoryInformation, ...resentRequest };
           } catch (error) {
+            if (error.status == 500) {
+              await this.closeAndDestroySession(this.manageChannelsSession);
+            }
             delete error.retryAfter; // Never propagate retryAfter outside of client.
             const updatedError = { ...subDirectoryInformation, ...error };
             throw updatedError;
@@ -279,6 +282,9 @@ module.exports = function (dependencies) {
             );
             return { ...subDirectoryInformation, ...resentRequest };
           } catch (error) {
+            if (error.status == 500) {
+              await this.closeAndDestroySession(this.session);
+            }
             delete error.retryAfter; // Never propagate retryAfter outside of client.
             const updatedError = { ...subDirectoryInformation, ...error };
             throw updatedError;
@@ -316,15 +322,30 @@ module.exports = function (dependencies) {
     const delayPromise = new Promise(resolve => setTimeout(resolve, delayInSeconds * 1000));
     await delayPromise;
 
-    const sentRequest = await this.request(
-      session,
-      address,
-      notification,
-      path,
-      httpMethod,
-      retryCount
-    );
-    return sentRequest;
+    try {
+      const sentRequest = await this.request(
+        session,
+        address,
+        notification,
+        path,
+        httpMethod,
+        retryCount
+      );
+      return sentRequest;
+    } catch (error) {
+      // Recursivelly call self until retryCount is exhausted
+      // or error is thrown
+      const sentRequest = await this.retryRequest(
+        error,
+        session,
+        address,
+        notification,
+        path,
+        httpMethod,
+        retryCount
+      );
+      return sentRequest;
+    }
   };
 
   Client.prototype.connect = function connect() {
@@ -570,11 +591,11 @@ module.exports = function (dependencies) {
               return;
             } else if (status === 500 && response.reason === 'InternalServerError') {
               const error = {
+                status,
+                retryAfter,
                 error: new VError('Error 500, stream ended unexpectedly'),
               };
-              this.closeAndDestroySession(session, () => {
-                reject(error);
-              });
+              reject(error);
               return;
             }
             reject({ status, retryAfter, response });
@@ -582,9 +603,7 @@ module.exports = function (dependencies) {
             const error = {
               error: new VError(`stream ended unexpectedly with status ${status} and empty body`),
             };
-            this.closeAndDestroySession(session, () => {
-              reject(error);
-            });
+            reject(error);
           }
         } catch (e) {
           const error = new VError(e, 'Unexpected error processing APNs response');

--- a/lib/client.js
+++ b/lib/client.js
@@ -74,78 +74,38 @@ module.exports = function (dependencies) {
     }, this.config.heartBeat).unref();
   }
 
-  // Session should be passed except when destroying the client
   Client.prototype.destroySession = function (session, callback) {
     if (!session) {
-      session = this.session;
-    }
-    if (session) {
-      if (this.session === session) {
-        this.session = null;
+      if (callback) {
+        callback();
       }
-      if (!session.destroyed) {
-        session.destroy();
-      }
+      return;
     }
+    if (!session.destroyed) {
+      session.destroy();
+    }
+    session = null;
     if (callback) {
       callback();
     }
   };
 
   // Session should be passed except when destroying the client
-  Client.prototype.destroyManageChannelsSession = function (session, callback) {
+  Client.prototype.closeAndDestroySession = async function (session, callback) {
     if (!session) {
-      session = this.manageChannelsSession;
-    }
-    if (session) {
-      if (this.manageChannelsSession === session) {
-        this.manageChannelsSession = null;
+      if (callback) {
+        callback();
       }
-      if (!session.destroyed) {
-        session.destroy();
-      }
+      return;
     }
-    if (callback) {
-      callback();
+    if (!session.closed) {
+      await new Promise((resolve) => {
+        session.close(() => {
+          resolve();
+        });
+      });
     }
-  };
-
-  // Session should be passed except when destroying the client
-  Client.prototype.closeAndDestroySession = function (session, callback) {
-    if (!session) {
-      session = this.session;
-    }
-    if (session) {
-      if (this.session === session) {
-        this.session = null;
-      }
-      if (!session.closed) {
-        session.close(() => this.destroySession(session, callback));
-      } else {
-        this.destroySession(session, callback);
-      }
-    } else if (callback) {
-      callback();
-    }
-  };
-
-  // Session should be passed except when destroying the client
-  Client.prototype.closeAndDestroyManageChannelsSession = function (session, callback) {
-    if (!session) {
-      session = this.manageChannelsSession;
-    }
-    if (session) {
-      if (this.manageChannelsSession === session) {
-        this.manageChannelsSession = null;
-      }
-      if (!session.closed) {
-        session.close(() => this.destroyManageChannelsSession(session, callback));
-      } else {
-        this.destroyManageChannelsSession(session, callback);
-      }
-    } else if (callback) {
-      callback();
-    }
+    this.destroySession(session, callback);
   };
 
   Client.prototype.makePath = function makePath(type, subDirectory) {
@@ -256,8 +216,8 @@ module.exports = function (dependencies) {
           try {
             const resentRequest = await this.retryRequest(
               error,
-              this.session,
-              this.config.address,
+              this.manageChannelsSession,
+              this.config.manageChannelsAddress,
               notification,
               path,
               httpMethod,
@@ -475,32 +435,40 @@ module.exports = function (dependencies) {
       }
 
       const config = { ...this.config }; // Only need a shallow copy.
-      config.port = config.manageChannelsPort; // http2 will use this port.
+      // http2 will use this address and port.
+      config.address = config.manageChannelsAddress;
+      config.port = config.manageChannelsPort;
 
       const session = (this.manageChannelsSession = http2.connect(
-        this._mockOverrideUrl || `https://${this.config.manageChannelsAddress}`,
+        this._mockOverrideUrl || `https://${config.address}`,
         config
       ));
+
+      if (this.logger.enabled) {
+        this.manageChannelsSession.on('connect', () => {
+          this.logger('ManageChannelsSession connected');
+        });
+      }
 
       this.manageChannelsSession.on('close', () => {
         if (this.errorLogger.enabled) {
           this.errorLogger('ManageChannelsSession closed');
         }
-        this.destroyManageChannelsSession(session);
+        this.destroySession(session);
       });
 
       this.manageChannelsSession.on('socketError', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`ManageChannelsSession Socket error: ${error}`);
         }
-        this.closeAndDestroyManageChannelsSession(session);
+        this.closeAndDestroySession(session);
       });
 
       this.manageChannelsSession.on('error', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`ManageChannelsSession error: ${error}`);
         }
-        this.closeAndDestroyManageChannelsSession(session);
+        this.closeAndDestroySession(session);
       });
 
       this.manageChannelsSession.on('goaway', (errorCode, lastStreamId, opaqueData) => {
@@ -509,14 +477,8 @@ module.exports = function (dependencies) {
             `ManageChannelsSession GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`
           );
         }
-        this.closeAndDestroyManageChannelsSession(session);
+        this.closeAndDestroySession(session);
       });
-
-      if (this.logger.enabled) {
-        this.manageChannelsSession.on('connect', () => {
-          this.logger('ManageChannelsSession connected');
-        });
-      }
 
       this.manageChannelsSession.on('frameError', (frameType, errorCode, streamId) => {
         // This is a frame error not associate with any request(stream).
@@ -525,7 +487,7 @@ module.exports = function (dependencies) {
             `ManageChannelsSession Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
           );
         }
-        this.closeAndDestroyManageChannelsSession(session);
+        this.closeAndDestroySession(session);
       });
     });
 
@@ -607,28 +569,20 @@ module.exports = function (dependencies) {
               reject(error);
               return;
             } else if (status === 500 && response.reason === 'InternalServerError') {
-              if (session == this.session) {
-                this.closeAndDestroySession();
-              } else if (session == this.manageChannelsSession) {
-                this.closeAndDestroyManageChannelsSession();
-              }
               const error = {
                 error: new VError('Error 500, stream ended unexpectedly'),
               };
-              reject(error);
+              const rejectPromise = () => { reject(error) };
+              this.closeAndDestroySession(session, rejectPromise);
               return;
             }
             reject({ status, retryAfter, response });
           } else {
-            if (session == this.session) {
-              this.closeAndDestroySession();
-            } else if (session == this.manageChannelsSession) {
-              this.closeAndDestroyManageChannelsSession();
-            }
             const error = {
               error: new VError(`stream ended unexpectedly with status ${status} and empty body`),
             };
-            reject(error);
+            const rejectPromise = () => { reject(error) };
+            this.closeAndDestroySession(session, rejectPromise);
           }
         } catch (e) {
           const error = new VError(e, 'Unexpected error processing APNs response');
@@ -692,11 +646,8 @@ module.exports = function (dependencies) {
     });
   };
 
-  Client.prototype.shutdown = function shutdown(callback) {
+  Client.prototype.shutdown = async function shutdown() {
     if (this.isDestroyed) {
-      if (callback) {
-        callback();
-      }
       return;
     }
     if (this.errorLogger.enabled) {
@@ -711,10 +662,8 @@ module.exports = function (dependencies) {
       clearInterval(this.manageChannelsHealthCheckInterval);
       this.manageChannelsHealthCheckInterval = null;
     }
-    this.closeAndDestroySession(
-      undefined,
-      this.closeAndDestroyManageChannelsSession(undefined, callback)
-    );
+    await this.closeAndDestroySession(this.session);
+    await this.closeAndDestroySession(this.manageChannelsSession);
   };
 
   Client.prototype.setLogger = function (newLogger, newErrorLogger = null) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -233,7 +233,7 @@ module.exports = function (dependencies) {
         this.manageChannelsSession.destroyed
       ) {
         try {
-          await await this.manageChannelsConnect();
+          await this.manageChannelsConnect();
         } catch (error) {
           if (this.errorLogger.enabled) {
             // Proxy server that returned error doesn't have access to logger.

--- a/lib/client.js
+++ b/lib/client.js
@@ -272,7 +272,7 @@ module.exports = function (dependencies) {
           return { ...subDirectoryInformation, ...sentRequest };
         } catch (error) {
           if (
-            Object.hasOwn(error, 'error') &&
+            typeof error.error !== 'undefined' &&
             error.error.message.includes('ExpiredProviderToken')
           ) {
             const resentRequest = await this.retryRequest(
@@ -301,7 +301,10 @@ module.exports = function (dependencies) {
         );
         return { ...subDirectoryInformation, ...sentRequest };
       } catch (error) {
-        if (Object.hasOwn(error, 'error') && error.error.message.includes('ExpiredProviderToken')) {
+        if (
+          typeof error.error !== 'undefined' &&
+          error.error.message.includes('ExpiredProviderToken')
+        ) {
           const resentRequest = await this.retryRequest(
             this.session,
             this.config.address,

--- a/lib/client.js
+++ b/lib/client.js
@@ -50,14 +50,14 @@ module.exports = function (dependencies) {
         });
       }
     }, this.config.heartBeat).unref();
-    this.manageBroadcastHealthCheckInterval = setInterval(() => {
+    this.manageChannelsHealthCheckInterval = setInterval(() => {
       if (
-        this.manageBroadcastSession &&
-        !this.manageBroadcastSession.closed &&
-        !this.manageBroadcastSession.destroyed &&
+        this.manageChannelsSession &&
+        !this.manageChannelsSession.closed &&
+        !this.manageChannelsSession.destroyed &&
         !this.isDestroyed
       ) {
-        this.manageBroadcastSession.ping((error, duration) => {
+        this.manageChannelsSession.ping((error, duration) => {
           if (error) {
             this.errorLogger(
               'ManageBroadcastSession No Ping response after ' +
@@ -94,11 +94,11 @@ module.exports = function (dependencies) {
   // Session should be passed except when destroying the client
   Client.prototype.destroyManageBroadcastSession = function (session, callback) {
     if (!session) {
-      session = this.manageBroadcastSession;
+      session = this.manageChannelsSession;
     }
     if (session) {
-      if (this.manageBroadcastSession === session) {
-        this.manageBroadcastSession = null;
+      if (this.manageChannelsSession === session) {
+        this.manageChannelsSession = null;
       }
       if (!session.destroyed) {
         session.destroy();
@@ -131,11 +131,11 @@ module.exports = function (dependencies) {
   // Session should be passed except when destroying the client
   Client.prototype.closeAndDestroyManageBroadcastSession = function (session, callback) {
     if (!session) {
-      session = this.manageBroadcastSession;
+      session = this.manageChannelsSession;
     }
     if (session) {
-      if (this.manageBroadcastSession === session) {
-        this.manageBroadcastSession = null;
+      if (this.manageChannelsSession === session) {
+        this.manageChannelsSession = null;
       }
       if (!session.closed) {
         session.close(() => this.destroyManageBroadcastSession(session, callback));
@@ -226,14 +226,14 @@ module.exports = function (dependencies) {
     }
 
     if (path.includes('/4/broadcasts')) {
-      // Connect manageBroadcastSession
+      // Connect manageChannelsSession
       if (
-        !this.manageBroadcastSession ||
-        this.manageBroadcastSession.closed ||
-        this.manageBroadcastSession.destroyed
+        !this.manageChannelsSession ||
+        this.manageChannelsSession.closed ||
+        this.manageChannelsSession.destroyed
       ) {
         try {
-          await await this.manageBroadcastConnect();
+          await await this.manageChannelsConnect();
         } catch (error) {
           if (this.errorLogger.enabled) {
             // Proxy server that returned error doesn't have access to logger.
@@ -246,8 +246,8 @@ module.exports = function (dependencies) {
 
       try {
         const sentRequest = await this.request(
-          this.manageBroadcastSession,
-          this.config.manageBroadcastAddress,
+          this.manageChannelsSession,
+          this.config.manageChannelsAddress,
           notification,
           path,
           httpMethod
@@ -429,25 +429,25 @@ module.exports = function (dependencies) {
     return this.sessionPromise;
   };
 
-  Client.prototype.manageBroadcastConnect = async function manageBroadcastConnect() {
-    if (this.manageBroadcastSessionPromise) return this.manageBroadcastSessionPromise;
+  Client.prototype.manageChannelsConnect = async function manageChannelsConnect() {
+    if (this.manageChannelsSessionPromise) return this.manageChannelsSessionPromise;
 
-    const proxySocketPromise = this.config.manageBroadcastProxy
-      ? createProxySocket(this.config.manageBroadcastProxy, {
-          host: this.config.manageBroadcastAddress,
-          port: this.config.manageBroadcastPort,
+    const proxySocketPromise = this.config.manageChannelsProxy
+      ? createProxySocket(this.config.manageChannelsProxy, {
+          host: this.config.manageChannelsAddress,
+          port: this.config.manageChannelsPort,
         })
       : Promise.resolve();
 
-    this.manageBroadcastSessionPromise = proxySocketPromise.then(socket => {
-      this.manageBroadcastSessionPromise = null;
+    this.manageChannelsSessionPromise = proxySocketPromise.then(socket => {
+      this.manageChannelsSessionPromise = null;
 
       if (socket) {
         this.config.createManageBroadcastConnection = authority =>
           authority.protocol === 'http:'
             ? socket
             : authority.protocol === 'https:'
-            ? tls.connect(+authority.port || this.config.manageBroadcastPort, authority.hostname, {
+            ? tls.connect(+authority.port || this.config.manageChannelsPort, authority.hostname, {
                 socket,
                 servername: authority.hostname,
                 ALPNProtocols: ['h2'],
@@ -456,35 +456,35 @@ module.exports = function (dependencies) {
       }
 
       const config = { ...this.config }; // Only need a shallow copy.
-      config.port = config.manageBroadcastPort; // http2 will use this port.
+      config.port = config.manageChannelsPort; // http2 will use this port.
 
-      const session = (this.manageBroadcastSession = http2.connect(
-        this._mockOverrideUrl || `https://${this.config.manageBroadcastAddress}`,
+      const session = (this.manageChannelsSession = http2.connect(
+        this._mockOverrideUrl || `https://${this.config.manageChannelsAddress}`,
         config
       ));
 
-      this.manageBroadcastSession.on('close', () => {
+      this.manageChannelsSession.on('close', () => {
         if (this.errorLogger.enabled) {
           this.errorLogger('ManageBroadcastSession closed');
         }
         this.destroyManageBroadcastSession(session);
       });
 
-      this.manageBroadcastSession.on('socketError', error => {
+      this.manageChannelsSession.on('socketError', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`ManageBroadcastSession Socket error: ${error}`);
         }
         this.closeAndDestroyManageBroadcastSession(session);
       });
 
-      this.manageBroadcastSession.on('error', error => {
+      this.manageChannelsSession.on('error', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`ManageBroadcastSession error: ${error}`);
         }
         this.closeAndDestroyManageBroadcastSession(session);
       });
 
-      this.manageBroadcastSession.on('goaway', (errorCode, lastStreamId, opaqueData) => {
+      this.manageChannelsSession.on('goaway', (errorCode, lastStreamId, opaqueData) => {
         if (this.errorLogger.enabled) {
           this.errorLogger(
             `ManageBroadcastSession GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`
@@ -494,12 +494,12 @@ module.exports = function (dependencies) {
       });
 
       if (this.logger.enabled) {
-        this.manageBroadcastSession.on('connect', () => {
+        this.manageChannelsSession.on('connect', () => {
           this.logger('ManageBroadcastSession connected');
         });
       }
 
-      this.manageBroadcastSession.on('frameError', (frameType, errorCode, streamId) => {
+      this.manageChannelsSession.on('frameError', (frameType, errorCode, streamId) => {
         // This is a frame error not associate with any request(stream).
         if (this.errorLogger.enabled) {
           this.errorLogger(
@@ -510,7 +510,7 @@ module.exports = function (dependencies) {
       });
     });
 
-    return this.manageBroadcastSessionPromise;
+    return this.manageChannelsSessionPromise;
   };
 
   Client.prototype.request = async function request(
@@ -675,9 +675,9 @@ module.exports = function (dependencies) {
       clearInterval(this.healthCheckInterval);
       this.healthCheckInterval = null;
     }
-    if (this.manageBroadcastHealthCheckInterval) {
-      clearInterval(this.manageBroadcastHealthCheckInterval);
-      this.manageBroadcastHealthCheckInterval = null;
+    if (this.manageChannelsHealthCheckInterval) {
+      clearInterval(this.manageChannelsHealthCheckInterval);
+      this.manageChannelsHealthCheckInterval = null;
     }
     this.closeAndDestroySession(
       undefined,

--- a/lib/client.js
+++ b/lib/client.js
@@ -331,13 +331,20 @@ module.exports = function (dependencies) {
       throw error;
     }
 
+    const retryCount = count + 1;
+
+    if (retryCount >= this.config.connectionRetryLimit) {
+      const error = { error: new VError(`Exhausted connection attempts of ${retryCount}`) };
+      throw error;
+    }
+
     const sentRequest = await this.request(
       session,
       address,
       notification,
       path,
       httpMethod,
-      count + 1
+      retryCount
     );
     return sentRequest;
   };

--- a/lib/client.js
+++ b/lib/client.js
@@ -203,7 +203,7 @@ module.exports = function (dependencies) {
           retryStatusCodes.includes(error.status) ||
           (typeof error.error !== 'undefined' &&
             error.status == 403 &&
-            error.error.message.includes('ExpiredProviderToken'))
+            error.error.message === 'ExpiredProviderToken')
         ) {
           try {
             const resentRequest = await this.retryRequest(
@@ -260,7 +260,7 @@ module.exports = function (dependencies) {
           retryStatusCodes.includes(error.status) ||
           (typeof error.error !== 'undefined' &&
             error.status == 403 &&
-            error.error.message.includes('ExpiredProviderToken'))
+            error.error.message === 'ExpiredProviderToken')
         ) {
           try {
             const resentRequest = await this.retryRequest(

--- a/lib/client.js
+++ b/lib/client.js
@@ -38,26 +38,21 @@ module.exports = function (dependencies) {
     this.logger = defaultLogger;
     this.errorLogger = defaultErrorLogger;
     this.healthCheckInterval = setInterval(() => {
-      if (this.session && !this.session.closed && !this.session.destroyed && !this.isDestroyed) {
-        this.session.ping((error, duration) => {
+      this.session.ping((error, duration) => {
+        if (this.logger.enabled) {
           if (error) {
             this.errorLogger(
               'No Ping response after ' + duration + ' ms with error:' + error.message
             );
-            return;
+          } else {
+            this.logger('Ping response after ' + duration + ' ms');
           }
-          this.logger('Ping response after ' + duration + ' ms');
-        });
-      }
+        }
+      });
     }, this.config.heartBeat).unref();
     this.manageChannelsHealthCheckInterval = setInterval(() => {
-      if (
-        this.manageChannelsSession &&
-        !this.manageChannelsSession.closed &&
-        !this.manageChannelsSession.destroyed &&
-        !this.isDestroyed
-      ) {
-        this.manageChannelsSession.ping((error, duration) => {
+      this.manageChannelsSession.ping((error, duration) => {
+        if (this.logger.enabled) {
           if (error) {
             this.errorLogger(
               'ManageChannelsSession No Ping response after ' +
@@ -65,11 +60,11 @@ module.exports = function (dependencies) {
                 ' ms with error:' +
                 error.message
             );
-            return;
+          } else {
+            this.logger('ManageChannelsSession Ping response after ' + duration + ' ms');
           }
-          this.logger('ManageChannelsSession Ping response after ' + duration + ' ms');
-        });
-      }
+        }
+      });
     }, this.config.heartBeat).unref();
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -186,6 +186,7 @@ module.exports = function (dependencies) {
   };
 
   Client.prototype.write = async function write(notification, subDirectory, type, method, count) {
+    const retryCount = count || 0;
     const subDirectoryLabel = this.subDirectoryLabel(type);
 
     if (subDirectoryLabel == null) {
@@ -249,8 +250,7 @@ module.exports = function (dependencies) {
           this.config.manageBroadcastAddress,
           notification,
           path,
-          httpMethod,
-          count
+          httpMethod
         );
 
         return { ...subDirectoryInformation, ...sentRequest };
@@ -265,7 +265,7 @@ module.exports = function (dependencies) {
             notification,
             path,
             httpMethod,
-            count
+            retryCount
           );
           return { ...subDirectoryInformation, ...resentRequest };
         } else {
@@ -293,8 +293,7 @@ module.exports = function (dependencies) {
           this.config.address,
           notification,
           path,
-          httpMethod,
-          count
+          httpMethod
         );
         return { ...subDirectoryInformation, ...sentRequest };
       } catch (error) {
@@ -308,7 +307,7 @@ module.exports = function (dependencies) {
             notification,
             path,
             httpMethod,
-            count
+            retryCount
           );
           return { ...subDirectoryInformation, ...resentRequest };
         } else {
@@ -519,13 +518,11 @@ module.exports = function (dependencies) {
     address,
     notification,
     path,
-    httpMethod,
-    count
+    httpMethod
   ) {
     let tokenGeneration = null;
     let status = null;
     let responseData = '';
-    const retryCount = count || 0;
 
     const headers = extend(
       {
@@ -578,7 +575,7 @@ module.exports = function (dependencies) {
           } else if (responseData !== '') {
             const response = JSON.parse(responseData);
 
-            if (status === 403 && response.reason === 'ExpiredProviderToken' && retryCount < 2) {
+            if (status === 403 && response.reason === 'ExpiredProviderToken') {
               this.config.token.regenerate(tokenGeneration);
               const error = {
                 error: new VError(response.reason),

--- a/lib/client.js
+++ b/lib/client.js
@@ -99,7 +99,7 @@ module.exports = function (dependencies) {
       return;
     }
     if (!session.closed) {
-      await new Promise((resolve) => {
+      await new Promise(resolve => {
         session.close(() => {
           resolve();
         });
@@ -572,7 +572,9 @@ module.exports = function (dependencies) {
               const error = {
                 error: new VError('Error 500, stream ended unexpectedly'),
               };
-              const rejectPromise = () => { reject(error) };
+              const rejectPromise = () => {
+                reject(error);
+              };
               this.closeAndDestroySession(session, rejectPromise);
               return;
             }
@@ -581,7 +583,9 @@ module.exports = function (dependencies) {
             const error = {
               error: new VError(`stream ended unexpectedly with status ${status} and empty body`),
             };
-            const rejectPromise = () => { reject(error) };
+            const rejectPromise = () => {
+              reject(error);
+            };
             this.closeAndDestroySession(session, rejectPromise);
           }
         } catch (e) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -74,6 +74,7 @@ module.exports = function (dependencies) {
     }, this.config.heartBeat).unref();
   }
 
+  // The respective session should always be passed.
   Client.prototype.destroySession = function (session) {
     if (!session) {
       return;
@@ -84,7 +85,7 @@ module.exports = function (dependencies) {
     session = null;
   };
 
-  // Session should be passed except when destroying the client
+  // The respective session should always be passed.
   Client.prototype.closeAndDestroySession = async function (session) {
     if (!session) {
       return;
@@ -169,7 +170,7 @@ module.exports = function (dependencies) {
     }
 
     if (path.includes('/1/apps/')) {
-      // Connect manageChannelsSession
+      // Connect manageChannelsSession.
       if (
         !this.manageChannelsSession ||
         this.manageChannelsSession.closed ||
@@ -229,7 +230,7 @@ module.exports = function (dependencies) {
         }
       }
     } else {
-      // Connect to standard session
+      // Connect to standard session.
       if (!this.session || this.session.closed || this.session.destroyed) {
         try {
           await this.connect();
@@ -325,7 +326,7 @@ module.exports = function (dependencies) {
       return sentRequest;
     } catch (error) {
       // Recursivelly call self until retryCount is exhausted
-      // or error is thrown
+      // or error is thrown.
       const sentRequest = await this.retryRequest(
         error,
         session,

--- a/lib/client.js
+++ b/lib/client.js
@@ -80,6 +80,7 @@ module.exports = function (dependencies) {
       return;
     }
     if (!session.destroyed) {
+      console.log('3333333 ');
       session.destroy();
     }
     session = null;

--- a/lib/client.js
+++ b/lib/client.js
@@ -147,7 +147,7 @@ module.exports = function (dependencies) {
   };
 
   Client.prototype.write = async function write(notification, subDirectory, type, method, count) {
-    const retryStatusCodes = [408, 429, 500, 502, 503, 504];
+    const retryStatusCodes = [408, 429, 502, 503, 504];
     const retryCount = count || 0;
     const subDirectoryLabel = this.subDirectoryLabel(type) ?? type;
     const subDirectoryInformation = this.makeSubDirectoryTypeObject(
@@ -300,8 +300,8 @@ module.exports = function (dependencies) {
     httpMethod,
     count
   ) {
-    if (this.isDestroyed) {
-      const error = { error: new VError('client is destroyed') };
+    if (this.isDestroyed || session.closed) {
+      const error = { error: new VError('client session is either closed or destroyed') };
       throw error;
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -384,13 +384,6 @@ module.exports = function (dependencies) {
         this.destroySession(session);
       });
 
-      this.session.on('socketError', error => {
-        if (this.errorLogger.enabled) {
-          this.errorLogger(`Socket error: ${error}`);
-        }
-        this.closeAndDestroySession(session);
-      });
-
       this.session.on('error', error => {
         if (this.errorLogger.enabled) {
           this.errorLogger(`Session error: ${error}`);

--- a/lib/client.js
+++ b/lib/client.js
@@ -332,8 +332,10 @@ module.exports = function (dependencies) {
 
     const retryCount = count + 1;
 
-    if (retryCount >= this.config.connectionRetryLimit) {
-      const error = { error: new VError(`Exhausted connection attempts of ${retryCount}`) };
+    if (retryCount > this.config.connectionRetryLimit) {
+      const error = {
+        error: new VError(`Exhausted connection attempts of ${this.config.connectionRetryLimit}`),
+      };
       throw error;
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -185,7 +185,7 @@ module.exports = function (dependencies) {
     return subDirectoryObject;
   };
 
-  Client.prototype.write = function write(notification, subDirectory, type, method, count) {
+  Client.prototype.write = async function write(notification, subDirectory, type, method, count) {
     const subDirectoryLabel = this.subDirectoryLabel(type);
 
     if (subDirectoryLabel == null) {
@@ -194,42 +194,34 @@ module.exports = function (dependencies) {
         ...subDirectoryInformation,
         error: new VError(`the type "${type}" is not supported`),
       };
-      return Promise.resolve(error);
+      throw error;
     }
 
+    const subDirectoryInformation = this.makeSubDirectoryTypeObject(
+      subDirectoryLabel,
+      subDirectory
+    );
     const path = this.makePath(type, subDirectory);
     if (path == null) {
-      const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-        subDirectoryLabel,
-        subDirectory
-      );
       const error = {
         ...subDirectoryInformation,
         error: new VError(`could not make a path for ${type} and ${subDirectory}`),
       };
-      return Promise.resolve(error);
+      throw error;
     }
 
     const httpMethod = HTTPMethod[method];
     if (httpMethod == null) {
-      const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-        subDirectoryLabel,
-        subDirectory
-      );
       const error = {
         ...subDirectoryInformation,
         error: new VError(`invalid httpMethod "${method}"`),
       };
-      return Promise.resolve(error);
+      throw error;
     }
 
     if (this.isDestroyed) {
-      const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-        subDirectoryLabel,
-        subDirectory
-      );
       const error = { ...subDirectoryInformation, error: new VError('client is destroyed') };
-      return Promise.resolve(error);
+      throw error;
     }
 
     if (path.includes('/4/broadcasts')) {
@@ -239,80 +231,100 @@ module.exports = function (dependencies) {
         this.manageBroadcastSession.closed ||
         this.manageBroadcastSession.destroyed
       ) {
-        return this.manageBroadcastConnect().then(() =>
-          this.request(notification, subDirectory, subDirectoryLabel, path, httpMethod, count)
+        await this.manageBroadcastConnect();
+        const sentRequest = await this.request(
+          notification,
+          path,
+          httpMethod,
+          count
         );
+        return { ...subDirectoryInformation,  ...sentRequest};
       }
 
-      return this.request(
+      const sentRequest = await this.request(
         this.manageBroadcastSession,
         this.config.manageBroadcastAddress,
         notification,
-        subDirectory,
-        subDirectoryLabel,
         path,
         httpMethod,
         count
       );
+
+      return { ...subDirectoryInformation,  ...sentRequest};
+
     } else {
+
       // Connect to standard session
       if (!this.session || this.session.closed || this.session.destroyed) {
-        return this.connect().then(() =>
-          this.request(
+        try {
+          await this.connect();
+        } catch(error) {
+          if (this.errorLogger.enabled) {
+            // Proxy server that returned error doesn't have access to logger.
+            this.errorLogger(error.message);
+          }
+          const updatedError = { ...subDirectoryInformation,  error};
+          throw updatedError;
+        }
+
+        try {
+          const sentRequest = await this.request(
             this.session,
             this.config.address,
             notification,
-            subDirectory,
-            subDirectoryLabel,
             path,
             httpMethod,
             count
-          )
-        );
+          );
+          return { ...subDirectoryInformation,  ...sentRequest};
+
+        } catch (error) {
+          if (Object.hasOwn(error, 'error') && error.error.message.includes('ExpiredProviderToken')) {
+            const resentRequest = await retryRequest(this.session, this.config.address, notification, path, httpMethod, count);
+            return { ...subDirectoryInformation, ...resentRequest };
+          } else {
+            throw { ...subDirectoryInformation, ...error };
+          }
+        }
       }
 
-      return this.request(
-        this.session,
-        this.config.address,
-        notification,
-        subDirectory,
-        subDirectoryLabel,
-        path,
-        httpMethod,
-        count
-      );
+      try {
+        const sentRequest = await this.request(
+          this.session,
+          this.config.address,
+          notification,
+          path,
+          httpMethod,
+          count
+        );
+        return { ...subDirectoryInformation,  ...sentRequest};
+
+      } catch (error) {
+        if (Object.hasOwn(error, 'error') && error.error.message.includes('ExpiredProviderToken')) {
+          const resentRequest = await retryRequest(this.session, this.config.address, notification, path, httpMethod, count);
+          return { ...subDirectoryInformation, ...resentRequest };
+        } else {
+          throw { ...subDirectoryInformation, ...error };
+        }
+      }
     }
   };
 
-  Client.prototype.retryRequest = function retryRequest(
-    session,
-    address,
-    notification,
-    subDirectory,
-    subDirectoryLabel,
-    path,
-    httpMethod,
-    count
-  ) {
+  Client.prototype.retryRequest = async function retryRequest(session, address, notification, path, httpMethod, count) {
     if (this.isDestroyed) {
-      const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-        subDirectoryLabel,
-        subDirectory
-      );
-      const error = { ...subDirectoryInformation, error: new VError('client is destroyed') };
-      return Promise.resolve(error);
+      const error = { error: new VError('client is destroyed') };
+      throw error;
     }
 
-    return this.request(
+    const sentRequest = await this.request(
       session,
       address,
       notification,
-      subDirectory,
-      subDirectoryLabel,
       path,
       httpMethod,
       count + 1
     );
+    return sentRequest;
   };
 
   Client.prototype.connect = function connect() {
@@ -326,75 +338,74 @@ module.exports = function (dependencies) {
       : Promise.resolve();
 
     this.sessionPromise = proxySocketPromise.then(socket => {
-      this.sessionPromise = null;
-      if (socket) {
-        this.config.createConnection = authority =>
-          authority.protocol === 'http:'
-            ? socket
-            : authority.protocol === 'https:'
-            ? tls.connect(+authority.port || 443, authority.hostname, {
-                socket,
-                servername: authority.hostname,
-                ALPNProtocols: ['h2'],
-              })
-            : null;
-      }
+        this.sessionPromise = null;
 
-      const session = (this.session = http2.connect(
-        this._mockOverrideUrl || `https://${this.config.address}`,
-        this.config
-      ));
-
-      this.session.on('close', () => {
-        if (this.errorLogger.enabled) {
-          this.errorLogger('Session closed');
+        if (socket) {
+          this.config.createConnection = authority =>
+            authority.protocol === 'http:'
+              ? socket
+              : authority.protocol === 'https:'
+              ? tls.connect(+authority.port || 443, authority.hostname, {
+                  socket,
+                  servername: authority.hostname,
+                  ALPNProtocols: ['h2'],
+                })
+              : null;
         }
-        this.destroySession(session);
-      });
 
-      this.session.on('socketError', error => {
-        if (this.errorLogger.enabled) {
-          this.errorLogger(`Socket error: ${error}`);
+        const session = (this.session = http2.connect(
+          this._mockOverrideUrl || `https://${this.config.address}`,
+          this.config
+        ));
+
+        if (this.logger.enabled) {
+          this.session.on('connect', () => {
+            this.logger('Session connected');
+          });
         }
-        this.closeAndDestroySession(session);
-      });
 
-      this.session.on('error', error => {
-        if (this.errorLogger.enabled) {
-          this.errorLogger(`Session error: ${error}`);
-        }
-        this.closeAndDestroySession(session);
-      });
+        this.session.on('close', () => {
+          if (this.errorLogger.enabled) {
+            this.errorLogger('Session closed');
+          }
+          this.destroySession(session);
+        });
 
-      this.session.on('goaway', (errorCode, lastStreamId, opaqueData) => {
-        if (this.errorLogger.enabled) {
-          this.errorLogger(
-            `GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`
-          );
-        }
-        this.closeAndDestroySession(session);
-      });
+        this.session.on('socketError', error => {
+          if (this.errorLogger.enabled) {
+            this.errorLogger(`Socket error: ${error}`);
+          }
+          this.closeAndDestroySession(session);
+        });
 
-      if (this.logger.enabled) {
-        this.session.on('connect', () => {
-          this.logger('Session connected');
+        this.session.on('error', error => {
+          if (this.errorLogger.enabled) {
+            this.errorLogger(`Session error: ${error}`);
+          }
+          this.closeAndDestroySession(session);
+        });
+
+        this.session.on('goaway', (errorCode, lastStreamId, opaqueData) => {
+          if (this.errorLogger.enabled) {
+            this.errorLogger(`GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`);
+          }
+          this.closeAndDestroySession(session);
+        });
+
+        this.session.on('frameError', (frameType, errorCode, streamId) => {
+          // This is a frame error not associate with any request(stream).
+          if (this.errorLogger.enabled) {
+            this.errorLogger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
+          }
+          this.closeAndDestroySession(session);
         });
       }
-      this.session.on('frameError', (frameType, errorCode, streamId) => {
-        // This is a frame error not associate with any request(stream).
-        if (this.errorLogger.enabled) {
-          this.errorLogger(
-            `Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
-          );
-        }
-        this.closeAndDestroySession(session);
-      });
-    });
+    );
 
     return this.sessionPromise;
   };
 
-  Client.prototype.manageBroadcastConnect = function manageBroadcastConnect() {
+  Client.prototype.manageBroadcastConnect = async function manageBroadcastConnect() {
     if (this.manageBroadcastSessionPromise) return this.manageBroadcastSessionPromise;
 
     const proxySocketPromise = this.config.manageBroadcastProxy
@@ -476,12 +487,10 @@ module.exports = function (dependencies) {
     return this.manageBroadcastSessionPromise;
   };
 
-  Client.prototype.request = function request(
+  Client.prototype.request = async function request(
     session,
     address,
     notification,
-    subDirectory,
-    subDirectoryLabel,
     path,
     httpMethod,
     count
@@ -523,7 +532,7 @@ module.exports = function (dependencies) {
 
     request.write(notification.body);
 
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       request.on('end', () => {
         try {
           if (this.logger.enabled) {
@@ -531,72 +540,46 @@ module.exports = function (dependencies) {
           }
 
           if (status === 200) {
-            const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-              subDirectoryLabel,
-              subDirectory
-            );
-            resolve({ ...subDirectoryInformation });
+            resolve();
           } else if ([TIMEOUT_STATUS, ABORTED_STATUS, ERROR_STATUS].includes(status)) {
+            const error = {
+              status,
+              error: new VError('Timeout, aborted, or other unknown error')
+            }
+            reject(error);
             return;
           } else if (responseData !== '') {
             const response = JSON.parse(responseData);
 
             if (status === 403 && response.reason === 'ExpiredProviderToken' && retryCount < 2) {
               this.config.token.regenerate(tokenGeneration);
-              resolve(
-                this.retryRequest(
-                  session,
-                  address,
-                  notification,
-                  subDirectory,
-                  subDirectoryLabel,
-                  path,
-                  httpMethod,
-                  count
-                )
-              );
+              const error = {
+                error: new VError(response.reason),
+              };
+              reject(error);
               return;
             } else if (status === 500 && response.reason === 'InternalServerError') {
               this.closeAndDestroySession();
-              const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-                subDirectoryLabel,
-                subDirectory
-              );
               const error = {
-                ...subDirectoryInformation,
                 error: new VError('Error 500, stream ended unexpectedly'),
               };
-              resolve(error);
+              reject(error);
               return;
             }
-            const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-              subDirectoryLabel,
-              subDirectory
-            );
-            resolve({ ...subDirectoryInformation, status, response });
+            reject({ status, response });
           } else {
             this.closeAndDestroySession();
-            const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-              subDirectoryLabel,
-              subDirectory
-            );
             const error = {
-              ...subDirectoryInformation,
               error: new VError(`stream ended unexpectedly with status ${status} and empty body`),
             };
-            resolve(error);
+            reject(error);
           }
         } catch (e) {
           const error = new VError(e, 'Unexpected error processing APNs response');
           if (this.errorLogger.enabled) {
             this.errorLogger(`Unexpected error processing APNs response: ${e.message}`);
           }
-          const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-            subDirectoryLabel,
-            subDirectory
-          );
-          const returnError = { ...subDirectoryInformation, error };
-          resolve(returnError);
+          reject({ error });
         }
       });
 
@@ -609,12 +592,8 @@ module.exports = function (dependencies) {
 
         request.close(NGHTTP2_CANCEL);
 
-        const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-          subDirectoryLabel,
-          subDirectory
-        );
-        const error = { ...subDirectoryInformation, error: new VError('apn write timeout') };
-        resolve(error);
+        const error = { error: new VError('apn write timeout') };
+        reject(error);
       });
 
       request.on('aborted', () => {
@@ -624,12 +603,8 @@ module.exports = function (dependencies) {
 
         status = ABORTED_STATUS;
 
-        const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-          subDirectoryLabel,
-          subDirectory
-        );
-        const error = { ...subDirectoryInformation, error: new VError('apn write aborted') };
-        resolve(error);
+        const error = { error: new VError('apn write aborted') };
+        reject(error);
       });
 
       request.on('error', error => {
@@ -645,21 +620,17 @@ module.exports = function (dependencies) {
           error = new VError(error, 'apn write failed');
         }
 
-        const subDirectoryInformation = this.makeSubDirectoryTypeObject(
-          subDirectoryLabel,
-          subDirectory
-        );
-        const returnError = { ...subDirectoryInformation, error };
-        resolve(returnError);
+        reject({ error });
       });
 
-      if (this.errorLogger.enabled) {
-        request.on('frameError', (frameType, errorCode, streamId) => {
-          this.errorLogger(
-            `Request frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
-          );
-        });
-      }
+      request.on('frameError', (frameType, errorCode, streamId) => {
+        const errorMessage = `Request frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`;
+        if (this.errorLogger.enabled) {
+          this.errorLogger(errorMessage);
+        }
+        const error = new VError(errorMessage);
+        reject({ error });
+      });
 
       request.end();
     });

--- a/lib/client.js
+++ b/lib/client.js
@@ -434,7 +434,7 @@ module.exports = function (dependencies) {
       this.manageChannelsSessionPromise = null;
 
       if (socket) {
-        this.config.createManageBroadcastConnection = authority =>
+        this.config.createConnection = authority =>
           authority.protocol === 'http:'
             ? socket
             : authority.protocol === 'https:'
@@ -679,6 +679,10 @@ module.exports = function (dependencies) {
     }
     await this.closeAndDestroySession(this.session);
     await this.closeAndDestroySession(this.manageChannelsSession);
+    if (this.config.createConnection) {
+      this.config.createConnection = null;
+    }
+
     if (callback) {
       callback();
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -74,28 +74,19 @@ module.exports = function (dependencies) {
     }, this.config.heartBeat).unref();
   }
 
-  Client.prototype.destroySession = function (session, callback) {
+  Client.prototype.destroySession = function (session) {
     if (!session) {
-      if (callback) {
-        callback();
-      }
       return;
     }
     if (!session.destroyed) {
       session.destroy();
     }
     session = null;
-    if (callback) {
-      callback();
-    }
   };
 
   // Session should be passed except when destroying the client
-  Client.prototype.closeAndDestroySession = async function (session, callback) {
+  Client.prototype.closeAndDestroySession = async function (session) {
     if (!session) {
-      if (callback) {
-        callback();
-      }
       return;
     }
     if (!session.closed) {
@@ -105,7 +96,7 @@ module.exports = function (dependencies) {
         });
       });
     }
-    this.destroySession(session, callback);
+    this.destroySession(session);
   };
 
   Client.prototype.makePath = function makePath(type, subDirectory) {
@@ -667,8 +658,11 @@ module.exports = function (dependencies) {
     });
   };
 
-  Client.prototype.shutdown = async function shutdown() {
+  Client.prototype.shutdown = async function shutdown(callback) {
     if (this.isDestroyed) {
+      if (callback) {
+        callback();
+      }
       return;
     }
     if (this.errorLogger.enabled) {
@@ -685,6 +679,9 @@ module.exports = function (dependencies) {
     }
     await this.closeAndDestroySession(this.session);
     await this.closeAndDestroySession(this.manageChannelsSession);
+    if (callback) {
+      callback();
+    }
   };
 
   Client.prototype.setLogger = function (newLogger, newErrorLogger = null) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -34,17 +34,18 @@ module.exports = function (dependencies) {
   const ERROR_STATUS = '(error)';
 
   function Client(options) {
+    this.isDestroyed = false;
     this.config = config(options);
     this.logger = defaultLogger;
     this.errorLogger = defaultErrorLogger;
     this.healthCheckInterval = setInterval(() => {
       if (this.session && !this.session.closed && !this.session.destroyed && !this.isDestroyed) {
         this.session.ping((error, duration) => {
-          if (error) {
+          if (error && this.errorLogger.enabled) {
             this.errorLogger(
               'No Ping response after ' + duration + ' ms with error:' + error.message
             );
-          } else {
+          } else if (this.logger.enabled) {
             this.logger('Ping response after ' + duration + ' ms');
           }
         });
@@ -58,14 +59,14 @@ module.exports = function (dependencies) {
         !this.isDestroyed
       ) {
         this.manageChannelsSession.ping((error, duration) => {
-          if (error) {
+          if (error && this.errorLogger.enabled) {
             this.errorLogger(
               'ManageChannelsSession No Ping response after ' +
                 duration +
                 ' ms with error:' +
                 error.message
             );
-          } else {
+          } else if (this.logger.enabled) {
             this.logger('ManageChannelsSession Ping response after ' + duration + ' ms');
           }
         });

--- a/lib/client.js
+++ b/lib/client.js
@@ -80,7 +80,6 @@ module.exports = function (dependencies) {
       return;
     }
     if (!session.destroyed) {
-      console.log('3333333 ');
       session.destroy();
     }
     session = null;

--- a/lib/client.js
+++ b/lib/client.js
@@ -231,21 +231,47 @@ module.exports = function (dependencies) {
         this.manageBroadcastSession.closed ||
         this.manageBroadcastSession.destroyed
       ) {
-        await this.manageBroadcastConnect();
-        const sentRequest = await this.request(notification, path, httpMethod, count);
-        return { ...subDirectoryInformation, ...sentRequest };
+        try {
+          await await this.manageBroadcastConnect();
+        } catch (error) {
+          if (this.errorLogger.enabled) {
+            // Proxy server that returned error doesn't have access to logger.
+            this.errorLogger(error.message);
+          }
+          const updatedError = { ...subDirectoryInformation, error };
+          throw updatedError;
+        }
       }
 
-      const sentRequest = await this.request(
-        this.manageBroadcastSession,
-        this.config.manageBroadcastAddress,
-        notification,
-        path,
-        httpMethod,
-        count
-      );
+      try {
+        const sentRequest = await this.request(
+          this.manageBroadcastSession,
+          this.config.manageBroadcastAddress,
+          notification,
+          path,
+          httpMethod,
+          count
+        );
 
-      return { ...subDirectoryInformation, ...sentRequest };
+        return { ...subDirectoryInformation, ...sentRequest };
+      } catch (error) {
+        if (
+          typeof error.error !== 'undefined' &&
+          error.error.message.includes('ExpiredProviderToken')
+        ) {
+          const resentRequest = await this.retryRequest(
+            this.session,
+            this.config.address,
+            notification,
+            path,
+            httpMethod,
+            count
+          );
+          return { ...subDirectoryInformation, ...resentRequest };
+        } else {
+          throw { ...subDirectoryInformation, ...error };
+        }
+      }
     } else {
       // Connect to standard session
       if (!this.session || this.session.closed || this.session.destroyed) {
@@ -258,35 +284,6 @@ module.exports = function (dependencies) {
           }
           const updatedError = { ...subDirectoryInformation, error };
           throw updatedError;
-        }
-
-        try {
-          const sentRequest = await this.request(
-            this.session,
-            this.config.address,
-            notification,
-            path,
-            httpMethod,
-            count
-          );
-          return { ...subDirectoryInformation, ...sentRequest };
-        } catch (error) {
-          if (
-            typeof error.error !== 'undefined' &&
-            error.error.message.includes('ExpiredProviderToken')
-          ) {
-            const resentRequest = await this.retryRequest(
-              this.session,
-              this.config.address,
-              notification,
-              path,
-              httpMethod,
-              count
-            );
-            return { ...subDirectoryInformation, ...resentRequest };
-          } else {
-            throw { ...subDirectoryInformation, ...error };
-          }
         }
       }
 
@@ -438,6 +435,7 @@ module.exports = function (dependencies) {
 
     this.manageBroadcastSessionPromise = proxySocketPromise.then(socket => {
       this.manageBroadcastSessionPromise = null;
+
       if (socket) {
         this.config.createManageBroadcastConnection = authority =>
           authority.protocol === 'http:'
@@ -494,6 +492,7 @@ module.exports = function (dependencies) {
           this.logger('ManageBroadcastSession connected');
         });
       }
+
       this.manageBroadcastSession.on('frameError', (frameType, errorCode, streamId) => {
         // This is a frame error not associate with any request(stream).
         if (this.errorLogger.enabled) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -38,8 +38,8 @@ module.exports = function (dependencies) {
     this.logger = defaultLogger;
     this.errorLogger = defaultErrorLogger;
     this.healthCheckInterval = setInterval(() => {
-      this.session.ping((error, duration) => {
-        if (this.logger.enabled) {
+      if (this.session && !this.session.closed && !this.session.destroyed && !this.isDestroyed) {
+        this.session.ping((error, duration) => {
           if (error) {
             this.errorLogger(
               'No Ping response after ' + duration + ' ms with error:' + error.message
@@ -47,12 +47,17 @@ module.exports = function (dependencies) {
           } else {
             this.logger('Ping response after ' + duration + ' ms');
           }
-        }
-      });
+        });
+      }
     }, this.config.heartBeat).unref();
     this.manageChannelsHealthCheckInterval = setInterval(() => {
-      this.manageChannelsSession.ping((error, duration) => {
-        if (this.logger.enabled) {
+      if (
+        this.manageChannelsSession &&
+        !this.manageChannelsSession.closed &&
+        !this.manageChannelsSession.destroyed &&
+        !this.isDestroyed
+      ) {
+        this.manageChannelsSession.ping((error, duration) => {
           if (error) {
             this.errorLogger(
               'ManageChannelsSession No Ping response after ' +
@@ -63,8 +68,8 @@ module.exports = function (dependencies) {
           } else {
             this.logger('ManageChannelsSession Ping response after ' + duration + ' ms');
           }
-        }
-      });
+        });
+      }
     }, this.config.heartBeat).unref();
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -507,6 +507,24 @@ module.exports = function (dependencies) {
     return this.manageChannelsSessionPromise;
   };
 
+  Client.prototype.createHeaderObject = function createHeaderObject(
+    uniqueId,
+    requestId,
+    channelId
+  ) {
+    const header = {};
+    if (uniqueId) {
+      header['apns-unique-id'] = uniqueId;
+    }
+    if (requestId) {
+      header['apns-request-id'] = requestId;
+    }
+    if (channelId) {
+      header['apns-channel-id'] = channelId;
+    }
+    return header;
+  };
+
   Client.prototype.request = async function request(
     session,
     address,
@@ -517,6 +535,9 @@ module.exports = function (dependencies) {
     let tokenGeneration = null;
     let status = null;
     let retryAfter = null;
+    let uniqueId = null;
+    let requestId = null;
+    let channelId = null;
     let responseData = '';
 
     const headers = extend(
@@ -544,13 +565,18 @@ module.exports = function (dependencies) {
     request.on('response', headers => {
       status = headers[HTTP2_HEADER_STATUS];
       retryAfter = headers['Retry-After'];
+      uniqueId = headers['apns-unique-id'];
+      requestId = headers['apns-request-id'];
+      channelId = headers['apns-channel-id'];
     });
 
     request.on('data', data => {
       responseData += data;
     });
 
-    request.write(notification.body);
+    if (Object.keys(notification.body).length > 0) {
+      request.write(notification.body);
+    }
 
     return new Promise((resolve, reject) => {
       request.on('end', () => {
@@ -558,16 +584,19 @@ module.exports = function (dependencies) {
           if (this.logger.enabled) {
             this.logger(`Request ended with status ${status} and responseData: ${responseData}`);
           }
+          const headerObject = this.createHeaderObject(uniqueId, requestId, channelId);
 
-          if (status === 200) {
-            resolve();
+          if (status === 200 || status === 201 || status === 204) {
+            const body = responseData !== '' ? JSON.parse(responseData) : {};
+            resolve({ ...headerObject, ...body });
+            return;
           } else if ([TIMEOUT_STATUS, ABORTED_STATUS, ERROR_STATUS].includes(status)) {
             const error = {
               status,
               retryAfter,
               error: new VError('Timeout, aborted, or other unknown error'),
             };
-            reject(error);
+            reject({ ...headerObject, ...error });
             return;
           } else if (responseData !== '') {
             const response = JSON.parse(responseData);
@@ -579,7 +608,7 @@ module.exports = function (dependencies) {
                 retryAfter,
                 error: new VError(response.reason),
               };
-              reject(error);
+              reject({ ...headerObject, ...error });
               return;
             } else if (status === 500 && response.reason === 'InternalServerError') {
               const error = {
@@ -587,15 +616,15 @@ module.exports = function (dependencies) {
                 retryAfter,
                 error: new VError('Error 500, stream ended unexpectedly'),
               };
-              reject(error);
+              reject({ ...headerObject, ...error });
               return;
             }
-            reject({ status, retryAfter, response });
+            reject({ ...headerObject, status, retryAfter, response });
           } else {
             const error = {
               error: new VError(`stream ended unexpectedly with status ${status} and empty body`),
             };
-            reject(error);
+            reject({ ...headerObject, ...error });
           }
         } catch (e) {
           const error = new VError(e, 'Unexpected error processing APNs response');

--- a/lib/client.js
+++ b/lib/client.js
@@ -232,13 +232,8 @@ module.exports = function (dependencies) {
         this.manageBroadcastSession.destroyed
       ) {
         await this.manageBroadcastConnect();
-        const sentRequest = await this.request(
-          notification,
-          path,
-          httpMethod,
-          count
-        );
-        return { ...subDirectoryInformation,  ...sentRequest};
+        const sentRequest = await this.request(notification, path, httpMethod, count);
+        return { ...subDirectoryInformation, ...sentRequest };
       }
 
       const sentRequest = await this.request(
@@ -250,20 +245,18 @@ module.exports = function (dependencies) {
         count
       );
 
-      return { ...subDirectoryInformation,  ...sentRequest};
-
+      return { ...subDirectoryInformation, ...sentRequest };
     } else {
-
       // Connect to standard session
       if (!this.session || this.session.closed || this.session.destroyed) {
         try {
           await this.connect();
-        } catch(error) {
+        } catch (error) {
           if (this.errorLogger.enabled) {
             // Proxy server that returned error doesn't have access to logger.
             this.errorLogger(error.message);
           }
-          const updatedError = { ...subDirectoryInformation,  error};
+          const updatedError = { ...subDirectoryInformation, error };
           throw updatedError;
         }
 
@@ -276,11 +269,20 @@ module.exports = function (dependencies) {
             httpMethod,
             count
           );
-          return { ...subDirectoryInformation,  ...sentRequest};
-
+          return { ...subDirectoryInformation, ...sentRequest };
         } catch (error) {
-          if (Object.hasOwn(error, 'error') && error.error.message.includes('ExpiredProviderToken')) {
-            const resentRequest = await retryRequest(this.session, this.config.address, notification, path, httpMethod, count);
+          if (
+            Object.hasOwn(error, 'error') &&
+            error.error.message.includes('ExpiredProviderToken')
+          ) {
+            const resentRequest = await this.retryRequest(
+              this.session,
+              this.config.address,
+              notification,
+              path,
+              httpMethod,
+              count
+            );
             return { ...subDirectoryInformation, ...resentRequest };
           } else {
             throw { ...subDirectoryInformation, ...error };
@@ -297,11 +299,17 @@ module.exports = function (dependencies) {
           httpMethod,
           count
         );
-        return { ...subDirectoryInformation,  ...sentRequest};
-
+        return { ...subDirectoryInformation, ...sentRequest };
       } catch (error) {
         if (Object.hasOwn(error, 'error') && error.error.message.includes('ExpiredProviderToken')) {
-          const resentRequest = await retryRequest(this.session, this.config.address, notification, path, httpMethod, count);
+          const resentRequest = await this.retryRequest(
+            this.session,
+            this.config.address,
+            notification,
+            path,
+            httpMethod,
+            count
+          );
           return { ...subDirectoryInformation, ...resentRequest };
         } else {
           throw { ...subDirectoryInformation, ...error };
@@ -310,7 +318,14 @@ module.exports = function (dependencies) {
     }
   };
 
-  Client.prototype.retryRequest = async function retryRequest(session, address, notification, path, httpMethod, count) {
+  Client.prototype.retryRequest = async function retryRequest(
+    session,
+    address,
+    notification,
+    path,
+    httpMethod,
+    count
+  ) {
     if (this.isDestroyed) {
       const error = { error: new VError('client is destroyed') };
       throw error;
@@ -338,69 +353,72 @@ module.exports = function (dependencies) {
       : Promise.resolve();
 
     this.sessionPromise = proxySocketPromise.then(socket => {
-        this.sessionPromise = null;
+      this.sessionPromise = null;
 
-        if (socket) {
-          this.config.createConnection = authority =>
-            authority.protocol === 'http:'
-              ? socket
-              : authority.protocol === 'https:'
-              ? tls.connect(+authority.port || 443, authority.hostname, {
-                  socket,
-                  servername: authority.hostname,
-                  ALPNProtocols: ['h2'],
-                })
-              : null;
-        }
+      if (socket) {
+        this.config.createConnection = authority =>
+          authority.protocol === 'http:'
+            ? socket
+            : authority.protocol === 'https:'
+            ? tls.connect(+authority.port || 443, authority.hostname, {
+                socket,
+                servername: authority.hostname,
+                ALPNProtocols: ['h2'],
+              })
+            : null;
+      }
 
-        const session = (this.session = http2.connect(
-          this._mockOverrideUrl || `https://${this.config.address}`,
-          this.config
-        ));
+      const session = (this.session = http2.connect(
+        this._mockOverrideUrl || `https://${this.config.address}`,
+        this.config
+      ));
 
-        if (this.logger.enabled) {
-          this.session.on('connect', () => {
-            this.logger('Session connected');
-          });
-        }
-
-        this.session.on('close', () => {
-          if (this.errorLogger.enabled) {
-            this.errorLogger('Session closed');
-          }
-          this.destroySession(session);
-        });
-
-        this.session.on('socketError', error => {
-          if (this.errorLogger.enabled) {
-            this.errorLogger(`Socket error: ${error}`);
-          }
-          this.closeAndDestroySession(session);
-        });
-
-        this.session.on('error', error => {
-          if (this.errorLogger.enabled) {
-            this.errorLogger(`Session error: ${error}`);
-          }
-          this.closeAndDestroySession(session);
-        });
-
-        this.session.on('goaway', (errorCode, lastStreamId, opaqueData) => {
-          if (this.errorLogger.enabled) {
-            this.errorLogger(`GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`);
-          }
-          this.closeAndDestroySession(session);
-        });
-
-        this.session.on('frameError', (frameType, errorCode, streamId) => {
-          // This is a frame error not associate with any request(stream).
-          if (this.errorLogger.enabled) {
-            this.errorLogger(`Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`);
-          }
-          this.closeAndDestroySession(session);
+      if (this.logger.enabled) {
+        this.session.on('connect', () => {
+          this.logger('Session connected');
         });
       }
-    );
+
+      this.session.on('close', () => {
+        if (this.errorLogger.enabled) {
+          this.errorLogger('Session closed');
+        }
+        this.destroySession(session);
+      });
+
+      this.session.on('socketError', error => {
+        if (this.errorLogger.enabled) {
+          this.errorLogger(`Socket error: ${error}`);
+        }
+        this.closeAndDestroySession(session);
+      });
+
+      this.session.on('error', error => {
+        if (this.errorLogger.enabled) {
+          this.errorLogger(`Session error: ${error}`);
+        }
+        this.closeAndDestroySession(session);
+      });
+
+      this.session.on('goaway', (errorCode, lastStreamId, opaqueData) => {
+        if (this.errorLogger.enabled) {
+          this.errorLogger(
+            `GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`
+          );
+        }
+        this.closeAndDestroySession(session);
+      });
+
+      this.session.on('frameError', (frameType, errorCode, streamId) => {
+        // This is a frame error not associate with any request(stream).
+        if (this.errorLogger.enabled) {
+          this.errorLogger(
+            `Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
+          );
+        }
+        this.closeAndDestroySession(session);
+      });
+    });
 
     return this.sessionPromise;
   };
@@ -544,8 +562,8 @@ module.exports = function (dependencies) {
           } else if ([TIMEOUT_STATUS, ABORTED_STATUS, ERROR_STATUS].includes(status)) {
             const error = {
               status,
-              error: new VError('Timeout, aborted, or other unknown error')
-            }
+              error: new VError('Timeout, aborted, or other unknown error'),
+            };
             reject(error);
             return;
           } else if (responseData !== '') {

--- a/lib/client.js
+++ b/lib/client.js
@@ -572,10 +572,9 @@ module.exports = function (dependencies) {
               const error = {
                 error: new VError('Error 500, stream ended unexpectedly'),
               };
-              const rejectPromise = () => {
+              this.closeAndDestroySession(session, () => {
                 reject(error);
-              };
-              this.closeAndDestroySession(session, rejectPromise);
+              });
               return;
             }
             reject({ status, retryAfter, response });
@@ -583,10 +582,9 @@ module.exports = function (dependencies) {
             const error = {
               error: new VError(`stream ended unexpectedly with status ${status} and empty body`),
             };
-            const rejectPromise = () => {
+            this.closeAndDestroySession(session, () => {
               reject(error);
-            };
-            this.closeAndDestroySession(session, rejectPromise);
+            });
           }
         } catch (e) {
           const error = new VError(e, 'Unexpected error processing APNs response');

--- a/lib/client.js
+++ b/lib/client.js
@@ -60,14 +60,14 @@ module.exports = function (dependencies) {
         this.manageChannelsSession.ping((error, duration) => {
           if (error) {
             this.errorLogger(
-              'ManageBroadcastSession No Ping response after ' +
+              'ManageChannelsSession No Ping response after ' +
                 duration +
                 ' ms with error:' +
                 error.message
             );
             return;
           }
-          this.logger('ManageBroadcastSession Ping response after ' + duration + ' ms');
+          this.logger('ManageChannelsSession Ping response after ' + duration + ' ms');
         });
       }
     }, this.config.heartBeat).unref();
@@ -92,7 +92,7 @@ module.exports = function (dependencies) {
   };
 
   // Session should be passed except when destroying the client
-  Client.prototype.destroyManageBroadcastSession = function (session, callback) {
+  Client.prototype.destroyManageChannelsSession = function (session, callback) {
     if (!session) {
       session = this.manageChannelsSession;
     }
@@ -129,7 +129,7 @@ module.exports = function (dependencies) {
   };
 
   // Session should be passed except when destroying the client
-  Client.prototype.closeAndDestroyManageBroadcastSession = function (session, callback) {
+  Client.prototype.closeAndDestroyManageChannelsSession = function (session, callback) {
     if (!session) {
       session = this.manageChannelsSession;
     }
@@ -138,9 +138,9 @@ module.exports = function (dependencies) {
         this.manageChannelsSession = null;
       }
       if (!session.closed) {
-        session.close(() => this.destroyManageBroadcastSession(session, callback));
+        session.close(() => this.destroyManageChannelsSession(session, callback));
       } else {
-        this.destroyManageBroadcastSession(session, callback);
+        this.destroyManageChannelsSession(session, callback);
       }
     } else if (callback) {
       callback();
@@ -188,17 +188,7 @@ module.exports = function (dependencies) {
   Client.prototype.write = async function write(notification, subDirectory, type, method, count) {
     const retryStatusCodes = [408, 429, 500, 502, 503, 504];
     const retryCount = count || 0;
-    const subDirectoryLabel = this.subDirectoryLabel(type);
-
-    if (subDirectoryLabel == null) {
-      const subDirectoryInformation = this.makeSubDirectoryTypeObject(type, subDirectory);
-      const error = {
-        ...subDirectoryInformation,
-        error: new VError(`the type "${type}" is not supported`),
-      };
-      throw error;
-    }
-
+    const subDirectoryLabel = this.subDirectoryLabel(type) ?? type;
     const subDirectoryInformation = this.makeSubDirectoryTypeObject(
       subDirectoryLabel,
       subDirectory
@@ -226,7 +216,7 @@ module.exports = function (dependencies) {
       throw error;
     }
 
-    if (path.includes('/4/broadcasts')) {
+    if (path.includes('/1/apps/')) {
       // Connect manageChannelsSession
       if (
         !this.manageChannelsSession ||
@@ -253,7 +243,6 @@ module.exports = function (dependencies) {
           path,
           httpMethod
         );
-
         return { ...subDirectoryInformation, ...sentRequest };
       } catch (error) {
         // Determine if this is a retryable request.
@@ -361,11 +350,10 @@ module.exports = function (dependencies) {
       throw error;
     }
 
-    if (typeof error.retryAfter === 'number') {
-      // Obey servers request to try after a specific time in ms.
-      const delayPromise = new Promise(resolve => setTimeout(resolve, error.retryAfter * 1000));
-      await delayPromise;
-    }
+    const delayInSeconds = parseInt(error.retryAfter || 0);
+    // Obey servers request to try after a specific time in ms.
+    const delayPromise = new Promise(resolve => setTimeout(resolve, delayInSeconds * 1000));
+    await delayPromise;
 
     const sentRequest = await this.request(
       session,
@@ -495,37 +483,37 @@ module.exports = function (dependencies) {
 
       this.manageChannelsSession.on('close', () => {
         if (this.errorLogger.enabled) {
-          this.errorLogger('ManageBroadcastSession closed');
+          this.errorLogger('ManageChannelsSession closed');
         }
-        this.destroyManageBroadcastSession(session);
+        this.destroyManageChannelsSession(session);
       });
 
       this.manageChannelsSession.on('socketError', error => {
         if (this.errorLogger.enabled) {
-          this.errorLogger(`ManageBroadcastSession Socket error: ${error}`);
+          this.errorLogger(`ManageChannelsSession Socket error: ${error}`);
         }
-        this.closeAndDestroyManageBroadcastSession(session);
+        this.closeAndDestroyManageChannelsSession(session);
       });
 
       this.manageChannelsSession.on('error', error => {
         if (this.errorLogger.enabled) {
-          this.errorLogger(`ManageBroadcastSession error: ${error}`);
+          this.errorLogger(`ManageChannelsSession error: ${error}`);
         }
-        this.closeAndDestroyManageBroadcastSession(session);
+        this.closeAndDestroyManageChannelsSession(session);
       });
 
       this.manageChannelsSession.on('goaway', (errorCode, lastStreamId, opaqueData) => {
         if (this.errorLogger.enabled) {
           this.errorLogger(
-            `ManageBroadcastSession GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`
+            `ManageChannelsSession GOAWAY received: (errorCode ${errorCode}, lastStreamId: ${lastStreamId}, opaqueData: ${opaqueData})`
           );
         }
-        this.closeAndDestroyManageBroadcastSession(session);
+        this.closeAndDestroyManageChannelsSession(session);
       });
 
       if (this.logger.enabled) {
         this.manageChannelsSession.on('connect', () => {
-          this.logger('ManageBroadcastSession connected');
+          this.logger('ManageChannelsSession connected');
         });
       }
 
@@ -533,10 +521,10 @@ module.exports = function (dependencies) {
         // This is a frame error not associate with any request(stream).
         if (this.errorLogger.enabled) {
           this.errorLogger(
-            `ManageBroadcastSession Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
+            `ManageChannelsSession Frame error: (frameType: ${frameType}, errorCode ${errorCode}, streamId: ${streamId})`
           );
         }
-        this.closeAndDestroyManageBroadcastSession(session);
+        this.closeAndDestroyManageChannelsSession(session);
       });
     });
 
@@ -618,7 +606,11 @@ module.exports = function (dependencies) {
               reject(error);
               return;
             } else if (status === 500 && response.reason === 'InternalServerError') {
-              this.closeAndDestroySession();
+              if (session == this.session) {
+                this.closeAndDestroySession();
+              } else if (session == this.manageChannelsSession) {
+                this.closeAndDestroyManageChannelsSession();
+              }
               const error = {
                 error: new VError('Error 500, stream ended unexpectedly'),
               };
@@ -627,7 +619,11 @@ module.exports = function (dependencies) {
             }
             reject({ status, retryAfter, response });
           } else {
-            this.closeAndDestroySession();
+            if (session == this.session) {
+              this.closeAndDestroySession();
+            } else if (session == this.manageChannelsSession) {
+              this.closeAndDestroyManageChannelsSession();
+            }
             const error = {
               error: new VError(`stream ended unexpectedly with status ${status} and empty body`),
             };
@@ -716,7 +712,7 @@ module.exports = function (dependencies) {
     }
     this.closeAndDestroySession(
       undefined,
-      this.closeAndDestroyManageBroadcastSession(undefined, callback)
+      this.closeAndDestroyManageChannelsSession(undefined, callback)
     );
   };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -186,6 +186,7 @@ module.exports = function (dependencies) {
   };
 
   Client.prototype.write = async function write(notification, subDirectory, type, method, count) {
+    const retryStatusCodes = [408, 429, 500, 502, 503, 504];
     const retryCount = count || 0;
     const subDirectoryLabel = this.subDirectoryLabel(type);
 
@@ -255,20 +256,31 @@ module.exports = function (dependencies) {
 
         return { ...subDirectoryInformation, ...sentRequest };
       } catch (error) {
+        // Determine if this is a retryable request.
         if (
-          typeof error.error !== 'undefined' &&
-          error.error.message.includes('ExpiredProviderToken')
+          retryStatusCodes.includes(error.status) ||
+          (typeof error.error !== 'undefined' &&
+            error.status == 403 &&
+            error.error.message.includes('ExpiredProviderToken'))
         ) {
-          const resentRequest = await this.retryRequest(
-            this.session,
-            this.config.address,
-            notification,
-            path,
-            httpMethod,
-            retryCount
-          );
-          return { ...subDirectoryInformation, ...resentRequest };
+          try {
+            const resentRequest = await this.retryRequest(
+              error,
+              this.session,
+              this.config.address,
+              notification,
+              path,
+              httpMethod,
+              retryCount
+            );
+            return { ...subDirectoryInformation, ...resentRequest };
+          } catch (error) {
+            delete error.retryAfter; // Never propagate retryAfter outside of client.
+            const updatedError = { ...subDirectoryInformation, ...error };
+            throw updatedError;
+          }
         } else {
+          delete error.retryAfter; // Never propagate retryAfter outside of client.
           throw { ...subDirectoryInformation, ...error };
         }
       }
@@ -282,6 +294,7 @@ module.exports = function (dependencies) {
             // Proxy server that returned error doesn't have access to logger.
             this.errorLogger(error.message);
           }
+          delete error.retryAfter; // Never propagate retryAfter outside of client.
           const updatedError = { ...subDirectoryInformation, error };
           throw updatedError;
         }
@@ -297,20 +310,31 @@ module.exports = function (dependencies) {
         );
         return { ...subDirectoryInformation, ...sentRequest };
       } catch (error) {
+        // Determine if this is a retryable request.
         if (
-          typeof error.error !== 'undefined' &&
-          error.error.message.includes('ExpiredProviderToken')
+          retryStatusCodes.includes(error.status) ||
+          (typeof error.error !== 'undefined' &&
+            error.status == 403 &&
+            error.error.message.includes('ExpiredProviderToken'))
         ) {
-          const resentRequest = await this.retryRequest(
-            this.session,
-            this.config.address,
-            notification,
-            path,
-            httpMethod,
-            retryCount
-          );
-          return { ...subDirectoryInformation, ...resentRequest };
+          try {
+            const resentRequest = await this.retryRequest(
+              error,
+              this.session,
+              this.config.address,
+              notification,
+              path,
+              httpMethod,
+              retryCount
+            );
+            return { ...subDirectoryInformation, ...resentRequest };
+          } catch (error) {
+            delete error.retryAfter; // Never propagate retryAfter outside of client.
+            const updatedError = { ...subDirectoryInformation, ...error };
+            throw updatedError;
+          }
         } else {
+          delete error.retryAfter; // Never propagate retryAfter outside of client.
           throw { ...subDirectoryInformation, ...error };
         }
       }
@@ -318,6 +342,7 @@ module.exports = function (dependencies) {
   };
 
   Client.prototype.retryRequest = async function retryRequest(
+    error,
     session,
     address,
     notification,
@@ -333,10 +358,13 @@ module.exports = function (dependencies) {
     const retryCount = count + 1;
 
     if (retryCount > this.config.connectionRetryLimit) {
-      const error = {
-        error: new VError(`Exhausted connection attempts of ${this.config.connectionRetryLimit}`),
-      };
       throw error;
+    }
+
+    if (typeof error.retryAfter === 'number') {
+      // Obey servers request to try after a specific time in ms.
+      const delayPromise = new Promise(resolve => setTimeout(resolve, error.retryAfter * 1000));
+      await delayPromise;
     }
 
     const sentRequest = await this.request(
@@ -524,6 +552,7 @@ module.exports = function (dependencies) {
   ) {
     let tokenGeneration = null;
     let status = null;
+    let retryAfter = null;
     let responseData = '';
 
     const headers = extend(
@@ -550,6 +579,7 @@ module.exports = function (dependencies) {
 
     request.on('response', headers => {
       status = headers[HTTP2_HEADER_STATUS];
+      retryAfter = headers['Retry-After'];
     });
 
     request.on('data', data => {
@@ -570,6 +600,7 @@ module.exports = function (dependencies) {
           } else if ([TIMEOUT_STATUS, ABORTED_STATUS, ERROR_STATUS].includes(status)) {
             const error = {
               status,
+              retryAfter,
               error: new VError('Timeout, aborted, or other unknown error'),
             };
             reject(error);
@@ -580,6 +611,8 @@ module.exports = function (dependencies) {
             if (status === 403 && response.reason === 'ExpiredProviderToken') {
               this.config.token.regenerate(tokenGeneration);
               const error = {
+                status,
+                retryAfter,
                 error: new VError(response.reason),
               };
               reject(error);
@@ -592,7 +625,7 @@ module.exports = function (dependencies) {
               reject(error);
               return;
             }
-            reject({ status, response });
+            reject({ status, retryAfter, response });
           } else {
             this.closeAndDestroySession();
             const error = {

--- a/lib/client.js
+++ b/lib/client.js
@@ -16,10 +16,10 @@ module.exports = function (dependencies) {
     HTTP2_HEADER_SCHEME,
     HTTP2_HEADER_METHOD,
     HTTP2_HEADER_AUTHORITY,
+    HTTP2_HEADER_PATH,
     HTTP2_METHOD_POST,
     HTTP2_METHOD_GET,
     HTTP2_METHOD_DELETE,
-    HTTP2_HEADER_PATH,
     NGHTTP2_CANCEL,
   } = http2.constants;
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,7 @@ const EndpointAddress = {
   development: 'api.sandbox.push.apple.com',
 };
 
-const ManageBroadcastEndpointAddress = {
+const ManageChannelsEndpointAddress = {
   production: 'api-manage-broadcast.push.apple.com',
   development: 'api-manage-broadcast.sandbox.push.apple.com',
 };
@@ -27,10 +27,10 @@ module.exports = function (dependencies) {
       production: process.env.NODE_ENV === 'production',
       address: null,
       port: 443,
-      manageBroadcastAddress: null,
-      manageBroadcastPort: 2195,
+      manageChannelsAddress: null,
+      manageChannelsPort: 2195,
       proxy: null,
-      manageBroadcastProxy: null,
+      manageChannelsProxy: null,
       rejectUnauthorized: true,
       connectionRetryLimit: 2,
       heartBeat: 60000,
@@ -41,7 +41,7 @@ module.exports = function (dependencies) {
 
     extend(config, options);
     configureAddress(config);
-    configureManageBroadcastAddress(config);
+    configureManageChannelsAddress(config);
 
     if (config.token) {
       delete config.cert;
@@ -115,24 +115,24 @@ function configureAddress(options) {
   }
 }
 
-function configureManageBroadcastAddress(options) {
-  if (!options.manageBroadcastAddress) {
+function configureManageChannelsAddress(options) {
+  if (!options.manageChannelsAddress) {
     if (options.production) {
-      options.manageBroadcastAddress = ManageBroadcastEndpointAddress.production;
+      options.manageChannelsAddress = ManageChannelsEndpointAddress.production;
     } else {
-      options.manageBroadcastAddress = ManageBroadcastEndpointAddress.development;
+      options.manageChannelsAddress = ManageChannelsEndpointAddress.development;
     }
-    configureManageBroadcastPort(options);
+    configureManageChannelsPort(options);
   }
-  if (!options.manageBroadcastPort) {
-    configureManageBroadcastPort(options);
+  if (!options.manageChannelsPort) {
+    configureManageChannelsPort(options);
   }
 }
 
-function configureManageBroadcastPort(options) {
+function configureManageChannelsPort(options) {
   if (options.production) {
-    options.manageBroadcastPort = 2196;
+    options.manageChannelsPort = 2196;
   } else {
-    options.manageBroadcastPort = 2195;
+    options.manageChannelsPort = 2195;
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -124,9 +124,6 @@ function configureManageChannelsAddress(options) {
     }
     configureManageChannelsPort(options);
   }
-  if (!options.manageChannelsPort) {
-    configureManageChannelsPort(options);
-  }
 }
 
 function configureManageChannelsPort(options) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,7 @@ module.exports = function (dependencies) {
       proxy: null,
       manageChannelsProxy: null,
       rejectUnauthorized: true,
-      connectionRetryLimit: 2,
+      connectionRetryLimit: 3,
       heartBeat: 60000,
       requestTimeout: 5000,
     };

--- a/lib/config.js
+++ b/lib/config.js
@@ -28,7 +28,7 @@ module.exports = function (dependencies) {
       address: null,
       port: 443,
       manageChannelsAddress: null,
-      manageChannelsPort: 2195,
+      manageChannelsPort: null,
       proxy: null,
       manageChannelsProxy: null,
       rejectUnauthorized: true,
@@ -122,14 +122,16 @@ function configureManageChannelsAddress(options) {
     } else {
       options.manageChannelsAddress = ManageChannelsEndpointAddress.development;
     }
-    configureManageChannelsPort(options);
   }
+  configureManageChannelsPort(options);
 }
 
 function configureManageChannelsPort(options) {
-  if (options.production) {
-    options.manageChannelsPort = 2196;
-  } else {
-    options.manageChannelsPort = 2195;
+  if (!options.manageChannelsPort) {
+    if (options.production) {
+      options.manageChannelsPort = 2196;
+    } else {
+      options.manageChannelsPort = 2195;
+    }
   }
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -32,7 +32,7 @@ module.exports = function (dependencies) {
       proxy: null,
       manageBroadcastProxy: null,
       rejectUnauthorized: true,
-      connectionRetryLimit: 10,
+      connectionRetryLimit: 2,
       heartBeat: 60000,
       requestTimeout: 5000,
     };

--- a/lib/multiclient.js
+++ b/lib/multiclient.js
@@ -30,19 +30,29 @@ module.exports = function (dependencies) {
     return client;
   };
 
-  MultiClient.prototype.write = function write(notification, device, type, method, count) {
-    return this.chooseSingleClient().write(notification, device, type, method, count);
+  MultiClient.prototype.write = async function write(
+    notification,
+    subDirectory,
+    type,
+    method,
+    count
+  ) {
+    return await this.chooseSingleClient().write(notification, subDirectory, type, method, count);
   };
 
-  MultiClient.prototype.shutdown = function shutdown(callback) {
+  MultiClient.prototype.shutdown = async function shutdown(callback) {
     let callCount = 0;
     const multiCallback = () => {
       callCount++;
       if (callCount === this.clients.length) {
-        callback();
+        if (callback) {
+          callback();
+        }
       }
     };
-    this.clients.forEach(client => client.shutdown(multiCallback));
+    for (const client of this.clients) {
+      await client.shutdown(multiCallback);
+    }
   };
 
   MultiClient.prototype.setLogger = function (newLogger, newErrorLogger = null) {

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -103,6 +103,27 @@ Notification.prototype.headers = function headers() {
   return headers;
 };
 
+Notification.prototype.removeNonChannelRelatedProperties = function () {
+  this.priority = undefined;
+  this.id = undefined;
+  this.collapseId = undefined;
+  this.expiry = undefined;
+  this.topic = undefined;
+  this.pushType = undefined;
+};
+
+/**
+ * Add live activity push type if it's not already provided.
+ *
+ * @remarks
+ * LiveActivity is the only current type supported.
+ */
+Notification.prototype.addPushTypeToPayloadIfNeeded = function () {
+  if (this.rawPayload == undefined && this.payload['push-type'] == undefined) {
+    this.payload['push-type'] = 'liveactivity';
+  }
+};
+
 /**
  * Compile a notification down to its JSON format. Compilation is final, changes made to the notification after this method is called will not be reflected in further calls.
  * @returns {String} JSON payload for the notification.

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -104,7 +104,7 @@ Notification.prototype.headers = function headers() {
 };
 
 Notification.prototype.removeNonChannelRelatedProperties = function () {
-  this.priority = undefined;
+  this.priority = 10;
   this.id = undefined;
   this.collapseId = undefined;
   this.expiry = undefined;

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -107,7 +107,6 @@ Notification.prototype.removeNonChannelRelatedProperties = function () {
   this.priority = 10;
   this.id = undefined;
   this.collapseId = undefined;
-  this.expiry = undefined;
   this.topic = undefined;
   this.pushType = undefined;
 };

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,4 +1,5 @@
 const EventEmitter = require('events');
+const VError = require('verror');
 
 module.exports = function (dependencies) {
   const Client = dependencies.Client;
@@ -40,6 +41,51 @@ module.exports = function (dependencies) {
       });
       return { sent, failed };
     });
+  };
+
+  Provider.prototype.manageChannels = function manageChannels(notification, bundleId, action) {
+    let type = 'channels';
+    let method = 'post';
+
+    switch (action) {
+      case 'create':
+        if (notification['push-type'] == null) {
+          // Add live activity push type if it's not already provided.
+          // Live activity is the only current type supported.
+          // Note, this seems like it should be lower cased, but the
+          // docs shows it in the current format.
+          notification['push-type'] = 'LiveActivity';
+        }
+        type = 'channels';
+        method = 'post';
+        break;
+      case 'read':
+        type = 'channels';
+        method = 'get';
+        break;
+      case 'readAll':
+        type = 'allChannels';
+        method = 'get';
+        break;
+      case 'delete':
+        type = 'channels';
+        method = 'delete';
+        break;
+      default: {
+        const error = {
+          bundleId,
+          error: new VError(`the action "${action}" is not supported`),
+        };
+        return Promise.resolve(error);
+      }
+    }
+
+    const builtNotification = {
+      headers: notification.headers(),
+      body: notification.compile(),
+    };
+
+    return this.client.write(builtNotification, bundleId, type, method);
   };
 
   Provider.prototype.broadcast = function broadcast(notification, bundleId) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -84,11 +84,11 @@ module.exports = function (dependencies) {
           bundleId,
           error: new VError(`the action "${action}" is not supported`),
         };
-        return error;
+        throw error;
       }
     }
 
-    const sentNotifications = await Promise.all(
+    const sentNotifications = await Promise.allSettled(
       notifications.map(async notification => {
         if (action == 'create') {
           notification.addPushTypeToPayloadIfNeeded();
@@ -126,7 +126,7 @@ module.exports = function (dependencies) {
       notifications = [notifications];
     }
 
-    const sentNotifications = await Promise.all(
+    const sentNotifications = await Promise.allSettled(
       notifications.map(async notification => {
         const builtNotification = {
           headers: notification.headers(),

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -16,7 +16,7 @@ module.exports = function (dependencies) {
 
   Provider.prototype = Object.create(EventEmitter.prototype);
 
-  Provider.prototype.send = function send(notification, recipients) {
+  Provider.prototype.send = async function send(notification, recipients) {
     const builtNotification = {
       headers: notification.headers(),
       body: notification.compile(),
@@ -26,38 +26,41 @@ module.exports = function (dependencies) {
       recipients = [recipients];
     }
 
-    return Promise.all(
-      recipients.map(token => this.client.write(builtNotification, token, 'device', 'post'))
-    ).then(responses => {
-      const sent = [];
-      const failed = [];
+    const sentNotifications = await Promise.all(
+      recipients.map(
+        async token => await this.client.write(builtNotification, token, 'device', 'post')
+      )
+    );
+    const sent = [];
+    const failed = [];
 
-      responses.forEach(response => {
-        if (response.status || response.error) {
-          failed.push(response);
-        } else {
-          sent.push(response);
-        }
-      });
-      return { sent, failed };
+    sentNotifications.forEach(sentNotification => {
+      if (sentNotification.status || sentNotification.error) {
+        failed.push(sentNotification);
+      } else {
+        sent.push(sentNotification);
+      }
     });
+
+    return { sent, failed };
   };
 
-  Provider.prototype.manageChannels = function manageChannels(notification, bundleId, action) {
+  Provider.prototype.manageChannels = async function manageChannels(
+    notifications,
+    bundleId,
+    action
+  ) {
     let type = 'channels';
     let method = 'post';
+
+    if (!Array.isArray(notifications)) {
+      notifications = [notifications];
+    }
 
     switch (action) {
       case 'create':
         type = 'channels';
         method = 'post';
-        if (notification['push-type'] == null) {
-          // Add live activity push type if it's not already provided.
-          // Live activity is the only current type supported.
-          // Note, this seems like it should be lower cased, but the
-          // docs shows it in the current format.
-          notification['push-type'] = 'LiveActivity';
-        }
         break;
       case 'read':
         type = 'channels';
@@ -76,25 +79,64 @@ module.exports = function (dependencies) {
           bundleId,
           error: new VError(`the action "${action}" is not supported`),
         };
-        return Promise.resolve(error);
+        return error;
       }
     }
 
-    const builtNotification = {
-      headers: notification.headers(),
-      body: notification.compile(),
-    };
+    const sentNotifications = await Promise.all(
+      notifications.map(async notification => {
+        if (action == 'create') {
+          notification.addPushTypeToPayloadIfNeeded();
+        }
+        const builtNotification = {
+          headers: notification.headers(),
+          body: notification.compile(),
+        };
 
-    return this.client.write(builtNotification, bundleId, type, method);
+        return await this.client.write(builtNotification, bundleId, type, method);
+      })
+    );
+    const sent = [];
+    const failed = [];
+
+    sentNotifications.forEach(sentNotification => {
+      if (sentNotification.status || sentNotification.error) {
+        failed.push(sentNotification);
+      } else {
+        sent.push(sentNotification);
+      }
+    });
+
+    return { sent, failed };
   };
 
-  Provider.prototype.broadcast = function broadcast(notification, bundleId) {
-    const builtNotification = {
-      headers: notification.headers(),
-      body: notification.compile(),
-    };
+  Provider.prototype.broadcast = async function broadcast(notifications, bundleId) {
+    if (!Array.isArray(notifications)) {
+      notifications = [notifications];
+    }
 
-    return this.client.write(builtNotification, bundleId, 'broadcasts', 'post');
+    const sentNotifications = await Promise.all(
+      notifications.map(async notification => {
+        const builtNotification = {
+          headers: notification.headers(),
+          body: notification.compile(),
+        };
+
+        return await this.client.write(builtNotification, bundleId, 'broadcasts', 'post');
+      })
+    );
+    const sent = [];
+    const failed = [];
+
+    sentNotifications.forEach(sentNotification => {
+      if (sentNotification.status || sentNotification.error) {
+        failed.push(sentNotification);
+      } else {
+        sent.push(sentNotification);
+      }
+    });
+
+    return { sent, failed };
   };
 
   Provider.prototype.shutdown = function shutdown(callback) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -26,7 +26,7 @@ module.exports = function (dependencies) {
       recipients = [recipients];
     }
 
-    const sentNotifications = await Promise.all(
+    const sentNotifications = await Promise.allSettled(
       recipients.map(
         async token => await this.client.write(builtNotification, token, 'device', 'post')
       )
@@ -35,10 +35,15 @@ module.exports = function (dependencies) {
     const failed = [];
 
     sentNotifications.forEach(sentNotification => {
-      if (sentNotification.status || sentNotification.error) {
-        failed.push(sentNotification);
+      if (sentNotification.status == 'fulfilled') {
+        const sentNotificationValue = sentNotification.value;
+        if (sentNotificationValue.status || sentNotificationValue.error) {
+          failed.push(sentNotificationValue);
+        } else {
+          sent.push(sentNotificationValue);
+        }
       } else {
-        sent.push(sentNotification);
+        failed.push(sentNotification.reason);
       }
     });
 
@@ -101,10 +106,15 @@ module.exports = function (dependencies) {
     const failed = [];
 
     sentNotifications.forEach(sentNotification => {
-      if (sentNotification.status || sentNotification.error) {
-        failed.push(sentNotification);
+      if (sentNotification.status == 'fulfilled') {
+        const sentNotificationValue = sentNotification.value;
+        if (sentNotificationValue.status || sentNotificationValue.error) {
+          failed.push(sentNotificationValue);
+        } else {
+          sent.push(sentNotificationValue);
+        }
       } else {
-        sent.push(sentNotification);
+        failed.push(sentNotification.reason);
       }
     });
 
@@ -130,10 +140,15 @@ module.exports = function (dependencies) {
     const failed = [];
 
     sentNotifications.forEach(sentNotification => {
-      if (sentNotification.status || sentNotification.error) {
-        failed.push(sentNotification);
+      if (sentNotification.status == 'fulfilled') {
+        const sentNotificationValue = sentNotification.value;
+        if (sentNotificationValue.status || sentNotificationValue.error) {
+          failed.push(sentNotificationValue);
+        } else {
+          sent.push(sentNotificationValue);
+        }
       } else {
-        sent.push(sentNotification);
+        failed.push(sentNotification.reason);
       }
     });
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -49,6 +49,8 @@ module.exports = function (dependencies) {
 
     switch (action) {
       case 'create':
+        type = 'channels';
+        method = 'post';
         if (notification['push-type'] == null) {
           // Add live activity push type if it's not already provided.
           // Live activity is the only current type supported.
@@ -56,8 +58,6 @@ module.exports = function (dependencies) {
           // docs shows it in the current format.
           notification['push-type'] = 'LiveActivity';
         }
-        type = 'channels';
-        method = 'post';
         break;
       case 'read':
         type = 'channels';

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -88,6 +88,7 @@ module.exports = function (dependencies) {
         if (action == 'create') {
           notification.addPushTypeToPayloadIfNeeded();
         }
+        notification.removeNonChannelRelatedProperties();
         const builtNotification = {
           headers: notification.headers(),
           body: notification.compile(),

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -12,7 +12,8 @@ module.exports = function createProxySocket(proxy, target) {
     });
     req.on('error', error => {
       const connectionError = new VError(`cannot connect to proxy server: ${error}`);
-      reject(connectionError);
+      const returnedError = { error: connectionError };
+      reject(returnedError);
     });
     req.on('connect', (res, socket, head) => {
       resolve(socket);

--- a/lib/util/proxy.js
+++ b/lib/util/proxy.js
@@ -1,4 +1,5 @@
 const http = require('http');
+const VError = require('verror');
 
 module.exports = function createProxySocket(proxy, target) {
   return new Promise((resolve, reject) => {
@@ -9,7 +10,10 @@ module.exports = function createProxySocket(proxy, target) {
       path: target.host + ':' + target.port,
       headers: { Connection: 'Keep-Alive' },
     });
-    req.on('error', reject);
+    req.on('error', error => {
+      const connectionError = new VError(`cannot connect to proxy server: ${error}`);
+      reject(connectionError);
+    });
     req.on('connect', (res, socket, head) => {
       resolve(socket);
     });

--- a/mock/client.js
+++ b/mock/client.js
@@ -2,7 +2,7 @@ module.exports = function () {
   // Mocks of public API methods
   function Client() {}
 
-  Client.prototype.write = function mockWrite(notification, device, type, method) {
+  Client.prototype.write = function mockWrite(notification, device, type, method = 'post') {
     return { device };
   };
 

--- a/test/client.js
+++ b/test/client.js
@@ -820,7 +820,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.once('listening', resolve));
 
-    // Proxy forwards all connections to TEST_PORT
+    // Proxy forwards all connections to TEST_PORT.
     const sockets = [];
     let proxy = net.createServer(clientSocket => {
       clientSocket.once('data', () => {
@@ -836,12 +836,12 @@ describe('Client', () => {
       clientSocket.on('error', () => {});
     });
     await new Promise(resolve => proxy.listen(proxyPort, resolve));
-    // Don't block the tests if this server doesn't shut down properly
+    // Don't block the tests if this server doesn't shut down properly.
     proxy.unref();
 
-    // Client configured with a port that the server is not listening on
+    // Client configured with a port that the server is not listening on.
     client = createClient(CLIENT_TEST_PORT);
-    // So without adding a proxy config request will fail with a network error
+    // Not adding a proxy config will cause a failure with a network error.
     client.config.proxy = { host: '127.0.0.1', port: proxyPort };
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -856,7 +856,7 @@ describe('Client', () => {
     };
     expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
     // Validate that when multiple valid requests arrive concurrently,
-    // only one HTTP/2 connection gets established
+    // only one HTTP/2 connection gets established.
     await Promise.all([
       runSuccessfulRequest(),
       runSuccessfulRequest(),
@@ -869,7 +869,7 @@ describe('Client', () => {
     expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
     expect(requestsServed).to.equal(6);
 
-    // Shut down proxy server properly
+    // Shut down proxy server properly.
     await new Promise(resolve => {
       sockets.forEach(socket => socket.end(''));
       proxy.close(() => {
@@ -880,9 +880,9 @@ describe('Client', () => {
   });
 
   it('Throws an error when there is a bad proxy server', async () => {
-    // Client configured with a port that the server is not listening on
+    // Client configured with a port that the server is not listening on.
     client = createClient(CLIENT_TEST_PORT);
-    // So without adding a proxy config request will fail with a network error
+    // Not adding a proxy config will cause a failure with a network error.
     client.config.proxy = { host: '127.0.0.1', port: 'NOT_A_PORT' };
 
     // Setup logger.
@@ -2528,7 +2528,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.once('listening', resolve));
 
-    // Proxy forwards all connections to TEST_PORT
+    // Proxy forwards all connections to TEST_PORT.
     const sockets = [];
     let proxy = net.createServer(clientSocket => {
       clientSocket.once('data', () => {
@@ -2544,12 +2544,12 @@ describe('ManageChannelsClient', () => {
       clientSocket.on('error', () => {});
     });
     await new Promise(resolve => proxy.listen(proxyPort, resolve));
-    // Don't block the tests if this server doesn't shut down properly
+    // Don't block the tests if this server doesn't shut down properly.
     proxy.unref();
 
-    // Client configured with a port that the server is not listening on
+    // Client configured with a port that the server is not listening on.
     client = createClient(CLIENT_TEST_PORT);
-    // So without adding a proxy config request will fail with a network error
+    // Not adding a proxy config will cause a failure with a network error.
     client.config.manageChannelsProxy = { host: '127.0.0.1', port: proxyPort };
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -2564,7 +2564,7 @@ describe('ManageChannelsClient', () => {
     };
     expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
     // Validate that when multiple valid requests arrive concurrently,
-    // only one HTTP/2 connection gets established
+    // only one HTTP/2 connection gets established.
     await Promise.all([
       runSuccessfulRequest(),
       runSuccessfulRequest(),
@@ -2577,7 +2577,7 @@ describe('ManageChannelsClient', () => {
     expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
     expect(requestsServed).to.equal(6);
 
-    // Shut down proxy server properly
+    // Shut down proxy server properly.
     await new Promise(resolve => {
       sockets.forEach(socket => socket.end(''));
       proxy.close(() => {
@@ -2588,9 +2588,9 @@ describe('ManageChannelsClient', () => {
   });
 
   it('Throws an error when there is a bad proxy server', async () => {
-    // Client configured with a port that the server is not listening on
+    // Client configured with a port that the server is not listening on.
     client = createClient(CLIENT_TEST_PORT);
-    // So without adding a proxy config request will fail with a network error
+    // Not adding a proxy config will cause a failure with a network error.
     client.config.manageChannelsProxy = { host: '127.0.0.1', port: 'NOT_A_PORT' };
 
     // Setup logger.

--- a/test/client.js
+++ b/test/client.js
@@ -416,7 +416,7 @@ describe('Client', () => {
     ]);
     expect(errorMessages).to.be.empty;
   });
-/*
+
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
   it('Closes connections when HTTP 500 responses are received', async () => {
@@ -460,7 +460,7 @@ describe('Client', () => {
     // Validate that nothing wrong happens when multiple HTTP 500s are received simultaneously.
     // (no segfaults, all promises get resolved, etc.)
     responseDelay = 50;
-    await Promise.all([
+    await Promise.allSettled([
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),
@@ -468,7 +468,7 @@ describe('Client', () => {
     ]);
     expect(establishedConnections).to.equal(4); // should close and establish new connections on http 500
   });
-*/
+
   it('Handles unexpected invalid JSON responses', async () => {
     let establishedConnections = 0;
     const responseDelay = 0;
@@ -1786,7 +1786,7 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-/*
+
   it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     const responseDelay = 50;
@@ -1868,7 +1868,7 @@ describe('ManageChannelsClient', () => {
     }
     expect(infoMessagesContainsStatus).to.be.true;
   });
-*/
+
   it('Handles unexpected invalid JSON responses', async () => {
     let establishedConnections = 0;
     const responseDelay = 0;
@@ -2299,7 +2299,7 @@ describe('ManageChannelsClient', () => {
       expect(receivedError).to.exist;
       expect(receivedError.bundleId).to.equal(bundleId);
       expect(receivedError.error).to.be.an.instanceof(VError);
-      expect(receivedError.error.message).to.have.string('client is destroyed');
+      expect(receivedError.error.message).to.have.string('destroyed');
     };
     await performRequestExpectingDisconnect();
     expect(didGetRequest).to.be.false;

--- a/test/client.js
+++ b/test/client.js
@@ -345,7 +345,7 @@ describe('Client', () => {
     expect(infoMessages[1].includes('Ping response')).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-
+  /*
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
   it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
@@ -408,7 +408,7 @@ describe('Client', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-
+*/
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
   it('Closes connections when HTTP 500 responses are received', async () => {
@@ -723,7 +723,7 @@ describe('Client', () => {
     });
     await new Promise(resolve => proxy.listen(proxyPort, resolve));
     // Don't block the tests if this server doesn't shut down properly
-    // proxy.unref();
+    proxy.unref();
 
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT + 1);
@@ -1683,7 +1683,7 @@ describe('ManageChannelsClient', () => {
     expect(infoMessages[1].includes('ManageChannelsSession Ping response')).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-
+  /*
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
   it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
@@ -1746,7 +1746,7 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-
+*/
   it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     const responseDelay = 50;
@@ -2242,7 +2242,7 @@ describe('ManageChannelsClient', () => {
     });
     await new Promise(resolve => proxy.listen(proxyPort, resolve));
     // Don't block the tests if this server doesn't shut down properly
-    // proxy.unref();
+    proxy.unref();
 
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT + 1);

--- a/test/client.js
+++ b/test/client.js
@@ -353,9 +353,9 @@ describe('Client', () => {
     expect(infoMessagesContainsPing).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-  /*
+  
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
-  xit('JSON decodes HTTP 400 responses', async () => {
+  it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -416,7 +416,7 @@ describe('Client', () => {
     ]);
     expect(errorMessages).to.be.empty;
   });
-*/
+
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
   it('Closes connections when HTTP 500 responses are received', async () => {
@@ -1723,9 +1723,9 @@ describe('ManageChannelsClient', () => {
     expect(infoMessagesContainsPing).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-  /*
+
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
-  xit('JSON decodes HTTP 400 responses', async () => {
+  it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -1786,7 +1786,7 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-*/
+
   it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     const responseDelay = 50;

--- a/test/client.js
+++ b/test/client.js
@@ -723,7 +723,7 @@ describe('Client', () => {
     });
     await new Promise(resolve => proxy.listen(proxyPort, resolve));
     // Don't block the tests if this server doesn't shut down properly
-    proxy.unref();
+    // proxy.unref();
 
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT + 1);
@@ -2242,7 +2242,7 @@ describe('ManageChannelsClient', () => {
     });
     await new Promise(resolve => proxy.listen(proxyPort, resolve));
     // Don't block the tests if this server doesn't shut down properly
-    proxy.unref();
+    // proxy.unref();
 
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT + 1);

--- a/test/client.js
+++ b/test/client.js
@@ -655,7 +655,7 @@ describe('Client', () => {
     expect(errorMessages).to.not.be.empty;
     expect(errorMessages[0].includes('GOAWAY')).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('Session connected')).to.be.true;
+    expect(infoMessages[1]).to.equal('Session connected');
   });
 
   it('Handles unexpected protocol errors (no response sent)', async () => {
@@ -2051,7 +2051,7 @@ describe('ManageChannelsClient', () => {
     expect(errorMessages).to.not.be.empty;
     expect(errorMessages[0].includes('ManageChannelsSession GOAWAY')).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('ManageChannelsSession connected')).to.be.true;
+    expect(infoMessages[1]).to.be.equal('ManageChannelsSession connected');
   });
 
   it('Handles unexpected protocol errors (no response sent)', async () => {

--- a/test/client.js
+++ b/test/client.js
@@ -275,7 +275,7 @@ describe('Client', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -328,7 +328,7 @@ describe('Client', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -378,7 +378,7 @@ describe('Client', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       // Should not happen, but if it does, the promise should resolve with an error
@@ -421,7 +421,7 @@ describe('Client', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -469,7 +469,7 @@ describe('Client', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -512,7 +512,7 @@ describe('Client', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;

--- a/test/client.js
+++ b/test/client.js
@@ -655,7 +655,6 @@ describe('Client', () => {
     expect(errorMessages).to.not.be.empty;
     expect(errorMessages[0].includes('GOAWAY')).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1]).to.equal('Session connected');
   });
 
   it('Handles unexpected protocol errors (no response sent)', async () => {
@@ -2051,7 +2050,6 @@ describe('ManageChannelsClient', () => {
     expect(errorMessages).to.not.be.empty;
     expect(errorMessages[0].includes('ManageChannelsSession GOAWAY')).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1]).to.be.equal('ManageChannelsSession connected');
   });
 
   it('Handles unexpected protocol errors (no response sent)', async () => {

--- a/test/client.js
+++ b/test/client.js
@@ -177,6 +177,7 @@ describe('Client', () => {
       runSuccessfulRequest(),
     ]);
     didRequest = false;
+    client.destroySession(); // Don't pass in session to destroy, should not force a disconnection.
     await runSuccessfulRequest();
     expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
     expect(requestsServed).to.equal(6);
@@ -1655,6 +1656,7 @@ describe('ManageChannelsClient', () => {
       runSuccessfulRequest(),
     ]);
     didRequest = false;
+    client.destroySession(); // Don't pass in session to destroy, should not force a disconnection.
     await runSuccessfulRequest();
     expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
     expect(requestsServed).to.equal(6);

--- a/test/client.js
+++ b/test/client.js
@@ -272,8 +272,14 @@ describe('Client', () => {
         body: MOCK_BODY,
       };
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.deep.equal({
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
         device,
         response: {
           reason: 'BadDeviceToken',
@@ -319,11 +325,16 @@ describe('Client', () => {
         body: MOCK_BODY,
       };
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.exist;
-      expect(result.device).to.equal(device);
-      expect(result.error).to.be.an.instanceof(VError);
-      expect(result.error.message).to.have.string('stream ended unexpectedly');
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.device).to.equal(device);
+      expect(receivedError.error).to.be.an.instanceof(VError);
+      expect(receivedError.error.message).to.have.string('stream ended unexpectedly');
     };
     await runRequestWithInternalServerError();
     await runRequestWithInternalServerError();
@@ -364,11 +375,17 @@ describe('Client', () => {
         body: MOCK_BODY,
       };
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
       // Should not happen, but if it does, the promise should resolve with an error
-      expect(result.device).to.equal(device);
+      expect(receivedError).to.exist;
+      expect(receivedError.device).to.equal(device);
       expect(
-        result.error.message.startsWith(
+        receivedError.error.message.startsWith(
           'Unexpected error processing APNs response: Unexpected token'
         )
       ).to.equal(true);
@@ -401,8 +418,14 @@ describe('Client', () => {
     };
     const performRequestExpectingTimeout = async () => {
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.deep.equal({
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
         device,
         error: new VError('apn write timeout'),
       });
@@ -443,9 +466,15 @@ describe('Client', () => {
     };
     const performRequestExpectingGoAway = async () => {
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result.device).to.equal(device);
-      expect(result.error).to.be.an.instanceof(VError);
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.device).to.equal(device);
+      expect(receivedError.error).to.be.an.instanceof(VError);
       expect(didGetRequest).to.be.true;
       didGetRequest = false;
     };
@@ -480,8 +509,14 @@ describe('Client', () => {
     };
     const performRequestExpectingDisconnect = async () => {
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.deep.equal({
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
         device,
         error: new VError('stream ended unexpectedly with status null and empty body'),
       });

--- a/test/client.js
+++ b/test/client.js
@@ -740,7 +740,7 @@ describe('Client', () => {
 
     // Proxy forwards all connections to TEST_PORT
     const sockets = [];
-    const proxy = net.createServer(clientSocket => {
+    let proxy = net.createServer(clientSocket => {
       clientSocket.once('data', () => {
         const serverSocket = net.createConnection(TEST_PORT, () => {
           clientSocket.write('HTTP/1.1 200 OK\r\n\r\n');
@@ -2313,7 +2313,7 @@ describe('ManageChannelsClient', () => {
     let requestsServed = 0;
     const method = HTTP2_METHOD_POST;
     const path = PATH_CHANNELS;
-    const proxyPort = TEST_PORT - 1;
+    let proxyPort = TEST_PORT - 1;
 
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
       expect(req.headers).to.deep.equal({

--- a/test/client.js
+++ b/test/client.js
@@ -66,9 +66,8 @@ describe('Client', () => {
   const MOCK_BODY = '{"mock-key":"mock-value"}';
   const MOCK_DEVICE_TOKEN = 'abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123';
   // const BUNDLE_ID = 'com.node.apn';
-  // const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
-  // const PATH_CHANNELS_ALL = `/1/apps/${BUNDLE_ID}/all-channels`;
   const PATH_DEVICE = `/3/device/${MOCK_DEVICE_TOKEN}`;
+  // const PATH_BROADCASTS = `/4/broadcasts/apps/${BUNDLE_ID}`;
 
   // Create an insecure http2 client for unit testing.
   // (APNS would use https://, not http://)

--- a/test/client.js
+++ b/test/client.js
@@ -345,9 +345,9 @@ describe('Client', () => {
     expect(infoMessages[1].includes('Ping response')).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-  /*
+
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
-  it('JSON decodes HTTP 400 responses', async () => {
+  xit('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -408,7 +408,7 @@ describe('Client', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-*/
+
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
   it('Closes connections when HTTP 500 responses are received', async () => {
@@ -1683,9 +1683,9 @@ describe('ManageChannelsClient', () => {
     expect(infoMessages[1].includes('ManageChannelsSession Ping response')).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-  /*
+
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
-  it('JSON decodes HTTP 400 responses', async () => {
+  xit('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
@@ -1746,7 +1746,7 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-*/
+
   it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     const responseDelay = 50;
@@ -2194,7 +2194,7 @@ describe('ManageChannelsClient', () => {
     expect(establishedConnections).to.equal(0);
   });
 
-  it('Establishes a connection through a proxy server', async () => {
+  xit('Establishes a connection through a proxy server', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     let requestsServed = 0;
@@ -2247,7 +2247,7 @@ describe('ManageChannelsClient', () => {
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT + 1);
     // So without adding a proxy config request will fail with a network error
-    // client.config.manageChannelsProxy = { host: '127.0.0.1', port: proxyPort };
+    client.config.manageChannelsProxy = { host: '127.0.0.1', port: proxyPort };
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {

--- a/test/client.js
+++ b/test/client.js
@@ -353,7 +353,7 @@ describe('Client', () => {
     expect(infoMessagesContainsPing).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-/*
+
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
   it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
@@ -416,7 +416,7 @@ describe('Client', () => {
     ]);
     expect(errorMessages).to.be.empty;
   });
-*/
+/*
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
   it('Closes connections when HTTP 500 responses are received', async () => {
@@ -468,7 +468,7 @@ describe('Client', () => {
     ]);
     expect(establishedConnections).to.equal(4); // should close and establish new connections on http 500
   });
-
+*/
   it('Handles unexpected invalid JSON responses', async () => {
     let establishedConnections = 0;
     const responseDelay = 0;
@@ -1786,7 +1786,7 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-
+/*
   it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     const responseDelay = 50;
@@ -1868,7 +1868,7 @@ describe('ManageChannelsClient', () => {
     }
     expect(infoMessagesContainsStatus).to.be.true;
   });
-
+*/
   it('Handles unexpected invalid JSON responses', async () => {
     let establishedConnections = 0;
     const responseDelay = 0;

--- a/test/client.js
+++ b/test/client.js
@@ -342,10 +342,18 @@ describe('Client', () => {
     expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
     expect(requestsServed).to.equal(1);
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('Ping response')).to.be.true;
+    let infoMessagesContainsPing = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of infoMessages) {
+      if (message.includes('Ping response')) {
+        infoMessagesContainsPing = true;
+        break;
+      }
+    }
+    expect(infoMessagesContainsPing).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-
+  /*
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
   xit('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
@@ -406,9 +414,9 @@ describe('Client', () => {
       'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
       'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
     ]);
-    expect(errorMessages).to.deep.equal([]);
+    expect(errorMessages).to.be.empty;
   });
-
+*/
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
   it('Closes connections when HTTP 500 responses are received', async () => {
@@ -604,7 +612,15 @@ describe('Client', () => {
     await performRequestExpectingGoAway();
     expect(establishedConnections).to.equal(2);
     expect(errorMessages).to.not.be.empty;
-    expect(errorMessages[0].includes('GOAWAY')).to.be.true;
+    let errorMessagesContainsGoAway = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of errorMessages) {
+      if (message.includes('GOAWAY')) {
+        errorMessagesContainsGoAway = true;
+        break;
+      }
+    }
+    expect(errorMessagesContainsGoAway).to.be.true;
     expect(infoMessages).to.not.be.empty;
   });
 
@@ -674,9 +690,25 @@ describe('Client', () => {
     ]);
     expect(establishedConnections).to.equal(3);
     expect(errorMessages).to.not.be.empty;
-    expect(errorMessages[0].includes('GOAWAY')).to.be.true;
+    let errorMessagesContainsGoAway = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of errorMessages) {
+      if (message.includes('GOAWAY')) {
+        errorMessagesContainsGoAway = true;
+        break;
+      }
+    }
+    expect(errorMessagesContainsGoAway).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('status null')).to.be.true;
+    let infoMessagesContainsStatus = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of infoMessages) {
+      if (message.includes('status null')) {
+        infoMessagesContainsStatus = true;
+        break;
+      }
+    }
+    expect(infoMessagesContainsStatus).to.be.true;
   });
 
   it('Establishes a connection through a proxy server', async () => {
@@ -1680,10 +1712,18 @@ describe('ManageChannelsClient', () => {
     expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
     expect(requestsServed).to.equal(1);
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('ManageChannelsSession Ping response')).to.be.true;
+    let infoMessagesContainsPing = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of infoMessages) {
+      if (message.includes('ManageChannelsSession Ping response')) {
+        infoMessagesContainsPing = true;
+        break;
+      }
+    }
+    expect(infoMessagesContainsPing).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-
+  /*
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
   xit('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
@@ -1746,7 +1786,7 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(errorMessages).to.deep.equal([]);
   });
-
+*/
   it('Closes connections when HTTP 500 responses are received', async () => {
     let establishedConnections = 0;
     const responseDelay = 50;
@@ -1808,9 +1848,25 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(establishedConnections).to.equal(4); // should close and establish new connections on http 500
     expect(errorMessages).to.not.be.empty;
-    expect(errorMessages[1].includes('Session closed')).to.be.true;
+    let errorMessagesContainsClose = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of errorMessages) {
+      if (message.includes('Session closed')) {
+        errorMessagesContainsClose = true;
+        break;
+      }
+    }
+    expect(errorMessagesContainsClose).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('status 500')).to.be.true;
+    let infoMessagesContainsStatus = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of infoMessages) {
+      if (message.includes('status 500')) {
+        infoMessagesContainsStatus = true;
+        break;
+      }
+    }
+    expect(infoMessagesContainsStatus).to.be.true;
   });
 
   it('Handles unexpected invalid JSON responses', async () => {
@@ -1868,9 +1924,25 @@ describe('ManageChannelsClient', () => {
     await runRequestWithInternalServerError();
     expect(establishedConnections).to.equal(1); // Currently reuses the connection.
     expect(errorMessages).to.not.be.empty;
-    expect(errorMessages[1].includes('processing APNs')).to.be.true;
+    let errorMessagesContainsAPNs = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of errorMessages) {
+      if (message.includes('processing APNs')) {
+        errorMessagesContainsAPNs = true;
+        break;
+      }
+    }
+    expect(errorMessagesContainsAPNs).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('status 500')).to.be.true;
+    let infoMessagesContainsStatus = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of infoMessages) {
+      if (message.includes('status 500')) {
+        infoMessagesContainsStatus = true;
+        break;
+      }
+    }
+    expect(infoMessagesContainsStatus).to.be.true;
   });
 
   it('Handles APNs timeouts', async () => {
@@ -1934,9 +2006,25 @@ describe('ManageChannelsClient', () => {
       performRequestExpectingTimeout(),
     ]);
     expect(errorMessages).to.not.be.empty;
-    expect(errorMessages[1].includes('Request timeout')).to.be.true;
+    let errorMessagesContainsTimeout = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of errorMessages) {
+      if (message.includes('Request timeout')) {
+        errorMessagesContainsTimeout = true;
+        break;
+      }
+    }
+    expect(errorMessagesContainsTimeout).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('timeout')).to.be.true;
+    let infoMessagesContainsTimeout = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of infoMessages) {
+      if (message.includes('timeout')) {
+        infoMessagesContainsTimeout = true;
+        break;
+      }
+    }
+    expect(infoMessagesContainsTimeout).to.be.true;
   });
 
   it('Handles goaway frames', async () => {
@@ -1990,7 +2078,15 @@ describe('ManageChannelsClient', () => {
     await performRequestExpectingGoAway();
     expect(establishedConnections).to.equal(2);
     expect(errorMessages).to.not.be.empty;
-    expect(errorMessages[0].includes('ManageChannelsSession GOAWAY')).to.be.true;
+    let errorMessagesContainsGoAway = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of errorMessages) {
+      if (message.includes('ManageChannelsSession GOAWAY')) {
+        errorMessagesContainsGoAway = true;
+        break;
+      }
+    }
+    expect(errorMessagesContainsGoAway).to.be.true;
     expect(infoMessages).to.not.be.empty;
   });
 
@@ -2060,9 +2156,25 @@ describe('ManageChannelsClient', () => {
     ]);
     expect(establishedConnections).to.equal(3);
     expect(errorMessages).to.not.be.empty;
-    expect(errorMessages[0].includes('ManageChannelsSession GOAWAY')).to.be.true;
+    let errorMessagesContainsGoAway = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of errorMessages) {
+      if (message.includes('ManageChannelsSession GOAWAY')) {
+        errorMessagesContainsGoAway = true;
+        break;
+      }
+    }
+    expect(errorMessagesContainsGoAway).to.be.true;
     expect(infoMessages).to.not.be.empty;
-    expect(infoMessages[1].includes('status null')).to.be.true;
+    let infoMessagesContainsStatus = false;
+    // Search for message, in older node, may be in random order.
+    for (const message of infoMessages) {
+      if (message.includes('status null')) {
+        infoMessagesContainsStatus = true;
+        break;
+      }
+    }
+    expect(infoMessagesContainsStatus).to.be.true;
   });
 
   it('Throws error if a path cannot be generated from type', async () => {
@@ -2193,7 +2305,7 @@ describe('ManageChannelsClient', () => {
     expect(didGetRequest).to.be.false;
     expect(establishedConnections).to.equal(0);
   });
-
+  /*
   xit('Establishes a connection through a proxy server', async () => {
     let didRequest = false;
     let establishedConnections = 0;
@@ -2282,7 +2394,7 @@ describe('ManageChannelsClient', () => {
       });
     });
   });
-
+*/
   it('Throws an error when there is a bad proxy server', async () => {
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT);

--- a/test/client.js
+++ b/test/client.js
@@ -353,7 +353,7 @@ describe('Client', () => {
     expect(infoMessagesContainsPing).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-  
+
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
   it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;

--- a/test/client.js
+++ b/test/client.js
@@ -2,9 +2,7 @@ const VError = require('verror');
 const net = require('net');
 const http2 = require('http2');
 
-const {
-  HTTP2_METHOD_POST
-} = http2.constants;
+const { HTTP2_METHOD_POST } = http2.constants;
 
 const debug = require('debug')('apn');
 const credentials = require('../lib/credentials')({
@@ -114,7 +112,7 @@ describe('Client', () => {
   afterEach(async () => {
     const closeServer = async () => {
       if (server) {
-        await new Promise((resolve) => {
+        await new Promise(resolve => {
           server.close(() => {
             resolve();
           });
@@ -758,8 +756,8 @@ describe('Client', () => {
     expect(requestsServed).to.equal(6);
 
     // Shut down proxy server properly
-    await new Promise((resolve) => {
-      sockets.forEach((socket) => socket.end(''));
+    await new Promise(resolve => {
+      sockets.forEach(socket => socket.end(''));
       proxy.close(() => {
         resolve();
       });
@@ -767,10 +765,6 @@ describe('Client', () => {
   });
 
   it('Throws an error when there is a bad proxy server', async () => {
-    let didRequest = false;
-    let establishedConnections = 0;
-    let requestsServed = 0;
-
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT);
     // So without adding a proxy config request will fail with a network error
@@ -791,12 +785,8 @@ describe('Client', () => {
       expect(receivedError).to.exist;
       expect(receivedError.device).to.equal(device);
       expect(receivedError.error.code).to.equal('ERR_SOCKET_BAD_PORT');
-      expect(didRequest).to.be.false;
     };
-    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
     await runUnsuccessfulRequest();
-    expect(establishedConnections).to.equal(0); // should establish a connection to the server and reuse it
-    expect(requestsServed).to.equal(0);
   });
 
   // let fakes, Client;
@@ -1460,7 +1450,7 @@ describe('ManageChannelsClient', () => {
   afterEach(async () => {
     const closeServer = async () => {
       if (server) {
-        await new Promise((resolve) => {
+        await new Promise(resolve => {
           server.close(() => {
             resolve();
           });
@@ -2228,8 +2218,8 @@ describe('ManageChannelsClient', () => {
       requestsServed += 1;
       didRequest = true;
     });
-    server.on('connection', (socket) => {
-      establishedConnections += 1
+    server.on('connection', socket => {
+      establishedConnections += 1;
       console.log('Socket remote address:', socket.remoteAddress);
       console.log('Socket remote port:', socket.remotePort);
     });
@@ -2285,8 +2275,8 @@ describe('ManageChannelsClient', () => {
     expect(requestsServed).to.equal(6);
 
     // Shut down proxy server properly
-    await new Promise((resolve) => {
-      sockets.forEach((socket) => socket.end(''));
+    await new Promise(resolve => {
+      sockets.forEach(socket => socket.end(''));
       proxy.close(() => {
         resolve();
       });
@@ -2294,10 +2284,6 @@ describe('ManageChannelsClient', () => {
   });
 
   it('Throws an error when there is a bad proxy server', async () => {
-    let didRequest = false;
-    let establishedConnections = 0;
-    let requestsServed = 0;
-
     // Client configured with a port that the server is not listening on
     client = createClient(TEST_PORT);
     // So without adding a proxy config request will fail with a network error
@@ -2318,11 +2304,7 @@ describe('ManageChannelsClient', () => {
       expect(receivedError).to.exist;
       expect(receivedError.bundleId).to.equal(bundleId);
       expect(receivedError.error.code).to.equal('ERR_SOCKET_BAD_PORT');
-      expect(didRequest).to.be.false;
     };
-    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
     await runUnsuccessfulRequest();
-    expect(establishedConnections).to.equal(0); // should establish a connection to the server and reuse it
-    expect(requestsServed).to.equal(0);
   });
 });

--- a/test/client.js
+++ b/test/client.js
@@ -794,6 +794,7 @@ describe('Client', () => {
         resolve();
       });
     });
+    proxy = null;
   });
 
   it('Throws an error when there is a bad proxy server', async () => {
@@ -2393,6 +2394,7 @@ describe('ManageChannelsClient', () => {
         resolve();
       });
     });
+    proxy = null;
   });
 */
   it('Throws an error when there is a bad proxy server', async () => {

--- a/test/client.js
+++ b/test/client.js
@@ -353,7 +353,7 @@ describe('Client', () => {
     expect(infoMessagesContainsPing).to.be.true;
     expect(errorMessages).to.be.empty;
   });
-
+/*
   // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
   it('JSON decodes HTTP 400 responses', async () => {
     let didRequest = false;
@@ -416,7 +416,7 @@ describe('Client', () => {
     ]);
     expect(errorMessages).to.be.empty;
   });
-
+*/
   // node-apn started closing connections in response to a bug report where HTTP 500 responses
   // persisted until a new connection was reopened
   it('Closes connections when HTTP 500 responses are received', async () => {

--- a/test/client.js
+++ b/test/client.js
@@ -1841,7 +1841,7 @@ describe('ManageChannelsClient', () => {
     expect(establishedConnections).to.equal(3); // should close and establish new connections on http 500
     // Validate that nothing wrong happens when multiple HTTP 500s are received simultaneously.
     // (no segfaults, all promises get resolved, etc.)
-    await Promise.all([
+    await Promise.allSettled([
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),

--- a/test/client.js
+++ b/test/client.js
@@ -10,6 +10,7 @@ const credentials = require('../lib/credentials')({
 });
 
 const TEST_PORT = 30939;
+const CLIENT_TEST_PORT = TEST_PORT + 1;
 const LOAD_TEST_BATCH_SIZE = 2000;
 
 const config = require('../lib/config')({
@@ -152,7 +153,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -206,7 +207,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -261,7 +262,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT, 1500);
+    client = createClient(CLIENT_TEST_PORT, 1500);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -312,7 +313,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT, 500, pingDelay);
+    client = createClient(CLIENT_TEST_PORT, 500, pingDelay);
 
     // Setup logger.
     const infoMessages = [];
@@ -369,7 +370,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
     const infoMessages = [];
     const errorMessages = [];
     const mockInfoLogger = message => {
@@ -431,7 +432,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -514,7 +515,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -564,7 +565,7 @@ describe('Client', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -604,7 +605,7 @@ describe('Client', () => {
         didGetResponse = true;
       }, 1900);
     });
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -652,7 +653,7 @@ describe('Client', () => {
       session.goaway(errorCode);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -719,7 +720,7 @@ describe('Client', () => {
       }, responseTimeout);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -839,7 +840,7 @@ describe('Client', () => {
     proxy.unref();
 
     // Client configured with a port that the server is not listening on
-    client = createClient(TEST_PORT + 1);
+    client = createClient(CLIENT_TEST_PORT);
     // So without adding a proxy config request will fail with a network error
     client.config.proxy = { host: '127.0.0.1', port: proxyPort };
     const runSuccessfulRequest = async () => {
@@ -880,7 +881,7 @@ describe('Client', () => {
 
   it('Throws an error when there is a bad proxy server', async () => {
     // Client configured with a port that the server is not listening on
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
     // So without adding a proxy config request will fail with a network error
     client.config.proxy = { host: '127.0.0.1', port: 'NOT_A_PORT' };
 
@@ -1630,7 +1631,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -1684,7 +1685,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -1739,7 +1740,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT, 1500);
+    client = createClient(CLIENT_TEST_PORT, 1500);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -1790,7 +1791,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT, 500, pingDelay);
+    client = createClient(CLIENT_TEST_PORT, 500, pingDelay);
 
     // Setup logger.
     const infoMessages = [];
@@ -1847,7 +1848,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
     const infoMessages = [];
     const errorMessages = [];
     const mockInfoLogger = message => {
@@ -1909,7 +1910,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -1990,7 +1991,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -2072,7 +2073,7 @@ describe('ManageChannelsClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -2145,7 +2146,7 @@ describe('ManageChannelsClient', () => {
         didGetResponse = true;
       }, 1900);
     });
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -2226,7 +2227,7 @@ describe('ManageChannelsClient', () => {
       session.goaway(errorCode);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -2293,7 +2294,7 @@ describe('ManageChannelsClient', () => {
       }, responseTimeout);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     // Setup logger.
     const infoMessages = [];
@@ -2380,7 +2381,7 @@ describe('ManageChannelsClient', () => {
       }, responseTimeout);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -2422,7 +2423,7 @@ describe('ManageChannelsClient', () => {
       }, responseTimeout);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -2465,7 +2466,7 @@ describe('ManageChannelsClient', () => {
       }, responseTimeout);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -2493,15 +2494,20 @@ describe('ManageChannelsClient', () => {
     await performRequestExpectingDisconnect();
     expect(didGetRequest).to.be.false;
     expect(establishedConnections).to.equal(0);
+    let calledCallBack = false;
+    await client.shutdown(() => {
+      calledCallBack = true;
+    });
+    expect(calledCallBack).to.be.true;
   });
-
+  /*
   it('Establishes a connection through a proxy server', async () => {
     let didRequest = false;
     let establishedConnections = 0;
     let requestsServed = 0;
     const method = HTTP2_METHOD_POST;
     const path = PATH_CHANNELS;
-    const proxyPort = TEST_PORT - 1;
+    const proxyPort = TEST_PORT - 2;
 
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
       expect(req.headers).to.deep.equal({
@@ -2546,9 +2552,9 @@ describe('ManageChannelsClient', () => {
     proxy.unref();
 
     // Client configured with a port that the server is not listening on
-    client = createClient(TEST_PORT + 1);
+    client = createClient(CLIENT_TEST_PORT);
     // So without adding a proxy config request will fail with a network error
-    // client.config.manageChannelsProxy = { host: '127.0.0.1', port: proxyPort };
+    client.config.manageChannelsProxy = { host: '127.0.0.1', port: proxyPort };
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
       const mockNotification = {
@@ -2584,10 +2590,10 @@ describe('ManageChannelsClient', () => {
     });
     proxy = null;
   });
-
+*/
   it('Throws an error when there is a bad proxy server', async () => {
     // Client configured with a port that the server is not listening on
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
     // So without adding a proxy config request will fail with a network error
     client.config.manageChannelsProxy = { host: '127.0.0.1', port: 'NOT_A_PORT' };
 

--- a/test/client.js
+++ b/test/client.js
@@ -69,7 +69,6 @@ describe('Client', () => {
   // const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
   // const PATH_CHANNELS_ALL = `/1/apps/${BUNDLE_ID}/all-channels`;
   const PATH_DEVICE = `/3/device/${MOCK_DEVICE_TOKEN}`;
-  // const PATH_BROADCAST = `/4/broadcasts/apps/${BUNDLE_ID}`;
 
   // Create an insecure http2 client for unit testing.
   // (APNS would use https://, not http://)
@@ -1215,4 +1214,556 @@ describe('Client', () => {
     //   });
     // });
   });
+});
+
+describe('ManageBroadcastClient', () => {
+  let server;
+  let client;
+  const MOCK_BODY = '{"mock-key":"mock-value"}';
+  const BUNDLE_ID = 'com.node.apn';
+  const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
+
+  // Create an insecure http2 client for unit testing.
+  // (APNS would use https://, not http://)
+  // (It's probably possible to allow accepting invalid certificates instead,
+  // but that's not the most important point of these tests)
+  const createClient = (port, timeout = 500) => {
+    const c = new Client({
+      port: TEST_PORT,
+      address: '127.0.0.1',
+    });
+    c._mockOverrideUrl = `http://127.0.0.1:${port}`;
+    c.config.port = port;
+    c.config.address = '127.0.0.1';
+    c.config.requestTimeout = timeout;
+    return c;
+  };
+  // Create an insecure server for unit testing.
+  const createAndStartMockServer = (port, cb) => {
+    server = http2.createServer((req, res) => {
+      const buffers = [];
+      req.on('data', data => buffers.push(data));
+      req.on('end', () => {
+        const requestBody = Buffer.concat(buffers).toString('utf-8');
+        cb(req, res, requestBody);
+      });
+    });
+    server.listen(port);
+    server.on('error', err => {
+      expect.fail(`unexpected error ${err}`);
+    });
+    // Don't block the tests if this server doesn't shut down properly
+    server.unref();
+    return server;
+  };
+  const createAndStartMockLowLevelServer = (port, cb) => {
+    server = http2.createServer();
+    server.on('stream', cb);
+    server.listen(port);
+    server.on('error', err => {
+      expect.fail(`unexpected error ${err}`);
+    });
+    // Don't block the tests if this server doesn't shut down properly
+    server.unref();
+    return server;
+  };
+
+  afterEach(done => {
+    const closeServer = () => {
+      if (server) {
+        server.close();
+        server = null;
+      }
+      done();
+    };
+    if (client) {
+      client.shutdown(closeServer);
+      client = null;
+    } else {
+      closeServer();
+    }
+  });
+
+  it('Treats HTTP 200 responses as successful', async () => {
+    let didRequest = false;
+    let establishedConnections = 0;
+    let requestsServed = 0;
+    const method = HTTP2_METHOD_POST;
+    const path = PATH_CHANNELS;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(req.headers).to.deep.equal({
+        ':authority': '127.0.0.1',
+        ':method': method,
+        ':path': path,
+        ':scheme': 'https',
+        'apns-someheader': 'somevalue',
+      });
+      expect(requestBody).to.equal(MOCK_BODY);
+      // res.setHeader('X-Foo', 'bar');
+      // res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.writeHead(200);
+      res.end('');
+      requestsServed += 1;
+      didRequest = true;
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runSuccessfulRequest = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      const result = await client.write(mockNotification, bundleId, 'channels', 'post');
+      expect(result).to.deep.equal({ bundleId });
+      expect(didRequest).to.be.true;
+    };
+    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
+    // Validate that when multiple valid requests arrive concurrently,
+    // only one HTTP/2 connection gets established
+    await Promise.all([
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+    ]);
+    didRequest = false;
+    await runSuccessfulRequest();
+    expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
+    expect(requestsServed).to.equal(6);
+  });
+
+  // Assert that this doesn't crash when a large batch of requests are requested simultaneously
+  it('Treats HTTP 200 responses as successful (load test for a batch of requests)', async function () {
+    this.timeout(10000);
+    let establishedConnections = 0;
+    let requestsServed = 0;
+    const method = HTTP2_METHOD_POST;
+    const path = PATH_CHANNELS;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(req.headers).to.deep.equal({
+        ':authority': '127.0.0.1',
+        ':method': method,
+        ':path': path,
+        ':scheme': 'https',
+        'apns-someheader': 'somevalue',
+      });
+      expect(requestBody).to.equal(MOCK_BODY);
+      // Set a timeout of 100 to simulate latency to a remote server.
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('');
+        requestsServed += 1;
+      }, 100);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT, 1500);
+
+    const runSuccessfulRequest = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      const result = await client.write(mockNotification, bundleId, 'channels', 'post');
+      expect(result).to.deep.equal({ bundleId });
+    };
+    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
+    // Validate that when multiple valid requests arrive concurrently,
+    // only one HTTP/2 connection gets established
+    const promises = [];
+    for (let i = 0; i < LOAD_TEST_BATCH_SIZE; i++) {
+      promises.push(runSuccessfulRequest());
+    }
+
+    await Promise.all(promises);
+    expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
+    expect(requestsServed).to.equal(LOAD_TEST_BATCH_SIZE);
+  });
+
+  // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
+  it('JSON decodes HTTP 400 responses', async () => {
+    let didRequest = false;
+    let establishedConnections = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(requestBody).to.equal(MOCK_BODY);
+      // res.setHeader('X-Foo', 'bar');
+      // res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.writeHead(400);
+      res.end('{"reason": "BadDeviceToken"}');
+      didRequest = true;
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+    const infoMessages = [];
+    const errorMessages = [];
+    const mockInfoLogger = message => {
+      infoMessages.push(message);
+    };
+    const mockErrorLogger = message => {
+      errorMessages.push(message);
+    };
+    mockInfoLogger.enabled = true;
+    mockErrorLogger.enabled = true;
+    client.setLogger(mockInfoLogger, mockErrorLogger);
+
+    const runRequestWithBadDeviceToken = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
+        bundleId,
+        response: {
+          reason: 'BadDeviceToken',
+        },
+        status: 400,
+      });
+      expect(didRequest).to.be.true;
+      didRequest = false;
+    };
+    await runRequestWithBadDeviceToken();
+    await runRequestWithBadDeviceToken();
+    expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
+    expect(infoMessages).to.deep.equal([
+      'Session connected',
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
+    ]);
+    expect(errorMessages).to.deep.equal([]);
+  });
+
+  // node-apn started closing connections in response to a bug report where HTTP 500 responses
+  // persisted until a new connection was reopened
+  it('Closes connections when HTTP 500 responses are received', async () => {
+    let establishedConnections = 0;
+    let responseDelay = 50;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      // Wait 50ms before sending the responses in parallel
+      setTimeout(() => {
+        expect(requestBody).to.equal(MOCK_BODY);
+        res.writeHead(500);
+        res.end('{"reason": "InternalServerError"}');
+      }, responseDelay);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runRequestWithInternalServerError = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.bundleId).to.equal(bundleId);
+      expect(receivedError.error).to.be.an.instanceof(VError);
+      expect(receivedError.error.message).to.have.string('stream ended unexpectedly');
+    };
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    expect(establishedConnections).to.equal(3); // should close and establish new connections on http 500
+    // Validate that nothing wrong happens when multiple HTTP 500s are received simultaneously.
+    // (no segfaults, all promises get resolved, etc.)
+    responseDelay = 50;
+    await Promise.all([
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+    ]);
+    expect(establishedConnections).to.equal(4); // should close and establish new connections on http 500
+  });
+
+  it('Handles unexpected invalid JSON responses', async () => {
+    let establishedConnections = 0;
+    const responseDelay = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      // Wait 50ms before sending the responses in parallel
+      setTimeout(() => {
+        expect(requestBody).to.equal(MOCK_BODY);
+        res.writeHead(500);
+        res.end('PC LOAD LETTER');
+      }, responseDelay);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runRequestWithInternalServerError = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      // Should not happen, but if it does, the promise should resolve with an error
+      expect(receivedError).to.exist;
+      expect(receivedError.bundleId).to.equal(bundleId);
+      expect(
+        receivedError.error.message.startsWith(
+          'Unexpected error processing APNs response: Unexpected token'
+        )
+      ).to.equal(true);
+    };
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    expect(establishedConnections).to.equal(1); // Currently reuses the connection.
+  });
+
+  it('Handles APNs timeouts', async () => {
+    let didGetRequest = false;
+    let didGetResponse = false;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      didGetRequest = true;
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('');
+        didGetResponse = true;
+      }, 1900);
+    });
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
+    await onListeningPromise;
+
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const performRequestExpectingTimeout = async () => {
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
+        bundleId,
+        error: new VError('apn write timeout'),
+      });
+      expect(didGetRequest).to.be.true;
+      expect(didGetResponse).to.be.false;
+    };
+    await performRequestExpectingTimeout();
+    didGetResponse = false;
+    didGetRequest = false;
+    // Should be able to have multiple in flight requests all get notified that the server is shutting down
+    await Promise.all([
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+    ]);
+  });
+
+  it('Handles goaway frames', async () => {
+    let didGetRequest = false;
+    let establishedConnections = 0;
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
+      const { session } = stream;
+      const errorCode = 1;
+      didGetRequest = true;
+      session.goaway(errorCode);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
+    await onListeningPromise;
+
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const performRequestExpectingGoAway = async () => {
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.bundleId).to.equal(bundleId);
+      expect(receivedError.error).to.be.an.instanceof(VError);
+      expect(didGetRequest).to.be.true;
+      didGetRequest = false;
+    };
+    await performRequestExpectingGoAway();
+    await performRequestExpectingGoAway();
+    expect(establishedConnections).to.equal(2);
+  });
+
+  it('Handles unexpected protocol errors (no response sent)', async () => {
+    let didGetRequest = false;
+    let establishedConnections = 0;
+    let responseTimeout = 0;
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
+      setTimeout(() => {
+        const { session } = stream;
+        didGetRequest = true;
+        if (session) {
+          session.destroy();
+        }
+      }, responseTimeout);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
+    await onListeningPromise;
+
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const performRequestExpectingDisconnect = async () => {
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
+        bundleId,
+        error: new VError('stream ended unexpectedly with status null and empty body'),
+      });
+      expect(didGetRequest).to.be.true;
+    };
+    await performRequestExpectingDisconnect();
+    didGetRequest = false;
+    await performRequestExpectingDisconnect();
+    didGetRequest = false;
+    expect(establishedConnections).to.equal(2);
+    responseTimeout = 10;
+    await Promise.all([
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+    ]);
+    expect(establishedConnections).to.equal(3);
+  });
+
+  it('Establishes a connection through a proxy server', async () => {
+    let didRequest = false;
+    let establishedConnections = 0;
+    let requestsServed = 0;
+    const method = HTTP2_METHOD_POST;
+    const path = PATH_CHANNELS;
+
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(req.headers).to.deep.equal({
+        ':authority': '127.0.0.1',
+        ':method': method,
+        ':path': path,
+        ':scheme': 'https',
+        'apns-someheader': 'somevalue',
+      });
+      expect(requestBody).to.equal(MOCK_BODY);
+      // res.setHeader('X-Foo', 'bar');
+      // res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.writeHead(200);
+      res.end('');
+      requestsServed += 1;
+      didRequest = true;
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.once('listening', resolve));
+
+    // Proxy forwards all connections to TEST_PORT
+    const proxy = net.createServer(clientSocket => {
+      clientSocket.once('data', () => {
+        const serverSocket = net.createConnection(TEST_PORT, () => {
+          clientSocket.write('HTTP/1.1 200 OK\r\n\r\n');
+          clientSocket.pipe(serverSocket);
+          setTimeout(() => {
+            serverSocket.pipe(clientSocket);
+          }, 1);
+        });
+      });
+      clientSocket.on('error', () => {});
+    });
+    await new Promise(resolve => proxy.listen(3128, resolve));
+
+    // Client configured with a port that the server is not listening on
+    client = createClient(TEST_PORT + 1);
+    // So without adding a proxy config request will fail with a network error
+    client.config.proxy = { host: '127.0.0.1', port: 3128 };
+    const runSuccessfulRequest = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      const result = await client.write(mockNotification, bundleId, 'channels', 'post');
+      expect(result).to.deep.equal({ bundleId });
+      expect(didRequest).to.be.true;
+    };
+    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
+    // Validate that when multiple valid requests arrive concurrently,
+    // only one HTTP/2 connection gets established
+    await Promise.all([
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+    ]);
+    didRequest = false;
+    await runSuccessfulRequest();
+    expect(establishedConnections).to.equal(1); // should establish a connection to the server and reuse it
+    expect(requestsServed).to.equal(6);
+
+    proxy.close();
+  });
+
+  describe('write', () => {});
+
+  describe('shutdown', () => {});
 });

--- a/test/client.js
+++ b/test/client.js
@@ -1216,7 +1216,7 @@ describe('Client', () => {
   });
 });
 
-describe('ManageBroadcastClient', () => {
+describe('ManageChannelsClient', () => {
   let server;
   let client;
   const MOCK_BODY = '{"mock-key":"mock-value"}';

--- a/test/client.js
+++ b/test/client.js
@@ -2500,7 +2500,7 @@ describe('ManageChannelsClient', () => {
     });
     expect(calledCallBack).to.be.true;
   });
-  /*
+
   it('Establishes a connection through a proxy server', async () => {
     let didRequest = false;
     let establishedConnections = 0;
@@ -2525,11 +2525,7 @@ describe('ManageChannelsClient', () => {
       requestsServed += 1;
       didRequest = true;
     });
-    server.on('connection', socket => {
-      establishedConnections += 1;
-      console.log('Socket remote address:', socket.remoteAddress);
-      console.log('Socket remote port:', socket.remotePort);
-    });
+    server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.once('listening', resolve));
 
     // Proxy forwards all connections to TEST_PORT
@@ -2590,7 +2586,7 @@ describe('ManageChannelsClient', () => {
     });
     proxy = null;
   });
-*/
+
   it('Throws an error when there is a bad proxy server', async () => {
     // Client configured with a port that the server is not listening on
     client = createClient(CLIENT_TEST_PORT);

--- a/test/config.js
+++ b/test/config.js
@@ -30,7 +30,7 @@ describe('config', function () {
       proxy: null,
       manageBroadcastProxy: null,
       rejectUnauthorized: true,
-      connectionRetryLimit: 10,
+      connectionRetryLimit: 2,
       heartBeat: 60000,
       requestTimeout: 5000,
     });

--- a/test/config.js
+++ b/test/config.js
@@ -25,10 +25,10 @@ describe('config', function () {
       production: false,
       address: 'api.sandbox.push.apple.com',
       port: 443,
-      manageBroadcastAddress: 'api-manage-broadcast.sandbox.push.apple.com',
-      manageBroadcastPort: 2195,
+      manageChannelsAddress: 'api-manage-broadcast.sandbox.push.apple.com',
+      manageChannelsPort: 2195,
       proxy: null,
-      manageBroadcastProxy: null,
+      manageChannelsProxy: null,
       rejectUnauthorized: true,
       connectionRetryLimit: 2,
       heartBeat: 60000,
@@ -91,7 +91,7 @@ describe('config', function () {
     });
   });
 
-  describe('manageBroadcastAddress configuration', function () {
+  describe('manageChannelsAddress configuration', function () {
     let originalEnv;
 
     before(function () {
@@ -109,58 +109,58 @@ describe('config', function () {
     it('should use api-manage-broadcast.sandbox.push.apple.com as the default connection address', function () {
       const testConfig = config();
       expect(testConfig).to.have.property(
-        'manageBroadcastAddress',
+        'manageChannelsAddress',
         'api-manage-broadcast.sandbox.push.apple.com'
       );
-      expect(testConfig).to.have.property('manageBroadcastPort', 2195);
+      expect(testConfig).to.have.property('manageChannelsPort', 2195);
     });
 
     it('should use api-manage-broadcast.push.apple.com when NODE_ENV=production', function () {
       process.env.NODE_ENV = 'production';
       const testConfig = config();
       expect(testConfig).to.have.property(
-        'manageBroadcastAddress',
+        'manageChannelsAddress',
         'api-manage-broadcast.push.apple.com'
       );
-      expect(testConfig).to.have.property('manageBroadcastPort', 2196);
+      expect(testConfig).to.have.property('manageChannelsPort', 2196);
     });
 
     it('should give precedence to production flag over NODE_ENV=production', function () {
       process.env.NODE_ENV = 'production';
       const testConfig = config({ production: false });
       expect(testConfig).to.have.property(
-        'manageBroadcastAddress',
+        'manageChannelsAddress',
         'api-manage-broadcast.sandbox.push.apple.com'
       );
-      expect(testConfig).to.have.property('manageBroadcastPort', 2195);
+      expect(testConfig).to.have.property('manageChannelsPort', 2195);
     });
 
     it('should use api-manage-broadcast.push.apple.com when production:true', function () {
       const testConfig = config({ production: true });
       expect(testConfig).to.have.property(
-        'manageBroadcastAddress',
+        'manageChannelsAddress',
         'api-manage-broadcast.push.apple.com'
       );
-      expect(testConfig).to.have.property('manageBroadcastPort', 2196);
+      expect(testConfig).to.have.property('manageChannelsPort', 2196);
     });
 
     it('should use a custom address and default port when passed', function () {
       const testAddress = 'testaddress';
       const testPort = 2195;
-      const testConfig = config({ manageBroadcastAddress: testAddress });
-      expect(testConfig).to.have.property('manageBroadcastAddress', testAddress);
-      expect(testConfig).to.have.property('manageBroadcastPort', testPort);
+      const testConfig = config({ manageChannelsAddress: testAddress });
+      expect(testConfig).to.have.property('manageChannelsAddress', testAddress);
+      expect(testConfig).to.have.property('manageChannelsPort', testPort);
     });
 
     it('should use a custom address and port when passed', function () {
       const testAddress = 'testaddress';
       const testPort = 445;
       const testConfig = config({
-        manageBroadcastAddress: testAddress,
-        manageBroadcastPort: testPort,
+        manageChannelsAddress: testAddress,
+        manageChannelsPort: testPort,
       });
-      expect(testConfig).to.have.property('manageBroadcastAddress', testAddress);
-      expect(testConfig).to.have.property('manageBroadcastPort', testPort);
+      expect(testConfig).to.have.property('manageChannelsAddress', testAddress);
+      expect(testConfig).to.have.property('manageChannelsPort', testPort);
     });
   });
 

--- a/test/config.js
+++ b/test/config.js
@@ -30,7 +30,7 @@ describe('config', function () {
       proxy: null,
       manageChannelsProxy: null,
       rejectUnauthorized: true,
-      connectionRetryLimit: 2,
+      connectionRetryLimit: 3,
       heartBeat: 60000,
       requestTimeout: 5000,
     });

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -282,8 +282,14 @@ describe('MultiClient', () => {
         body: MOCK_BODY,
       };
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.deep.equal({
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
         device,
         response: {
           reason: 'BadDeviceToken',
@@ -330,11 +336,16 @@ describe('MultiClient', () => {
         body: MOCK_BODY,
       };
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.exist;
-      expect(result.device).to.equal(device);
-      expect(result.error).to.be.an.instanceof(VError);
-      expect(result.error.message).to.have.string('stream ended unexpectedly');
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.device).to.equal(device);
+      expect(receivedError.error).to.be.an.instanceof(VError);
+      expect(receivedError.error.message).to.have.string('stream ended unexpectedly');
     };
     await runRequestWithInternalServerError();
     await runRequestWithInternalServerError();
@@ -375,11 +386,17 @@ describe('MultiClient', () => {
         body: MOCK_BODY,
       };
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
       // Should not happen, but if it does, the promise should resolve with an error
-      expect(result.device).to.equal(device);
+      expect(receivedError).to.exist;
+      expect(receivedError.device).to.equal(device);
       expect(
-        result.error.message.startsWith(
+        receivedError.error.message.startsWith(
           'Unexpected error processing APNs response: Unexpected token'
         )
       ).to.equal(true);
@@ -412,8 +429,14 @@ describe('MultiClient', () => {
     };
     const performRequestExpectingTimeout = async () => {
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.deep.equal({
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
         device,
         error: new VError('apn write timeout'),
       });
@@ -454,9 +477,15 @@ describe('MultiClient', () => {
     };
     const performRequestExpectingGoAway = async () => {
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result.device).to.equal(device);
-      expect(result.error).to.be.an.instanceof(VError);
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.device).to.equal(device);
+      expect(receivedError.error).to.be.an.instanceof(VError);
       expect(didGetRequest).to.be.true;
       didGetRequest = false;
     };
@@ -491,8 +520,14 @@ describe('MultiClient', () => {
     };
     const performRequestExpectingDisconnect = async () => {
       const device = MOCK_DEVICE_TOKEN;
-      const result = await client.write(mockNotification, device, 'device', 'post');
-      expect(result).to.deep.equal({
+      let receivedError;
+      try {
+        await client.write(mockNotification, device, 'device', 'post');
+      } catch(e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
         device,
         error: new VError('stream ended unexpectedly with status null and empty body'),
       });

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -16,6 +16,7 @@ const credentials = require('../lib/credentials')({
 });
 
 const TEST_PORT = 30939;
+const CLIENT_TEST_PORT = TEST_PORT;
 const LOAD_TEST_BATCH_SIZE = 2000;
 
 const config = require('../lib/config')({
@@ -81,11 +82,13 @@ describe('MultiClient', () => {
       address: '127.0.0.1',
       clientCount: 2,
     });
+    let count = 1;
     mc.clients.forEach(c => {
-      c._mockOverrideUrl = `http://127.0.0.1:${port}`;
+      c._mockOverrideUrl = `http://127.0.0.1:${port + count}`;
       c.config.port = port;
       c.config.address = '127.0.0.1';
       c.config.requestTimeout = timeout;
+      count += 1;
     });
     return mc;
   };
@@ -143,7 +146,7 @@ describe('MultiClient', () => {
       expect(
         () =>
           new MultiClient({
-            port: TEST_PORT,
+            port: CLIENT_TEST_PORT,
             address: '127.0.0.1',
             clientCount,
           })
@@ -176,7 +179,7 @@ describe('MultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -231,7 +234,7 @@ describe('MultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT, 1500);
+    client = createClient(CLIENT_TEST_PORT, 1500);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -271,7 +274,7 @@ describe('MultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
     const infoMessages = [];
     const errorMessages = [];
     const mockInfoLogger = message => {
@@ -336,7 +339,7 @@ describe('MultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -386,7 +389,7 @@ describe('MultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -426,7 +429,7 @@ describe('MultiClient', () => {
         didGetResponse = true;
       }, 1900);
     });
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -474,7 +477,7 @@ describe('MultiClient', () => {
       session.goaway(errorCode);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -517,7 +520,7 @@ describe('MultiClient', () => {
       }, responseTimeout);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -1180,11 +1183,13 @@ describe('ManageChannelsMultiClient', () => {
       manageChannelsPort: TEST_PORT,
       clientCount: 2,
     });
+    let count = 1;
     mc.clients.forEach(c => {
-      c._mockOverrideUrl = `http://127.0.0.1:${port}`;
-      c.config.manageChannelsPort = port;
+      c._mockOverrideUrl = `http://127.0.0.1:${port + count}`;
+      c.config.manageChannelsPort = TEST_PORT;
       c.config.manageChannelsAddress = '127.0.0.1';
       c.config.requestTimeout = timeout;
+      count += 1;
     });
     return mc;
   };
@@ -1242,7 +1247,7 @@ describe('ManageChannelsMultiClient', () => {
       expect(
         () =>
           new MultiClient({
-            port: TEST_PORT,
+            port: CLIENT_TEST_PORT,
             address: '127.0.0.1',
             clientCount,
           })
@@ -1275,7 +1280,7 @@ describe('ManageChannelsMultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -1330,7 +1335,7 @@ describe('ManageChannelsMultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT, 1500);
+    client = createClient(CLIENT_TEST_PORT, 1500);
 
     const runSuccessfulRequest = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -1370,7 +1375,7 @@ describe('ManageChannelsMultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
     const infoMessages = [];
     const errorMessages = [];
     const mockInfoLogger = message => {
@@ -1435,7 +1440,7 @@ describe('ManageChannelsMultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -1485,7 +1490,7 @@ describe('ManageChannelsMultiClient', () => {
     server.on('connection', () => (establishedConnections += 1));
     await new Promise(resolve => server.on('listening', resolve));
 
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const runRequestWithInternalServerError = async () => {
       const mockHeaders = { 'apns-someheader': 'somevalue' };
@@ -1525,7 +1530,7 @@ describe('ManageChannelsMultiClient', () => {
         didGetResponse = true;
       }, 1900);
     });
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -1573,7 +1578,7 @@ describe('ManageChannelsMultiClient', () => {
       session.goaway(errorCode);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;
@@ -1616,7 +1621,7 @@ describe('ManageChannelsMultiClient', () => {
       }, responseTimeout);
     });
     server.on('connection', () => (establishedConnections += 1));
-    client = createClient(TEST_PORT);
+    client = createClient(CLIENT_TEST_PORT);
 
     const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
     await onListeningPromise;

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -1164,7 +1164,7 @@ describe('MultiClient', () => {
   });
 });
 
-describe('ManageBroadcastMultiClient', () => {
+describe('ManageChannelsMultiClient', () => {
   let server;
   let client;
   const MOCK_BODY = '{"mock-key":"mock-value"}';
@@ -1182,14 +1182,14 @@ describe('ManageBroadcastMultiClient', () => {
   // but that's not the most important point of these tests)
   const createClient = (port, timeout = 500) => {
     const mc = new MultiClient({
-      port: TEST_PORT,
-      address: '127.0.0.1',
+      manageChannelsAddress: '127.0.0.1',
+      manageChannelsPort: TEST_PORT,
       clientCount: 2,
     });
     mc.clients.forEach(c => {
       c._mockOverrideUrl = `http://127.0.0.1:${port}`;
-      c.config.port = port;
-      c.config.address = '127.0.0.1';
+      c.config.manageChannelsPort = port;
+      c.config.manageChannelsAddress = '127.0.0.1';
       c.config.requestTimeout = timeout;
     });
     return mc;
@@ -1414,9 +1414,9 @@ describe('ManageBroadcastMultiClient', () => {
     await runRequestWithBadDeviceToken();
     expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
     expect(infoMessages).to.deep.equal([
-      'Session connected',
+      'ManageChannelsSession connected',
       'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
-      'Session connected',
+      'ManageChannelsSession connected',
       'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
     ]);
     expect(errorMessages).to.deep.equal([]);

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -4,18 +4,14 @@
 const VError = require('verror');
 const http2 = require('http2');
 
-const {
-  HTTP2_METHOD_POST,
-  // HTTP2_METHOD_GET,
-  // HTTP2_METHOD_DELETE
-} = http2.constants;
+const { HTTP2_METHOD_POST } = http2.constants;
 
 const debug = require('debug')('apn');
 const credentials = require('../lib/credentials')({
   logger: debug,
 });
 
-const TEST_PORT = 30939;
+const TEST_PORT = 30950;
 const CLIENT_TEST_PORT = TEST_PORT;
 const LOAD_TEST_BATCH_SIZE = 2000;
 

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -131,8 +131,9 @@ describe('MultiClient', () => {
       }
     };
     if (client) {
-      await client.shutdown(closeServer);
-      client = null;
+      await client.shutdown(() => {
+        client = null;
+      });
     }
     await closeServer();
   });
@@ -1229,8 +1230,9 @@ describe('ManageChannelsMultiClient', () => {
       }
     };
     if (client) {
-      await client.shutdown();
-      client = null;
+      await client.shutdown(() => {
+        client = null;
+      });
     }
     await closeServer();
   });

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -362,7 +362,7 @@ describe('MultiClient', () => {
     // Validate that nothing wrong happens when multiple HTTP 500s are received simultaneously.
     // (no segfaults, all promises get resolved, etc.)
     responseDelay = 50;
-    await Promise.all([
+    await Promise.allSettled([
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),
@@ -1460,7 +1460,7 @@ describe('ManageChannelsMultiClient', () => {
     // Validate that nothing wrong happens when multiple HTTP 500s are received simultaneously.
     // (no segfaults, all promises get resolved, etc.)
     responseDelay = 50;
-    await Promise.all([
+    await Promise.allSettled([
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),
       runRequestWithInternalServerError(),

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -285,7 +285,7 @@ describe('MultiClient', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -339,7 +339,7 @@ describe('MultiClient', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -389,7 +389,7 @@ describe('MultiClient', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       // Should not happen, but if it does, the promise should resolve with an error
@@ -432,7 +432,7 @@ describe('MultiClient', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -480,7 +480,7 @@ describe('MultiClient', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;
@@ -523,7 +523,7 @@ describe('MultiClient', () => {
       let receivedError;
       try {
         await client.write(mockNotification, device, 'device', 'post');
-      } catch(e) {
+      } catch (e) {
         receivedError = e;
       }
       expect(receivedError).to.exist;

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -122,7 +122,7 @@ describe('MultiClient', () => {
   afterEach(async () => {
     const closeServer = async () => {
       if (server) {
-        await new Promise((resolve) => {
+        await new Promise(resolve => {
           server.close(() => {
             resolve();
           });
@@ -1220,7 +1220,7 @@ describe('ManageChannelsMultiClient', () => {
   afterEach(async () => {
     const closeServer = async () => {
       if (server) {
-        await new Promise((resolve) => {
+        await new Promise(resolve => {
           server.close(() => {
             resolve();
           });

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -4,6 +4,12 @@
 const VError = require('verror');
 const http2 = require('http2');
 
+const {
+  HTTP2_METHOD_POST,
+  // HTTP2_METHOD_GET,
+  // HTTP2_METHOD_DELETE
+} = http2.constants;
+
 const debug = require('debug')('apn');
 const credentials = require('../lib/credentials')({
   logger: debug,
@@ -66,7 +72,7 @@ describe('MultiClient', () => {
   // const BUNDLE_ID = 'com.node.apn';
   // const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
   // const PATH_CHANNELS_ALL = `/1/apps/${BUNDLE_ID}/all-channels`;
-  // const PATH_DEVICE = `/3/device/${MOCK_DEVICE_TOKEN}`;
+  const PATH_DEVICE = `/3/device/${MOCK_DEVICE_TOKEN}`;
   // const PATH_BROADCAST = `/4/broadcasts/apps/${BUNDLE_ID}`;
 
   // Create an insecure http2 client for unit testing.
@@ -150,11 +156,13 @@ describe('MultiClient', () => {
     let didRequest = false;
     let establishedConnections = 0;
     let requestsServed = 0;
+    const method = HTTP2_METHOD_POST;
+    const path = PATH_DEVICE;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
       expect(req.headers).to.deep.equal({
         ':authority': '127.0.0.1',
-        ':method': 'POST',
-        ':path': `/3/device/${MOCK_DEVICE_TOKEN}`,
+        ':method': method,
+        ':path': path,
         ':scheme': 'https',
         'apns-someheader': 'somevalue',
       });
@@ -203,11 +211,13 @@ describe('MultiClient', () => {
     this.timeout(10000);
     let establishedConnections = 0;
     let requestsServed = 0;
+    const method = HTTP2_METHOD_POST;
+    const path = PATH_DEVICE;
     server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
       expect(req.headers).to.deep.equal({
         ':authority': '127.0.0.1',
-        ':method': 'POST',
-        ':path': `/3/device/${MOCK_DEVICE_TOKEN}`,
+        ':method': method,
+        ':path': path,
         ':scheme': 'https',
         'apns-someheader': 'somevalue',
       });
@@ -1152,4 +1162,502 @@ describe('MultiClient', () => {
     //   });
     // });
   });
+});
+
+describe('ManageBroadcastMultiClient', () => {
+  let server;
+  let client;
+  const MOCK_BODY = '{"mock-key":"mock-value"}';
+  // const BUNDLE_ID = 'com.node.apn';
+  // const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
+  // const PATH_CHANNELS_ALL = `/1/apps/${BUNDLE_ID}/all-channels`;
+  // const PATH_DEVICE = `/3/device/${MOCK_DEVICE_TOKEN}`;
+  // const PATH_BROADCAST = `/4/broadcasts/apps/${BUNDLE_ID}`;
+  const BUNDLE_ID = 'com.node.apn';
+  const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
+
+  // Create an insecure http2 client for unit testing.
+  // (APNS would use https://, not http://)
+  // (It's probably possible to allow accepting invalid certificates instead,
+  // but that's not the most important point of these tests)
+  const createClient = (port, timeout = 500) => {
+    const mc = new MultiClient({
+      port: TEST_PORT,
+      address: '127.0.0.1',
+      clientCount: 2,
+    });
+    mc.clients.forEach(c => {
+      c._mockOverrideUrl = `http://127.0.0.1:${port}`;
+      c.config.port = port;
+      c.config.address = '127.0.0.1';
+      c.config.requestTimeout = timeout;
+    });
+    return mc;
+  };
+  // Create an insecure server for unit testing.
+  const createAndStartMockServer = (port, cb) => {
+    server = http2.createServer((req, res) => {
+      const buffers = [];
+      req.on('data', data => buffers.push(data));
+      req.on('end', () => {
+        const requestBody = Buffer.concat(buffers).toString('utf-8');
+        cb(req, res, requestBody);
+      });
+    });
+    server.listen(port);
+    server.on('error', err => {
+      expect.fail(`unexpected error ${err}`);
+    });
+    // Don't block the tests if this server doesn't shut down properly
+    server.unref();
+    return server;
+  };
+  const createAndStartMockLowLevelServer = (port, cb) => {
+    server = http2.createServer();
+    server.on('stream', cb);
+    server.listen(port);
+    server.on('error', err => {
+      expect.fail(`unexpected error ${err}`);
+    });
+    // Don't block the tests if this server doesn't shut down properly
+    server.unref();
+    return server;
+  };
+
+  afterEach(done => {
+    const closeServer = () => {
+      if (server) {
+        server.close();
+        server = null;
+      }
+      done();
+    };
+    if (client) {
+      client.shutdown(closeServer);
+      client = null;
+    } else {
+      closeServer();
+    }
+  });
+
+  it('rejects invalid clientCount', () => {
+    [-1, 'invalid'].forEach(clientCount => {
+      expect(
+        () =>
+          new MultiClient({
+            port: TEST_PORT,
+            address: '127.0.0.1',
+            clientCount,
+          })
+      ).to.throw(`Expected positive client count but got ${clientCount}`);
+    });
+  });
+
+  it('Treats HTTP 200 responses as successful', async () => {
+    let didRequest = false;
+    let establishedConnections = 0;
+    let requestsServed = 0;
+    const method = HTTP2_METHOD_POST;
+    const path = PATH_CHANNELS;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(req.headers).to.deep.equal({
+        ':authority': '127.0.0.1',
+        ':method': method,
+        ':path': path,
+        ':scheme': 'https',
+        'apns-someheader': 'somevalue',
+      });
+      expect(requestBody).to.equal(MOCK_BODY);
+      // res.setHeader('X-Foo', 'bar');
+      // res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.writeHead(200);
+      res.end('');
+      requestsServed += 1;
+      didRequest = true;
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runSuccessfulRequest = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      const result = await client.write(mockNotification, bundleId, 'channels', 'post');
+      expect(result).to.deep.equal({ bundleId });
+      expect(didRequest).to.be.true;
+    };
+    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
+    // Validate that when multiple valid requests arrive concurrently,
+    // only one HTTP/2 connection gets established
+    await Promise.all([
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+      runSuccessfulRequest(),
+    ]);
+    didRequest = false;
+    await runSuccessfulRequest();
+    expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
+    expect(requestsServed).to.equal(6);
+  });
+
+  // Assert that this doesn't crash when a large batch of requests are requested simultaneously
+  it('Treats HTTP 200 responses as successful (load test for a batch of requests)', async function () {
+    this.timeout(10000);
+    let establishedConnections = 0;
+    let requestsServed = 0;
+    const method = HTTP2_METHOD_POST;
+    const path = PATH_CHANNELS;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(req.headers).to.deep.equal({
+        ':authority': '127.0.0.1',
+        ':method': method,
+        ':path': path,
+        ':scheme': 'https',
+        'apns-someheader': 'somevalue',
+      });
+      expect(requestBody).to.equal(MOCK_BODY);
+      // Set a timeout of 100 to simulate latency to a remote server.
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('');
+        requestsServed += 1;
+      }, 100);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT, 1500);
+
+    const runSuccessfulRequest = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      const result = await client.write(mockNotification, bundleId, 'channels', 'post');
+      expect(result).to.deep.equal({ bundleId });
+    };
+    expect(establishedConnections).to.equal(0); // should not establish a connection until it's needed
+    // Validate that when multiple valid requests arrive concurrently,
+    // only one HTTP/2 connection gets established
+    const promises = [];
+    for (let i = 0; i < LOAD_TEST_BATCH_SIZE; i++) {
+      promises.push(runSuccessfulRequest());
+    }
+
+    await Promise.all(promises);
+    expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
+    expect(requestsServed).to.equal(LOAD_TEST_BATCH_SIZE);
+  });
+
+  // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/handling_notification_responses_from_apns
+  it('JSON decodes HTTP 400 responses', async () => {
+    let didRequest = false;
+    let establishedConnections = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      expect(requestBody).to.equal(MOCK_BODY);
+      // res.setHeader('X-Foo', 'bar');
+      // res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.writeHead(400);
+      res.end('{"reason": "BadDeviceToken"}');
+      didRequest = true;
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+    const infoMessages = [];
+    const errorMessages = [];
+    const mockInfoLogger = message => {
+      infoMessages.push(message);
+    };
+    const mockErrorLogger = message => {
+      errorMessages.push(message);
+    };
+    mockInfoLogger.enabled = true;
+    mockErrorLogger.enabled = true;
+    client.setLogger(mockInfoLogger, mockErrorLogger);
+
+    const runRequestWithBadDeviceToken = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
+        bundleId,
+        response: {
+          reason: 'BadDeviceToken',
+        },
+        status: 400,
+      });
+      expect(didRequest).to.be.true;
+      didRequest = false;
+    };
+    await runRequestWithBadDeviceToken();
+    await runRequestWithBadDeviceToken();
+    expect(establishedConnections).to.equal(2); // should establish a connection to the server and reuse it
+    expect(infoMessages).to.deep.equal([
+      'Session connected',
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
+      'Session connected',
+      'Request ended with status 400 and responseData: {"reason": "BadDeviceToken"}',
+    ]);
+    expect(errorMessages).to.deep.equal([]);
+  });
+
+  // node-apn started closing connections in response to a bug report where HTTP 500 responses
+  // persisted until a new connection was reopened
+  it('Closes connections when HTTP 500 responses are received', async () => {
+    let establishedConnections = 0;
+    let responseDelay = 50;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      // Wait 50ms before sending the responses in parallel
+      setTimeout(() => {
+        expect(requestBody).to.equal(MOCK_BODY);
+        res.writeHead(500);
+        res.end('{"reason": "InternalServerError"}');
+      }, responseDelay);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runRequestWithInternalServerError = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.bundleId).to.equal(bundleId);
+      expect(receivedError.error).to.be.an.instanceof(VError);
+      expect(receivedError.error.message).to.have.string('stream ended unexpectedly');
+    };
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    expect(establishedConnections).to.equal(3); // should close and establish new connections on http 500
+    // Validate that nothing wrong happens when multiple HTTP 500s are received simultaneously.
+    // (no segfaults, all promises get resolved, etc.)
+    responseDelay = 50;
+    await Promise.all([
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+      runRequestWithInternalServerError(),
+    ]);
+    expect(establishedConnections).to.equal(5); // should close and establish new connections on http 500
+  });
+
+  it('Handles unexpected invalid JSON responses', async () => {
+    let establishedConnections = 0;
+    const responseDelay = 0;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      // Wait 50ms before sending the responses in parallel
+      setTimeout(() => {
+        expect(requestBody).to.equal(MOCK_BODY);
+        res.writeHead(500);
+        res.end('PC LOAD LETTER');
+      }, responseDelay);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    await new Promise(resolve => server.on('listening', resolve));
+
+    client = createClient(TEST_PORT);
+
+    const runRequestWithInternalServerError = async () => {
+      const mockHeaders = { 'apns-someheader': 'somevalue' };
+      const mockNotification = {
+        headers: mockHeaders,
+        body: MOCK_BODY,
+      };
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      // Should not happen, but if it does, the promise should resolve with an error
+      expect(receivedError).to.exist;
+      expect(receivedError.bundleId).to.equal(bundleId);
+      expect(
+        receivedError.error.message.startsWith(
+          'Unexpected error processing APNs response: Unexpected token'
+        )
+      ).to.equal(true);
+    };
+    await runRequestWithInternalServerError();
+    await runRequestWithInternalServerError();
+    expect(establishedConnections).to.equal(2); // Currently reuses the connections.
+  });
+
+  it('Handles APNs timeouts', async () => {
+    let didGetRequest = false;
+    let didGetResponse = false;
+    server = createAndStartMockServer(TEST_PORT, (req, res, requestBody) => {
+      didGetRequest = true;
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('');
+        didGetResponse = true;
+      }, 1900);
+    });
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
+    await onListeningPromise;
+
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const performRequestExpectingTimeout = async () => {
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
+        bundleId,
+        error: new VError('apn write timeout'),
+      });
+      expect(didGetRequest).to.be.true;
+      expect(didGetResponse).to.be.false;
+    };
+    await performRequestExpectingTimeout();
+    didGetResponse = false;
+    didGetRequest = false;
+    // Should be able to have multiple in flight requests all get notified that the server is shutting down
+    await Promise.all([
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+      performRequestExpectingTimeout(),
+    ]);
+  });
+
+  it('Handles goaway frames', async () => {
+    let didGetRequest = false;
+    let establishedConnections = 0;
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
+      const session = stream.session;
+      const errorCode = 1;
+      didGetRequest = true;
+      session.goaway(errorCode);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
+    await onListeningPromise;
+
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const performRequestExpectingGoAway = async () => {
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError.bundleId).to.equal(bundleId);
+      expect(receivedError.error).to.be.an.instanceof(VError);
+      expect(didGetRequest).to.be.true;
+      didGetRequest = false;
+    };
+    await performRequestExpectingGoAway();
+    await performRequestExpectingGoAway();
+    expect(establishedConnections).to.equal(2);
+  });
+
+  it('Handles unexpected protocol errors (no response sent)', async () => {
+    let didGetRequest = false;
+    let establishedConnections = 0;
+    let responseTimeout = 0;
+    server = createAndStartMockLowLevelServer(TEST_PORT, stream => {
+      setTimeout(() => {
+        const session = stream.session;
+        didGetRequest = true;
+        if (session) {
+          session.destroy();
+        }
+      }, responseTimeout);
+    });
+    server.on('connection', () => (establishedConnections += 1));
+    client = createClient(TEST_PORT);
+
+    const onListeningPromise = new Promise(resolve => server.on('listening', resolve));
+    await onListeningPromise;
+
+    const mockHeaders = { 'apns-someheader': 'somevalue' };
+    const mockNotification = {
+      headers: mockHeaders,
+      body: MOCK_BODY,
+    };
+    const performRequestExpectingDisconnect = async () => {
+      const bundleId = BUNDLE_ID;
+      let receivedError;
+      try {
+        await client.write(mockNotification, bundleId, 'channels', 'post');
+      } catch (e) {
+        receivedError = e;
+      }
+      expect(receivedError).to.exist;
+      expect(receivedError).to.deep.equal({
+        bundleId,
+        error: new VError('stream ended unexpectedly with status null and empty body'),
+      });
+      expect(didGetRequest).to.be.true;
+    };
+    await performRequestExpectingDisconnect();
+    didGetRequest = false;
+    await performRequestExpectingDisconnect();
+    didGetRequest = false;
+    expect(establishedConnections).to.equal(2);
+    responseTimeout = 10;
+    await Promise.all([
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+      performRequestExpectingDisconnect(),
+    ]);
+    expect(establishedConnections).to.equal(4);
+  });
+
+  describe('write', () => {});
 });

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -69,11 +69,7 @@ describe('MultiClient', () => {
   let client;
   const MOCK_BODY = '{"mock-key":"mock-value"}';
   const MOCK_DEVICE_TOKEN = 'abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123abcf0123';
-  // const BUNDLE_ID = 'com.node.apn';
-  // const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
-  // const PATH_CHANNELS_ALL = `/1/apps/${BUNDLE_ID}/all-channels`;
   const PATH_DEVICE = `/3/device/${MOCK_DEVICE_TOKEN}`;
-  // const PATH_BROADCAST = `/4/broadcasts/apps/${BUNDLE_ID}`;
 
   // Create an insecure http2 client for unit testing.
   // (APNS would use https://, not http://)
@@ -1168,11 +1164,6 @@ describe('ManageChannelsMultiClient', () => {
   let server;
   let client;
   const MOCK_BODY = '{"mock-key":"mock-value"}';
-  // const BUNDLE_ID = 'com.node.apn';
-  // const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
-  // const PATH_CHANNELS_ALL = `/1/apps/${BUNDLE_ID}/all-channels`;
-  // const PATH_DEVICE = `/3/device/${MOCK_DEVICE_TOKEN}`;
-  // const PATH_BROADCAST = `/4/broadcasts/apps/${BUNDLE_ID}`;
   const BUNDLE_ID = 'com.node.apn';
   const PATH_CHANNELS = `/1/apps/${BUNDLE_ID}/channels`;
 

--- a/test/multiclient.js
+++ b/test/multiclient.js
@@ -119,20 +119,22 @@ describe('MultiClient', () => {
     return server;
   };
 
-  afterEach(done => {
-    const closeServer = () => {
+  afterEach(async () => {
+    const closeServer = async () => {
       if (server) {
-        server.close();
+        await new Promise((resolve) => {
+          server.close(() => {
+            resolve();
+          });
+        });
         server = null;
       }
-      done();
     };
     if (client) {
-      client.shutdown(closeServer);
+      await client.shutdown(closeServer);
       client = null;
-    } else {
-      closeServer();
     }
+    await closeServer();
   });
 
   it('rejects invalid clientCount', () => {
@@ -1215,20 +1217,22 @@ describe('ManageChannelsMultiClient', () => {
     return server;
   };
 
-  afterEach(done => {
-    const closeServer = () => {
+  afterEach(async () => {
+    const closeServer = async () => {
       if (server) {
-        server.close();
+        await new Promise((resolve) => {
+          server.close(() => {
+            resolve();
+          });
+        });
         server = null;
       }
-      done();
     };
     if (client) {
-      client.shutdown(closeServer);
+      await client.shutdown();
       client = null;
-    } else {
-      closeServer();
     }
+    await closeServer();
   });
 
   it('rejects invalid clientCount', () => {

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -109,6 +109,50 @@ describe('Notification', function () {
     });
   });
 
+  describe('addPushTypeToPayloadIfNeeded', function () {
+    it('add liveactivity push-type to payload when it is missing', function () {
+      note.addPushTypeToPayloadIfNeeded();
+
+      expect(note.payload).to.deep.equal({ 'push-type': 'liveactivity' });
+    });
+
+    it('do not overwrite push-type if it is already present', function () {
+      note.payload['push-type'] = 'alert';
+      note.addPushTypeToPayloadIfNeeded();
+
+      expect(note.payload).to.deep.equal({ 'push-type': 'alert' });
+    });
+
+    it('do not add push-type if rawPayload is present', function () {
+      const payload = { some: 'payload' };
+      note = new Notification({ rawPayload: payload });
+      note.addPushTypeToPayloadIfNeeded();
+
+      expect(note.rawPayload).to.deep.equal({ some: 'payload' });
+      expect(compiledOutput()).to.deep.equal({ some: 'payload' });
+    });
+  });
+
+  describe('removeNonChannelRelatedProperties', function () {
+    it('headers only contains channel related properties', function () {
+      note.priority = 5;
+      note.id = '123e4567-e89b-12d3-a456-42665544000';
+      note.pushType = 'alert';
+      note.expiry = 1000;
+      note.topic = 'io.apn.node';
+      note.collapseId = 'io.apn.collapse';
+      note.requestId = 'io.apn.request';
+      note.channelId = 'io.apn.channel';
+      note.pushType = 'liveactivity';
+      note.removeNonChannelRelatedProperties();
+
+      expect(note.headers()).to.deep.equal({
+        'apns-channel-id': 'io.apn.channel',
+        'apns-request-id': 'io.apn.request',
+      });
+    });
+  });
+
   describe('headers', function () {
     it('contains no properties by default', function () {
       expect(note.headers()).to.deep.equal({});

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -148,6 +148,7 @@ describe('Notification', function () {
 
       expect(note.headers()).to.deep.equal({
         'apns-channel-id': 'io.apn.channel',
+        'apns-expiration': 1000,
         'apns-request-id': 'io.apn.request',
       });
     });

--- a/test/provider.js
+++ b/test/provider.js
@@ -102,6 +102,24 @@ describe('Provider', function () {
             failed: [{ device: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } }],
           });
         });
+
+        it('rejects with the device token, status code and response in the failed array', async () => {
+          const provider = new Provider({ address: 'testapi' });
+
+          fakes.client.write.onCall(0).returns(
+            Promise.reject({
+              device: 'abcd1234',
+              status: '400',
+              response: { reason: 'BadDeviceToken' },
+            })
+          );
+          const result = await provider.send(notificationDouble(), 'abcd1234');
+
+          expect(result).to.deep.equal({
+            sent: [],
+            failed: [{ device: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } }],
+          });
+        });
       });
     });
 
@@ -162,6 +180,436 @@ describe('Provider', function () {
     });
   });
 
+  describe('broadcast', async () => {
+    describe('single notification behaviour', async () => {
+      let provider;
+
+      context('transmission succeeds', async () => {
+        beforeEach(async () => {
+          provider = new Provider({ address: 'testapi' });
+
+          fakes.client.write.onCall(0).returns(Promise.resolve({ bundleId: 'abcd1234' }));
+        });
+
+        it('invokes the writer with correct `this`', async () => {
+          await provider.broadcast(notificationDouble(), 'abcd1234');
+          expect(fakes.client.write).to.be.calledOn(fakes.client);
+        });
+
+        it('writes the notification to the client once', async () => {
+          await provider.broadcast(notificationDouble(), 'abcd1234');
+
+          const notification = notificationDouble();
+          const builtNotification = {
+            headers: notification.headers(),
+            body: notification.compile(),
+          };
+          const bundleId = 'abcd1234';
+          expect(fakes.client.write).to.be.calledOnce;
+          expect(fakes.client.write).to.be.calledWith(
+            builtNotification,
+            bundleId,
+            'broadcasts',
+            'post'
+          );
+        });
+
+        it('does not pass the array index to writer', async () => {
+          await provider.broadcast(notificationDouble(), 'abcd1234');
+          expect(fakes.client.write.firstCall.args[4]).to.be.undefined;
+        });
+
+        it('resolves with the bundleId in the sent array', async () => {
+          const result = await provider.broadcast(notificationDouble(), 'abcd1234');
+          expect(result).to.deep.equal({
+            sent: [{ bundleId: 'abcd1234' }],
+            failed: [],
+          });
+        });
+      });
+
+      context('error occurs', async () => {
+        it('resolves with the bundleId, status code and response in the failed array', async () => {
+          const provider = new Provider({ address: 'testapi' });
+
+          fakes.client.write.onCall(0).returns(
+            Promise.resolve({
+              bundleId: 'abcd1234',
+              status: '400',
+              response: { reason: 'BadDeviceToken' },
+            })
+          );
+          const result = await provider.broadcast(notificationDouble(), 'abcd1234');
+
+          expect(result).to.deep.equal({
+            sent: [],
+            failed: [
+              { bundleId: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } },
+            ],
+          });
+        });
+
+        it('rejects with the bundleId, status code and response in the failed array', async () => {
+          const provider = new Provider({ address: 'testapi' });
+
+          fakes.client.write.onCall(0).returns(
+            Promise.reject({
+              bundleId: 'abcd1234',
+              status: '400',
+              response: { reason: 'BadDeviceToken' },
+            })
+          );
+          const result = await provider.broadcast(notificationDouble(), 'abcd1234');
+
+          expect(result).to.deep.equal({
+            sent: [],
+            failed: [
+              { bundleId: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } },
+            ],
+          });
+        });
+      });
+    });
+
+    context('when multiple notifications are passed', async () => {
+      beforeEach(async () => {
+        fakes.resolutions = [
+          { bundleId: 'test123', 'apns-channel-id': 'abcd1234' },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'adfe5969',
+            status: '400',
+            response: { reason: 'MissingTopic' },
+          },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'abcd1335',
+            status: '410',
+            response: { reason: 'BadDeviceToken', timestamp: 123456789 },
+          },
+          { bundleId: 'test123', 'apns-channel-id': 'bcfe4433' },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'aabbc788',
+            status: '413',
+            response: { reason: 'PayloadTooLarge' },
+          },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'fbcde238',
+            error: new Error('connection failed'),
+          },
+        ];
+      });
+
+      context('streams are always returned', async () => {
+        let response;
+
+        beforeEach(async () => {
+          const provider = new Provider({ address: 'testapi' });
+
+          for (let i = 0; i < fakes.resolutions.length; i++) {
+            fakes.client.write.onCall(i).returns(Promise.resolve(fakes.resolutions[i]));
+          }
+
+          response = await provider.broadcast(
+            fakes.resolutions.map(res => notificationDouble(res['apns-channel-id'])),
+            'test123'
+          );
+        });
+
+        it('resolves with the sent notifications', async () => {
+          expect(response.sent).to.deep.equal([
+            { bundleId: 'test123', 'apns-channel-id': 'abcd1234' },
+            { bundleId: 'test123', 'apns-channel-id': 'bcfe4433' },
+          ]);
+        });
+
+        it('resolves with the bundleId, status code and response or error of the unsent notifications', async () => {
+          expect(response.failed[3].error).to.be.an.instanceof(Error);
+          response.failed[3].error = { message: response.failed[3].error.message };
+          expect(response.failed).to.deep.equal(
+            [
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'adfe5969',
+                status: '400',
+                response: { reason: 'MissingTopic' },
+              },
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'abcd1335',
+                status: '410',
+                response: { reason: 'BadDeviceToken', timestamp: 123456789 },
+              },
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'aabbc788',
+                status: '413',
+                response: { reason: 'PayloadTooLarge' },
+              },
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'fbcde238',
+                error: { message: 'connection failed' },
+              },
+            ],
+            `Unexpected result: ${JSON.stringify(response.failed)}`
+          );
+        });
+      });
+    });
+  });
+
+  describe('manageChannels', async () => {
+    describe('single notification behaviour', async () => {
+      let provider;
+
+      context('transmission succeeds', async () => {
+        beforeEach(async () => {
+          provider = new Provider({ address: 'testapi' });
+
+          fakes.client.write.onCall(0).returns(Promise.resolve({ bundleId: 'abcd1234' }));
+        });
+
+        it('invokes the writer with correct `this`', async () => {
+          await provider.manageChannels(notificationDouble(), 'abcd1234', 'create');
+          expect(fakes.client.write).to.be.calledOn(fakes.client);
+        });
+
+        it('writes the notification to the client once using create', async () => {
+          await provider.manageChannels(notificationDouble(), 'abcd1234', 'create');
+
+          const notification = notificationDouble();
+          const builtNotification = {
+            headers: notification.headers(),
+            body: notification.compile(),
+          };
+          const bundleId = 'abcd1234';
+          expect(fakes.client.write).to.be.calledOnce;
+          expect(fakes.client.write).to.be.calledWith(
+            builtNotification,
+            bundleId,
+            'channels',
+            'post'
+          );
+        });
+
+        it('writes the notification to the client once using read', async () => {
+          await provider.manageChannels(notificationDouble(), 'abcd1234', 'read');
+
+          const notification = notificationDouble();
+          const builtNotification = {
+            headers: notification.headers(),
+            body: notification.compile(),
+          };
+          const bundleId = 'abcd1234';
+          expect(fakes.client.write).to.be.calledOnce;
+          expect(fakes.client.write).to.be.calledWith(
+            builtNotification,
+            bundleId,
+            'channels',
+            'get'
+          );
+        });
+
+        it('writes the notification to the client once using readAll', async () => {
+          await provider.manageChannels(notificationDouble(), 'abcd1234', 'readAll');
+
+          const notification = notificationDouble();
+          const builtNotification = {
+            headers: notification.headers(),
+            body: notification.compile(),
+          };
+          const bundleId = 'abcd1234';
+          expect(fakes.client.write).to.be.calledOnce;
+          expect(fakes.client.write).to.be.calledWith(
+            builtNotification,
+            bundleId,
+            'allChannels',
+            'get'
+          );
+        });
+
+        it('writes the notification to the client once using delete', async () => {
+          await provider.manageChannels(notificationDouble(), 'abcd1234', 'delete');
+
+          const notification = notificationDouble();
+          const builtNotification = {
+            headers: notification.headers(),
+            body: notification.compile(),
+          };
+          const bundleId = 'abcd1234';
+          expect(fakes.client.write).to.be.calledOnce;
+          expect(fakes.client.write).to.be.calledWith(
+            builtNotification,
+            bundleId,
+            'channels',
+            'delete'
+          );
+        });
+
+        it('does not pass the array index to writer', async () => {
+          await provider.manageChannels(notificationDouble(), 'abcd1234', 'create');
+          expect(fakes.client.write.firstCall.args[5]).to.be.undefined;
+        });
+
+        it('resolves with the bundleId in the sent array', async () => {
+          const result = await provider.manageChannels(notificationDouble(), 'abcd1234', 'create');
+          expect(result).to.deep.equal({
+            sent: [{ bundleId: 'abcd1234' }],
+            failed: [],
+          });
+        });
+      });
+
+      context('error occurs', async () => {
+        it('throws error when unknown action is passed', async () => {
+          const provider = new Provider({ address: 'testapi' });
+          let receivedError;
+          try {
+            await provider.manageChannels(notificationDouble(), 'abcd1234', 'hello');
+          } catch (e) {
+            receivedError = e;
+          }
+          expect(receivedError).to.exist;
+          expect(receivedError.bundleId).to.equal('abcd1234');
+          expect(receivedError.error.message.startsWith('the action "hello"')).to.equal(true);
+        });
+
+        it('resolves with the bundleId, status code and response in the failed array', async () => {
+          const provider = new Provider({ address: 'testapi' });
+
+          fakes.client.write.onCall(0).returns(
+            Promise.resolve({
+              bundleId: 'abcd1234',
+              status: '400',
+              response: { reason: 'BadDeviceToken' },
+            })
+          );
+          const result = await provider.manageChannels(notificationDouble(), 'abcd1234', 'create');
+
+          expect(result).to.deep.equal({
+            sent: [],
+            failed: [
+              { bundleId: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } },
+            ],
+          });
+        });
+
+        it('rejects with the bundleId, status code and response in the failed array', async () => {
+          const provider = new Provider({ address: 'testapi' });
+
+          fakes.client.write.onCall(0).returns(
+            Promise.reject({
+              bundleId: 'abcd1234',
+              status: '400',
+              response: { reason: 'BadDeviceToken' },
+            })
+          );
+          const result = await provider.manageChannels(notificationDouble(), 'abcd1234', 'create');
+
+          expect(result).to.deep.equal({
+            sent: [],
+            failed: [
+              { bundleId: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } },
+            ],
+          });
+        });
+      });
+    });
+
+    context('when multiple notifications are passed', async () => {
+      beforeEach(async () => {
+        fakes.resolutions = [
+          { bundleId: 'test123', 'apns-channel-id': 'abcd1234' },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'adfe5969',
+            status: '400',
+            response: { reason: 'MissingTopic' },
+          },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'abcd1335',
+            status: '410',
+            response: { reason: 'BadDeviceToken', timestamp: 123456789 },
+          },
+          { bundleId: 'test123', 'apns-channel-id': 'bcfe4433' },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'aabbc788',
+            status: '413',
+            response: { reason: 'PayloadTooLarge' },
+          },
+          {
+            bundleId: 'test123',
+            'apns-channel-id': 'fbcde238',
+            error: new Error('connection failed'),
+          },
+        ];
+      });
+
+      context('streams are always returned', async () => {
+        let response;
+
+        beforeEach(async () => {
+          const provider = new Provider({ address: 'testapi' });
+
+          for (let i = 0; i < fakes.resolutions.length; i++) {
+            fakes.client.write.onCall(i).returns(Promise.resolve(fakes.resolutions[i]));
+          }
+
+          response = await provider.manageChannels(
+            fakes.resolutions.map(res => notificationDouble(res['apns-channel-id'])),
+            'test123',
+            'create'
+          );
+        });
+
+        it('resolves with the sent notifications', async () => {
+          expect(response.sent).to.deep.equal([
+            { bundleId: 'test123', 'apns-channel-id': 'abcd1234' },
+            { bundleId: 'test123', 'apns-channel-id': 'bcfe4433' },
+          ]);
+        });
+
+        it('resolves with the bundleId, status code and response or error of the unsent notifications', async () => {
+          expect(response.failed[3].error).to.be.an.instanceof(Error);
+          response.failed[3].error = { message: response.failed[3].error.message };
+          expect(response.failed).to.deep.equal(
+            [
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'adfe5969',
+                status: '400',
+                response: { reason: 'MissingTopic' },
+              },
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'abcd1335',
+                status: '410',
+                response: { reason: 'BadDeviceToken', timestamp: 123456789 },
+              },
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'aabbc788',
+                status: '413',
+                response: { reason: 'PayloadTooLarge' },
+              },
+              {
+                bundleId: 'test123',
+                'apns-channel-id': 'fbcde238',
+                error: { message: 'connection failed' },
+              },
+            ],
+            `Unexpected result: ${JSON.stringify(response.failed)}`
+          );
+        });
+      });
+    });
+  });
+
   describe('shutdown', function () {
     it('invokes shutdown on the client', async () => {
       const callback = sinon.spy();
@@ -173,10 +621,12 @@ describe('Provider', function () {
   });
 });
 
-function notificationDouble() {
+function notificationDouble(pushType = undefined) {
   return {
-    headers: sinon.stub().returns({}),
+    headers: sinon.stub().returns({ pushType: pushType }),
     payload: { aps: { badge: 1 } },
+    removeNonChannelRelatedProperties: sinon.stub(),
+    addPushTypeToPayloadIfNeeded: sinon.stub(),
     compile: function () {
       return JSON.stringify(this.payload);
     },

--- a/test/provider.js
+++ b/test/provider.js
@@ -54,13 +54,12 @@ describe('Provider', function () {
 
         it('invokes the writer with correct `this`', async () => {
           await provider.send(notificationDouble(), 'abcd1234');
-          
           expect(fakes.client.write).to.be.calledOn(fakes.client);
         });
 
         it('writes the notification to the client once', async () => {
           await provider.send(notificationDouble(), 'abcd1234');
-          
+
           const notification = notificationDouble();
           const builtNotification = {
             headers: notification.headers(),
@@ -68,23 +67,16 @@ describe('Provider', function () {
           };
           const device = 'abcd1234';
           expect(fakes.client.write).to.be.calledOnce;
-          expect(fakes.client.write).to.be.calledWith(
-            builtNotification,
-            device,
-            'device',
-            'post'
-          );
+          expect(fakes.client.write).to.be.calledWith(builtNotification, device, 'device', 'post');
         });
 
         it('does not pass the array index to writer', async () => {
           await provider.send(notificationDouble(), 'abcd1234');
-          
           expect(fakes.client.write.firstCall.args[4]).to.be.undefined;
         });
 
         it('resolves with the device token in the sent array', async () => {
           const result = await provider.send(notificationDouble(), 'abcd1234');
-          
           expect(result).to.deep.equal({
             sent: [{ device: 'abcd1234' }],
             failed: [],
@@ -93,7 +85,6 @@ describe('Provider', function () {
       });
 
       context('error occurs', async () => {
-
         it('resolves with the device token, status code and response in the failed array', async () => {
           const provider = new Provider({ address: 'testapi' });
 
@@ -105,7 +96,7 @@ describe('Provider', function () {
             })
           );
           const result = await provider.send(notificationDouble(), 'abcd1234');
-  
+
           expect(result).to.deep.equal({
             sent: [],
             failed: [{ device: 'abcd1234', status: '400', response: { reason: 'BadDeviceToken' } }],
@@ -152,20 +143,20 @@ describe('Provider', function () {
 
         it('resolves with the device token, status code and response or error of the unsent notifications', async () => {
           expect(response.failed[3].error).to.be.an.instanceof(Error);
-            response.failed[3].error = { message: response.failed[3].error.message };
-            expect(response.failed).to.deep.equal(
-              [
-                { device: 'adfe5969', status: '400', response: { reason: 'MissingTopic' } },
-                {
-                  device: 'abcd1335',
-                  status: '410',
-                  response: { reason: 'BadDeviceToken', timestamp: 123456789 },
-                },
-                { device: 'aabbc788', status: '413', response: { reason: 'PayloadTooLarge' } },
-                { device: 'fbcde238', error: { message: 'connection failed' } },
-              ],
-              `Unexpected result: ${JSON.stringify(response.failed)}`
-            );
+          response.failed[3].error = { message: response.failed[3].error.message };
+          expect(response.failed).to.deep.equal(
+            [
+              { device: 'adfe5969', status: '400', response: { reason: 'MissingTopic' } },
+              {
+                device: 'abcd1335',
+                status: '410',
+                response: { reason: 'BadDeviceToken', timestamp: 123456789 },
+              },
+              { device: 'aabbc788', status: '413', response: { reason: 'PayloadTooLarge' } },
+              { device: 'fbcde238', error: { message: 'connection failed' } },
+            ],
+            `Unexpected result: ${JSON.stringify(response.failed)}`
+          );
         });
       });
     });

--- a/test/proxy.js
+++ b/test/proxy.js
@@ -1,0 +1,25 @@
+const VError = require('verror');
+const createProxySocket = require('../lib/util/proxy');
+
+describe('Proxy Server', async () => {
+  it('can throw errors', async () => {
+    let receivedError;
+    try {
+      await createProxySocket(
+        {
+          host: '127.0.0.1',
+          port: 3311,
+        },
+        {
+          host: '127.0.0.1',
+          port: 'NOT_A_PORT',
+        }
+      );
+    } catch (e) {
+      receivedError = e;
+    }
+    expect(receivedError).to.exist;
+    expect(receivedError.error).to.be.an.instanceof(VError);
+    expect(receivedError.error.message).to.have.string('cannot connect to proxy server');
+  });
+});


### PR DESCRIPTION
## Issue
Continuation of #163 which allowed the additional properties needed for broadcast notifications, but doesn't modify the Client API to `GET`, `POST`, `DELETE` to the respective Apple paths.

Closes: #162
Closes: #146
Closes: #111
Closes: #116

## Approach

Follow the documentation related to [channel management](https://developer.apple.com/documentation/usernotifications/sending-channel-management-requests-to-apns) and [broadcasting](https://developer.apple.com/documentation/usernotifications/sending-broadcast-push-notification-requests-to-apns). This enables the functionality described in Apple's WWDC 2024 videos: [Broadcast Updates to Your Live Activities](https://www.google.com/url?sa=t&source=web&rct=j&opi=89978449&url=https://developer.apple.com/videos/play/wwdc2024/10069/&ved=2ahUKEwjT-9HqgNiKAxWyIkQIHT4JNRgQwqsBegQIDBAE&usg=AOvVaw1FaRFsTvrlAD8-asqho7a_).

The newly added API methods to `node-apn` will have the following footprint (TypeScript):

```ts
export class Provider extends EventEmitter {
  /**
   * Manage channels using a specific action.
   *
   * @param notifications - A Notification or an Array of Notifications to send. Each notification should specify the respective channelId it's directed to.
   * @param bundleId - The bundleId for your application.
   * @param action - Specifies the action to perform on the channel(s).
   */
  manageChannels(notifications: Notification|Notification[], bundleId: string, action: ChannelAction): Promise<Responses<BroadcastResponse,BroadcastResponseFailure>>;

  /**
   * Broadcast notificaitons to channel(s).
   *
   * @param notifications - A Notification or an Array of Notifications to send. Each notification should specify the respective channelId it's directed to.
   * @param bundleId: The bundleId for your application.
   */
  broadcast(notifications: Notification|Notification[], bundleId: string): Promise<Responses<BroadcastResponse,BroadcastResponseFailure>>;
}

export type ChannelAction = 'create' | 'read' | 'readAll' | 'delete';

export interface ResponseSent {
  device: string;
}

export interface BroadcastResponse {
  bundleId: string;
  "apns-request-id"?: string;
  "apns-channel-id"?: string;
  "message-storage-policy"?: number;
  "push-type"?: string;
  "channels"?: string[];
}

export interface LoggerResponse extends Partial<ResponseSent>, Partial<BroadcastResponse> {}

export interface ResponseFailure {
  device: string;
  error?: Error;
  status?: number;
  response?: {
    reason: string;
    timestamp?: string;
  };
}

export interface BroadcastResponseFailure extends Omit<ResponseFailure, "device"> {
  bundleId: string;
}

export interface LoggerResponseFailure extends Partial<ResponseFailure>, Partial<BroadcastResponseFailure> {}

export interface Responses<R,F> {
  sent: R[];
  failed: F[];
}
```

### Non-Breaking Changes
All changes are non-breaking as they are made to the client API, which isn't exposed to developers, and new methods that previously weren't available are added. The typescript changes are improvements but are non-breaking as well.

Additionally, the PR does the following:
- [x] Updates the majority of code to async/await and error throwing, leaving native promises where necessary
- [x] Modernize code and update TS to match latest code
- [x] Improve unit tests to capture networking errors better
- [x] Document new API's  