### PR TITLE
refactor: Bump node-forge from 1.3.2 to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "debug": "4.4.3",
         "jsonwebtoken": "9.0.3",
-        "node-forge": "1.3.2",
+        "node-forge": "1.4.0",
         "verror": "1.10.1"
       },
       "devDependencies": {
@@ -4644,9 +4644,9 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
-      "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "debug": "4.4.3",
     "jsonwebtoken": "9.0.3",
-    "node-forge": "1.3.2",
+    "node-forge": "1.4.0",
     "verror": "1.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #207

### Changes

- **1.4.0**: Security fixes for 4 HIGH severity CVEs — DoS in `BigInteger.modInverse()` (CVE-2026-33891), RSA-PKCS#1 v1.5 signature forgery (CVE-2026-33894), Ed25519 signature forgery (CVE-2026-33895), `basicConstraints` bypass in certificate chain verification (CVE-2026-33896). Also adds pseudonym OID support.

### Breaking Changes

None

### Code Changes Required

None — the upgrade is a drop-in replacement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `node-forge` dependency to version 1.4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->