### PR TITLE
fix: Does not allow sending the priority of 10 for notifications

### DIFF
--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -68,7 +68,7 @@ Notification.prototype = require('./apsProperties');
 Notification.prototype.headers = function headers() {
   const headers = {};
 
-  if (this.priority !== 10) {
+  if (Number.isInteger(this.priority)) {
     headers['apns-priority'] = this.priority;
   }
 

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -154,14 +154,15 @@ describe('Notification', function () {
       expect(note.headers()).to.deep.equal({
         'apns-channel-id': 'io.apn.channel',
         'apns-expiration': 1000,
+        "apns-priority": 10,
         'apns-request-id': 'io.apn.request',
       });
     });
   });
 
   describe('headers', function () {
-    it('contains no properties by default', function () {
-      expect(note.headers()).to.deep.equal({});
+    it('contains only thr priority property by default', function () {
+      expect(note.headers()).to.deep.equal({ "apns-priority": 10 });
     });
 
     context('priority is non-default', function () {

--- a/test/notification/index.js
+++ b/test/notification/index.js
@@ -161,7 +161,7 @@ describe('Notification', function () {
   });
 
   describe('headers', function () {
-    it('contains only thr priority property by default', function () {
+    it('contains only the priority property by default', function () {
       expect(note.headers()).to.deep.equal({ "apns-priority": 10 });
     });
 


### PR DESCRIPTION
Allows the priority of `10` to be sent to the APN server. Previously, the library didn't omit the value of `10` because the APN server uses this value as default. For broadcast messages, this may not be the case, so the change sends the value regardless.

The original default behavior from a developer using the library is still the same. Basically, if the dev doesn't specify a priority, the default is still `10`.

Closes: #172