### PR TITLE
fix: Incorrectly attempting to send body in `GET`, `DELETE` requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,8 @@ jobs:
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/lib/client.js
+++ b/lib/client.js
@@ -567,7 +567,7 @@ module.exports = function (dependencies) {
       responseData += data;
     });
 
-    if (Object.keys(notification.body).length > 0) {
+    if (notification.body !== "") {
       request.write(notification.body);
     }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -567,7 +567,7 @@ module.exports = function (dependencies) {
       responseData += data;
     });
 
-    if (notification.body !== "") {
+    if (notification.body !== '{}') {
       request.write(notification.body);
     }
 

--- a/test/client.js
+++ b/test/client.js
@@ -1761,7 +1761,7 @@ describe('ManageChannelsClient', () => {
       const mockHeaders = { 'apns-channel-id': channel, ...additionalHeaderInfo };
       const mockNotification = {
         headers: mockHeaders,
-        body: {},
+        body: "",
       };
       const bundleId = BUNDLE_ID;
       const result = await client.write(mockNotification, bundleId, 'channels', 'delete');
@@ -1822,7 +1822,7 @@ describe('ManageChannelsClient', () => {
       const mockHeaders = { 'apns-request-id': requestId };
       const mockNotification = {
         headers: mockHeaders,
-        body: {},
+        body: "",
       };
       const bundleId = BUNDLE_ID;
       const result = await client.write(mockNotification, bundleId, 'allChannels', 'get');

--- a/test/client.js
+++ b/test/client.js
@@ -1761,7 +1761,7 @@ describe('ManageChannelsClient', () => {
       const mockHeaders = { 'apns-channel-id': channel, ...additionalHeaderInfo };
       const mockNotification = {
         headers: mockHeaders,
-        body: "",
+        body: '{}',
       };
       const bundleId = BUNDLE_ID;
       const result = await client.write(mockNotification, bundleId, 'channels', 'delete');
@@ -1822,7 +1822,7 @@ describe('ManageChannelsClient', () => {
       const mockHeaders = { 'apns-request-id': requestId };
       const mockNotification = {
         headers: mockHeaders,
-        body: "",
+        body: '{}',
       };
       const bundleId = BUNDLE_ID;
       const result = await client.write(mockNotification, bundleId, 'allChannels', 'get');

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -17,6 +17,11 @@ describe('Notification', function () {
       expect(note.topic).to.equal('io.apn.node');
       expect(compiledOutput()).to.have.nested.deep.property('aps.badge', 5);
     });
+
+    it('no initialization values', function () {
+      expect(note.compile()).to.equal('{}');
+      expect(compiledOutput()).to.be.empty;
+    });
   });
 
   describe('rawPayload', function () {


### PR DESCRIPTION
PR #164 introduced the ability to `GET` and `DELETE` to add functionality for channel management. Previously, the API could only `POST`, which always required a `body` to be sent. In cases of `GET` and `DELETE`, a body shouldn't be sent. #164 attempts to only send a body when necessary but incorrectly assumes the body is an `Object` when it is always a JSON string.

This checks against an empty JSON string and adds a test to verify the body is a JSON string and not an `Object`.

Closes: #168 