### PR TITLE
feat: Add `input-push-channel` and `input-push-token` to APS

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -133,6 +133,8 @@ interface Aps {
   timestamp?: number
   event?: string
   "dismissal-date"?: number
+  "input-push-channel": string
+  "input-push-token": number
   "attributes-type"?: string
   attributes?: Object
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -133,8 +133,8 @@ interface Aps {
   timestamp?: number
   event?: string
   "dismissal-date"?: number
-  "input-push-channel": string
-  "input-push-token": number
+  "input-push-channel"?: string
+  "input-push-token"?: number
   "attributes-type"?: string
   attributes?: Object
 }

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -179,6 +179,30 @@ module.exports = {
     }
   },
 
+  set filterCriteria(value) {
+    if (typeof value === 'string' || value === undefined) {
+      this.aps['filter-criteria'] = value;
+    }
+  },
+
+  set inputPushChannel(value) {
+    if (typeof value === 'string' || value === undefined) {
+      this.aps['input-push-channel'] = value;
+    }
+  },
+
+  set inputPushToken(value) {
+    if (typeof value === 'number' || value === undefined) {
+      this.aps['input-push-token'] = value;
+    }
+  },
+
+  set attributesType(value) {
+    if (typeof value === 'string' || value === undefined) {
+      this.aps['attributes-type'] = value;
+    }
+  },
+
   prepareAlert: function () {
     if (typeof this.aps.alert !== 'object') {
       this.aps.alert = { body: this.aps.alert };

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -203,6 +203,12 @@ module.exports = {
     }
   },
 
+  set attributes(value) {
+    if (typeof value === 'object' || value === undefined) {
+      this.aps['attributes'] = value;
+    }
+  },
+
   prepareAlert: function () {
     if (typeof this.aps.alert !== 'object') {
       this.aps.alert = { body: this.aps.alert };

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -57,6 +57,10 @@ Notification.prototype = require('./apsProperties');
   'event',
   'contentState',
   'dismissalDate',
+  'filterCriteria',
+  'inputPushChannel',
+  'inputPushToken',
+  'attributesType',
 ].forEach(propName => {
   const methodName = 'set' + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -61,6 +61,7 @@ Notification.prototype = require('./apsProperties');
   'inputPushChannel',
   'inputPushToken',
   'attributesType',
+  'attributes',
 ].forEach(propName => {
   const methodName = 'set' + propName[0].toUpperCase() + propName.slice(1);
   Notification.prototype[methodName] = function (value) {

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -1099,6 +1099,38 @@ describe('Notification', function () {
       });
     });
 
+    describe('input-push-channel', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.input-push-channel');
+      });
+
+      it('can be set to a string', function () {
+        note.inputPushChannel = 'the-input-push-channel';
+
+        expect(compiledOutput()).to.have.nested.property(
+          'aps.input-push-channel',
+          'the-input-push-channel'
+        );
+      });
+
+      it('can be set to undefined', function () {
+        note.inputPushChannel = 'input-push-channel';
+        note.inputPushChannel = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property('aps.input-push-channel');
+      });
+
+      describe('setInputPushChannel', function () {
+        it('is chainable', function () {
+          expect(note.setInputPushChannel('the-input-push-channel')).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property(
+            'aps.input-push-channel',
+            'the-input-push-channel'
+          );
+        });
+      });
+    });
+
     describe('input-push-token', function () {
       it('defaults to undefined', function () {
         expect(compiledOutput()).to.not.have.nested.property('aps.input-push-token');
@@ -1119,7 +1151,7 @@ describe('Notification', function () {
 
       describe('setInputPushToken', function () {
         it('is chainable', function () {
-          expect(note.setDismissalDate(1)).to.equal(note);
+          expect(note.setInputPushToken(1)).to.equal(note);
           expect(compiledOutput()).to.have.nested.property('aps.input-push-token', 1);
         });
       });
@@ -1134,8 +1166,8 @@ describe('Notification', function () {
         note.filterCriteria = 'the-filter-criteria';
 
         expect(compiledOutput()).to.have.nested.property(
-          'aps.interruption-level',
-          'the-interruption-level'
+          'aps.filter-criteria',
+          'the-filter-criteria'
         );
       });
 
@@ -1146,12 +1178,44 @@ describe('Notification', function () {
         expect(compiledOutput()).to.not.have.nested.property('aps.filter-criteria');
       });
 
-      describe('setfilterCriteria', function () {
+      describe('setFilterCriteria', function () {
         it('is chainable', function () {
-          expect(note.setß('the-filter-criteria')).to.equal(note);
+          expect(note.setFilterCriteria('the-filter-criteria')).to.equal(note);
           expect(compiledOutput()).to.have.nested.property(
             'aps.filter-criteria',
             'the-filter-criteria'
+          );
+        });
+      });
+    });
+
+    describe('attributes-type', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.attributes-type');
+      });
+
+      it('can be set to a string', function () {
+        note.attributesType = 'the-attributes-type';
+
+        expect(compiledOutput()).to.have.nested.property(
+          'aps.attributes-type',
+          'the-attributes-type'
+        );
+      });
+
+      it('can be set to undefined', function () {
+        note.attributesType = 'attributes-type';
+        note.attributesType = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property('aps.attributes-type');
+      });
+
+      describe('setAttributesType', function () {
+        it('is chainable', function () {
+          expect(note.setAttributesType('the-attributes-type')).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property(
+            'aps.attributes-type',
+            'the-attributes-type'
           );
         });
       });

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -1099,6 +1099,64 @@ describe('Notification', function () {
       });
     });
 
+    describe('input-push-token', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.input-push-token');
+      });
+
+      it('can be set to a number', function () {
+        note.inputPushToken = 1;
+
+        expect(compiledOutput()).to.have.nested.property('aps.input-push-token', 1);
+      });
+
+      it('can be set to undefined', function () {
+        note.inputPushToken = 1;
+        note.inputPushToken = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property('aps.input-push-token');
+      });
+
+      describe('setInputPushToken', function () {
+        it('is chainable', function () {
+          expect(note.setDismissalDate(1)).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property('aps.input-push-token', 1);
+        });
+      });
+    });
+
+    describe('filter-criteria', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.filter-criteria');
+      });
+
+      it('can be set to a string', function () {
+        note.filterCriteria = 'the-filter-criteria';
+
+        expect(compiledOutput()).to.have.nested.property(
+          'aps.interruption-level',
+          'the-interruption-level'
+        );
+      });
+
+      it('can be set to undefined', function () {
+        note.filterCriteria = 'filter-criteria';
+        note.filterCriteria = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property('aps.filter-criteria');
+      });
+
+      describe('setfilterCriteria', function () {
+        it('is chainable', function () {
+          expect(note.setß('the-filter-criteria')).to.equal(note);
+          expect(compiledOutput()).to.have.nested.property(
+            'aps.filter-criteria',
+            'the-filter-criteria'
+          );
+        });
+      });
+    });
+
     context('when no aps properties are set', function () {
       it('is not present', function () {
         expect(compiledOutput().aps).to.be.undefined;

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -1221,6 +1221,37 @@ describe('Notification', function () {
       });
     });
 
+    describe('attributes', function () {
+      const payload = { foo: 'bar' };
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.property('aps.attributes');
+      });
+
+      it('can be set to a object', function () {
+        note.attributes = payload;
+
+        expect(compiledOutput())
+          .to.have.nested.property('aps.attributes')
+          .that.deep.equals(payload);
+      });
+
+      it('can be set to undefined', function () {
+        note.attributes = payload;
+        note.attributes = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.property('aps.attributes');
+      });
+
+      describe('setAttributes', function () {
+        it('is chainable', function () {
+          expect(note.setAttributes(payload)).to.equal(note);
+          expect(compiledOutput())
+            .to.have.nested.property('aps.attributes')
+            .that.deep.equals(payload);
+        });
+      });
+    });
+
     context('when no aps properties are set', function () {
       it('is not present', function () {
         expect(compiledOutput().aps).to.be.undefined;


### PR DESCRIPTION
Closes: #176 

Add new fields for Live Activities in TS and JS:
- [x] `"input-push-channel"?: string`
- [x] `"input-push-token"?: number`

Add missing properties and set methods for APS in JS:
- [x] `filterCriteria`
- [x] `attributesType`
- [x] `attributes` 