### PR TITLE
feat: Add support for notification push type `widgets`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -267,7 +267,7 @@ export class MultiProvider extends EventEmitter {
   shutdown(callback?: () => void): Promise<void>;
 }
 
-export type NotificationPushType = 'background' | 'alert' | 'voip' | 'pushtotalk' | 'liveactivity' | 'location' | 'complication' | 'fileprovider' | 'mdm';
+export type NotificationPushType = 'background' | 'alert' | 'voip' | 'pushtotalk' | 'liveactivity' | 'location' | 'complication' | 'fileprovider' | 'mdm' | 'widgets';
 
 export type ChannelAction = 'create' | 'read' | 'readAll' | 'delete';
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -120,6 +120,7 @@ interface Aps {
   badge?: number
   sound?: string | ApsSound
   "content-available"?: undefined | 1
+  "content-changed"?: undefined | true
   "mutable-content"?: undefined | 1
   "url-args"?: string[]
   category?: string

--- a/index.d.ts
+++ b/index.d.ts
@@ -368,6 +368,10 @@ export class Notification {
    */
   public mutableContent: boolean;
   /**
+   * Setting this to true will specify "content-changed" in the payload when it is compiled
+   */
+  public contentChanged: boolean;
+  /**
    * The value to specify for the `mdm` field where applicable.
    */
   public mdm: string|Object;

--- a/lib/notification/apsProperties.js
+++ b/lib/notification/apsProperties.js
@@ -145,6 +145,14 @@ module.exports = {
     }
   },
 
+  set contentChanged(value) {
+    if (value === true || value === 1) {
+      this.aps['content-changed'] = true;
+    } else {
+      this.aps['content-changed'] = undefined;
+    }
+  },
+
   set mdm(value) {
     this._mdm = value;
   },

--- a/lib/notification/index.js
+++ b/lib/notification/index.js
@@ -45,6 +45,7 @@ Notification.prototype = require('./apsProperties');
   'sound',
   'contentAvailable',
   'mutableContent',
+  'contentChanged',
   'mdm',
   'urlArgs',
   'category',

--- a/test/notification/apsProperties.js
+++ b/test/notification/apsProperties.js
@@ -761,6 +761,38 @@ describe('Notification', function () {
       });
     });
 
+    describe('content-changed', function () {
+      it('defaults to undefined', function () {
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.content-changed');
+      });
+
+      it('can be set to a boolean value', function () {
+        note.contentChanged = true;
+
+        expect(compiledOutput()).to.have.nested.deep.property('aps.content-changed', true);
+      });
+
+      it('can be set to `1`', function () {
+        note.contentChanged = 1;
+
+        expect(compiledOutput()).to.have.nested.deep.property('aps.content-changed', true);
+      });
+
+      it('can be set to undefined', function () {
+        note.contentChanged = true;
+        note.contentChanged = undefined;
+
+        expect(compiledOutput()).to.not.have.nested.deep.property('aps.content-changed');
+      });
+
+      describe('setContentChanged', function () {
+        it('is chainable', function () {
+          expect(note.setContentChanged(true)).to.equal(note);
+          expect(compiledOutput()).to.have.nested.deep.property('aps.content-changed', true);
+        });
+      });
+    });
+
     describe('mdm', function () {
       it('defaults to undefined', function () {
         expect(compiledOutput()).to.not.have.nested.deep.property('mdm');


### PR DESCRIPTION
As per Apple's documentation "widgets" is now a valid push type: https://developer.apple.com/documentation/widgetkit/updating-widgets-with-widgetkit-push-notifications

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "widgets" notification type.
  * Added a public "content changed" flag for notifications; when enabled it includes a corresponding APS field in outgoing payloads and offers a chainable setter.

* **Tests**
  * Added tests covering default omission, setting behavior (true and 1), removal, and setter chaining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->