### PR TITLE
feat: Remove support for Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: Node.js 18
-            NODE_VERSION: 18
           - name: Node.js 20
             NODE_VERSION: 20
           - name: Node.js 22

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     }
   },
   "engines": {
-    "node": ">=18"
+    "node": "20 || 22 || 24"
   },
   "license": "MIT"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Node.js version requirement from 18 to 20, 22, or 24
  * Updated CI testing matrix to support Node.js 20, 22, and 24 only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->